### PR TITLE
extend Fadecandy driver

### DIFF
--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -305,10 +305,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	}
 	else if (type == "fadecandy")
 	{
-		const std::string host  = deviceConfig.get("output", "127.0.0.1").asString();
-		const uint16_t port     = deviceConfig.get("port", 7890).asInt();
-		const uint16_t channel  = deviceConfig.get("channel", 0).asInt();
-		device = new LedDeviceFadeCandy(host, port, channel);
+		device = new LedDeviceFadeCandy(deviceConfig);
 	}
 	else if (type == "udp")
 	{

--- a/libsrc/leddevice/LedDeviceFadeCandy.h
+++ b/libsrc/leddevice/LedDeviceFadeCandy.h
@@ -68,4 +68,10 @@ private:
 	///
 	int transferData();
 	
+	int sendSysEx(uint8_t systemId, uint8_t commandId, QByteArray msg);
+
+	void setGlobalColorCorrection(double gamma, double r=1.0, double g=1.0, double b=1.0);
+
+	void setFirmwareConfig(bool noDither, bool noInterp, bool manualLED, bool ledOnOff);
+	
 };


### PR DESCRIPTION
**1.** Tell us something about your changes.
extend Fadecandy driver to set all hardware/fcserver config data. 

**2.** If this changes affect the .conf file. Please provide the changed section
yes, if fadecandy device is used.
valid config block is shown in LedDeviceFadeCandy.h as doxygen doc

```
 "device" :
 {
 	"name"          : "MyPi",
 	"type"          : "fadecandy",
 	"output"        : "localhost",
 	"colorOrder"    : "rgb",
 	"gamma"         : 1.0,
 	"whitepoint"    : [1.0, 1.0, 1.0],
 	"dither"        : false,
 	"interpolation" : false,
 	"manualLed"     : false,
 	"ledOn"         : false
 }, 
```

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

