### PR TITLE
fix config install in deb package

### DIFF
--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -20,7 +20,7 @@ install_file()
 echo "--- hyperion ambilight postinstall ---"
 echo "- install configuration template"
 mkdir -p /etc/hyperion
-install_file /usr/share/hyperion/config/hyperion.config.json.example /etc/hyperion/hyperion.config.json
+install_file /usr/share/hyperion/config/hyperion.config.json.default /etc/hyperion/hyperion.config.json
 
 
 HYPERION_RUNNING=false


### PR DESCRIPTION
**1.** Tell us something about your changes.
the default config was renamed - this produced an error in debian postinstall. @brindosch please change config name in cmake/debian/postinst if you change the config name again.

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


