### PR TITLE
udplistener will now set remaining LEDs to black.

### DIFF
--- a/include/udplistener/UDPListener.h
+++ b/include/udplistener/UDPListener.h
@@ -77,9 +77,6 @@ private:
 	/// hyperion priority
 	int _timeout;
 
-	/// The latest led color data
-	std::vector<ColorRgb> _ledColors;
-
 	/// Logger instance
 	Logger * _log;
 	

--- a/libsrc/udplistener/UDPListener.cpp
+++ b/libsrc/udplistener/UDPListener.cpp
@@ -17,7 +17,6 @@ UDPListener::UDPListener(const int priority, const int timeout, const std::strin
 	_openConnections(),
 	_priority(priority),
 	_timeout(timeout),
-	_ledColors(Hyperion::getInstance()->getLedCount(), ColorRgb::BLACK),
 	_log(Logger::getInstance("UDPLISTENER")),
 	_isActive(false),
 	_listenPort(listenPort),
@@ -104,11 +103,13 @@ void UDPListener::readPendingDatagrams()
 
 void UDPListener::processTheDatagram(const QByteArray * datagram)
 {
-	int packlen = datagram->size()/3;
-	int ledlen = _ledColors.size();
-	int maxled = std::min(packlen , ledlen);
+	int packetLedCount = datagram->size()/3;
+	int hyperionLedCount = Hyperion::getInstance()->getLedCount();
+	DebugIf( (packetLedCount != hyperionLedCount), _log, "packetLedCount (%d) != hyperionLedCount (%d)", packetLedCount, hyperionLedCount);
 
-	for (int ledIndex=0; ledIndex < maxled; ledIndex++) {
+        std::vector<ColorRgb> _ledColors(Hyperion::getInstance()->getLedCount(), ColorRgb::BLACK);
+
+	for (int ledIndex=0; ledIndex < std::min(packetLedCount, hyperionLedCount);  ledIndex++) {
 		ColorRgb & rgb =  _ledColors[ledIndex];
 		rgb.red = datagram->at(ledIndex*3+0);
 		rgb.green = datagram->at(ledIndex*3+1);


### PR DESCRIPTION
**1.** Tell us something about your changes.
eg: configure 42 leds, but a udp packet only contains 10 leds, the remaining 32 are now set to black

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)
#54 

Note: For further discussions use our forum: forum.hyperion-project.org
