### PR TITLE
native UDP listener enhancements

### DIFF
--- a/include/udplistener/UDPListener.h
+++ b/include/udplistener/UDPListener.h
@@ -9,6 +9,7 @@
 
 // Hyperion includes
 #include <hyperion/Hyperion.h>
+#include <utils/Logger.h>
 
 class UDPClientConnection;
 
@@ -25,7 +26,7 @@ public:
 	/// @param hyperion Hyperion instance
 	/// @param port port number on which to start listening for connections
 	///
-	UDPListener(const int priority, const int timeout, uint16_t port = 2801);
+	UDPListener(const int priority, const int timeout, const std::string& address, quint16 listenPort);
 	~UDPListener();
 
 	///
@@ -59,4 +60,7 @@ private:
 
         /// The latest led color data
         std::vector<ColorRgb> _ledColors;
+
+	/// Logger instance
+	Logger * _log;
 };

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -5,6 +5,7 @@
 #include <QLocale>
 #include <QFile>
 #include <QHostInfo>
+#include <QHostAddress>
 #include <cstdint>
 #include <limits>
 
@@ -249,6 +250,7 @@ void HyperionDaemon::startNetworkServices()
 			_udpListener = new UDPListener(
 						udpListenerConfig.get("priority",700).asInt(),
 						udpListenerConfig.get("timeout",10000).asInt(),
+						udpListenerConfig.get("address", "").asString(),
 						udpListenerConfig.get("port", 2801).asUInt()
 					);
 			Info(_log, "UDP listener created and started on port %d", _udpListener->getPort());


### PR DESCRIPTION
**1.** Tell us something about your changes.
native UDP listener enhancements
- uses new logger
- can specifiy which ip address to listen on
- if its a multicast address, multicast is enabled

**2.** If this changes affect the .conf file. Please provide the changed section
The address option is new and optional, default is listen on all ip addresses
        "udpListener" :
        {
                "enable" : true,
//              "address" : "239.255.28.01",
//              "address" : "10.0.0.72",
//              "address" : "10.0.0.7",
//              "address" : "0.0.0.0",
                "port" : 2801,
                "priority" : 800,
                "timeout"  : 5000
        },

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


- uses new logger
- can specifiy which ip address to listen on
- if its a multicast address, multicast is enabled