### PR TITLE
Fixed compile error when no grabbers are defined + remove avahi warning

### DIFF
--- a/libsrc/bonjour/bonjourserviceregister.cpp
+++ b/libsrc/bonjour/bonjourserviceregister.cpp
@@ -26,15 +26,15 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-//#include "bonjourserviceregister.h"
 #include <bonjour/bonjourserviceregister.h>
-
+#include <stdlib.h>
 
 #include <QtCore/QSocketNotifier>
 
 BonjourServiceRegister::BonjourServiceRegister(QObject *parent)
     : QObject(parent), dnssref(0), bonjourSocket(0)
 {
+	setenv("AVAHI_COMPAT_NOWARN", "1", 1);
 }
 
 BonjourServiceRegister::~BonjourServiceRegister()

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
 	#endif
 
 	#if !defined(ENABLE_DISPMANX) && !defined(ENABLE_OSX) && !defined(ENABLE_FB)
-		ErrorIf(config.isMember("framegrabber"), log, "No grabber can be instantiated, because all grabbers have been left out from the build" << std::endl;
+		ErrorIf(config.isMember("framegrabber"), log, "No grabber can be instantiated, because all grabbers have been left out from the build");
 	#endif
 
 	// run the application


### PR DESCRIPTION
It was missing a )

 setenv("AVAHI_COMPAT_NOWARN", "1", 1);