### PR TITLE
UDPListener improvements:

### DIFF
--- a/include/udplistener/UDPListener.h
+++ b/include/udplistener/UDPListener.h
@@ -26,7 +26,7 @@ public:
 	/// @param hyperion Hyperion instance
 	/// @param port port number on which to start listening for connections
 	///
-	UDPListener(const int priority, const int timeout, const std::string& address, quint16 listenPort);
+	UDPListener(const int priority, const int timeout, const std::string& address, quint16 listenPort, bool shared);
 	~UDPListener();
 
 	///

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -251,7 +251,8 @@ void HyperionDaemon::startNetworkServices()
 						udpListenerConfig.get("priority",700).asInt(),
 						udpListenerConfig.get("timeout",10000).asInt(),
 						udpListenerConfig.get("address", "").asString(),
-						udpListenerConfig.get("port", 2801).asUInt()
+						udpListenerConfig.get("port", 2801).asUInt(),
+						udpListenerConfig.get("shared", false).asBool()
 					);
 			Info(_log, "UDP listener created and started on port %d", _udpListener->getPort());
 		}


### PR DESCRIPTION
**1.** Tell us something about your changes.
- if you listen to a multicast address, it now also listens to all ipv4 addresses

- shared udp sockets - multiple hyperiond instance can optionally share the same udp packets
False is the defaul

**2.** If this changes affect the .conf file. Please provide the changed section
"shared" : true

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org
