### PR TITLE
logger: set global log level

### DIFF
--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -25,9 +25,11 @@
 class Logger
 {
 public:
-	enum LogLevel { DEBUG=0, INFO=1,WARNING=2,ERROR=3 };
+	enum LogLevel { UNSET=0,DEBUG=1, INFO=2,WARNING=3,ERROR=4 };
 
 	static Logger* getInstance(std::string name="", LogLevel minLevel=Logger::INFO);
+	static void deleteInstance(std::string name="");
+	static void setLogLevel(LogLevel level,std::string name="");
 
 	void Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...);
 	void setMinLevel(LogLevel level) { _minLevel = level; };
@@ -38,6 +40,7 @@ protected:
 
 private:
 	static std::map<std::string,Logger*> *LoggerMap;
+	static LogLevel GLOBAL_MIN_LOG_LEVEL;
 
 	std::string _name;
 	std::string _appname;

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -39,7 +39,9 @@ void startNewHyperion(int parentPid, std::string hyperionFile, std::string confi
 
 int main(int argc, char** argv)
 {
-	Logger* log = Logger::getInstance("MAIN", Logger::INFO);
+	// initialize main logger and set global log level
+	Logger* log = Logger::getInstance("MAIN");
+	Logger::setLogLevel(Logger::INFO);
 
 	// Initialising QCoreApplication
 	QCoreApplication app(argc, argv);
@@ -125,8 +127,10 @@ int main(int argc, char** argv)
 	int rc = app.exec();
 	Info(log, "INFO: Application closed with code %d", rc);
 
+	// delete components
 	delete webConfig;
 	delete hyperiond;
+	Logger::deleteInstance();
 
 	return rc;
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.
Add ability to set loglevel for all loggers and for specific loggers.

Example:
```
// will set min log level for all loggers to warning
Logger::setLogLevel(Logger::WARNING);

// will set loglevel of specific logger to warning
// if global log level is set (above) this is useless
Logger::setLogLevel(Logger::WARNING, ”EFFECT”);
```

Next step is to connect this with config ....
**2.** If this changes affect the .conf file. Please provide the changed section
No
**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


