### PR TITLE
multi fix commit

### DIFF
--- a/.travis/travis_install.sh
+++ b/.travis/travis_install.sh
@@ -11,6 +11,6 @@ fi
 # install linux deps for hyperion compile
 if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
 	echo "Install linux deps"
-	sudo apt-get -qq update ; sudo apt-get install -qq -y qtbase5-dev libqt5serialport5-dev libusb-1.0-0-dev python-dev libxrender-dev libavahi-core-dev libavahi-compat-libdnssd-dev
+	sudo apt-get -qq update ; sudo apt-get install -qq -y qtbase5-dev libqt5serialport5-dev libusb-1.0-0-dev python-dev libxrender-dev libavahi-core-dev libavahi-compat-libdnssd-dev doxygen
 fi
 

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -58,10 +58,11 @@
 	/// Next to the list with color transforms there is also a smoothing option.
 	///  * 'smoothing' : Smoothing of the colors in the time-domain with the following tuning 
 	///                  parameters:
-	///            - 'type'            The type of smoothing algorithm ('linear' or 'none')
-	///            - 'time_ms'         The time constant for smoothing algorithm in milliseconds
-	///            - 'updateFrequency' The update frequency of the leds in Hz
-	///            - 'updateDelay'     The delay of the output to leds (in periods of smoothing)
+	///            - 'type'             The type of smoothing algorithm ('linear' or 'none')
+	///            - 'time_ms'          The time constant for smoothing algorithm in milliseconds
+	///            - 'updateFrequency'  The update frequency of the leds in Hz
+	///            - 'updateDelay'      The delay of the output to leds (in periods of smoothing)
+	///            - 'continuousOutput' Flag for enabling continuous output to Leds regardless of new input or not
 	"color" :
 	{
 		"channelAdjustment" :
@@ -133,11 +134,12 @@
 
 		"smoothing" :
 		{
-			"enable"          : true,
-			"type"            : "linear",
-			"time_ms"         : 200,
-			"updateFrequency" : 20.0000,
-			"updateDelay"     : 0
+			"enable"           : true,
+			"type"             : "linear",
+			"time_ms"          : 200,
+			"updateFrequency"  : 20.0000,
+			"updateDelay"      : 0,
+			"continuousOutput" : true
 		}
 	},
 

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -83,11 +83,12 @@
 		],
 		"smoothing" :
 		{
-			"enable"          : true,
-			"type"            : "linear",
-			"time_ms"         : 200,
-			"updateFrequency" : 20.0000,
-			"updateDelay"     : 0
+			"enable"           : true,
+			"type"             : "linear",
+			"time_ms"          : 200,
+			"updateFrequency"  : 20.0000,
+			"updateDelay"      : 0,
+			"continuousOutput" : false
 		}
 	},
 	

--- a/include/leddevice/LedDevice.h
+++ b/include/leddevice/LedDevice.h
@@ -33,6 +33,13 @@ public:
 	/// Switch the leds off
 	virtual int switchOff() = 0;
 	
+	///
+	/// Opens and configures the output device
+	///
+	/// @return Zero on succes else negative
+	///
+	int open();
+
 protected:
 	Logger * _log;
 };

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -481,47 +481,31 @@ LedString Hyperion::createLedString(const Json::Value& ledsConfig, const ColorOr
 }
 
 LedDevice * Hyperion::createColorSmoothing(const Json::Value & smoothingConfig, LedDevice * ledDevice)
-{
+{      
 	Logger * log = Logger::getInstance("Core");
-	std::string type = smoothingConfig.get("type", "none").asString();
+	std::string type = smoothingConfig.get("type", "linear").asString();
 	std::transform(type.begin(), type.end(), type.begin(), ::tolower);
 
+	type = "linear"; // TODO currently hardcoded type, delete it if we have more types
 	if ( ! smoothingConfig.get("enable", true).asBool() )
 	{
-		Info(log,"Smoothing disabled in config");
+		Info(log,"Smoothing disabled");
 		return ledDevice;
-	}
-	if (type == "none")
-	{
-		Info(log, "Smoothing set to none");
-		return ledDevice;
-	}
-	else if (type == "linear")
-	{
-		if (!smoothingConfig.isMember("time_ms"))
-		{
-			Error(log, "Unable to create smoothing of type linear because of missing parameter 'time_ms'");
-		}
-		else if (!smoothingConfig.isMember("updateFrequency"))
-		{
-			Error(log, "Unable to create smoothing of type linear because of missing parameter 'updateFrequency'");
-		}
-		else
-		{
-			const unsigned updateDelay = smoothingConfig.get("updateDelay", Json::Value(0u)).asUInt();
-			Info(log, "Creating linear smoothing");
-			return new LinearColorSmoothing(
-					ledDevice,
-					smoothingConfig["updateFrequency"].asDouble(),
-					smoothingConfig["time_ms"].asInt(),
-					updateDelay);
-		}
-	}
-	else
-	{
-		Error(log, "Unknown smoothing type %s.", type.c_str());
 	}
 
+	if (type == "linear")
+	{
+		Info(log, "Creating linear smoothing");
+		return new LinearColorSmoothing(
+		            ledDevice,
+		            smoothingConfig.get("updateFrequency", 25.0).asDouble(),
+		            smoothingConfig.get("time_ms", 200).asInt(),
+		            smoothingConfig.get("updateDelay", 0).asUInt(),
+		            smoothingConfig.get("continuousOutput", false).asBool()
+		            );
+	}
+
+	Error(log, "Smoothing disabled, because of unknown type '%s'.", type.c_str());
 	return ledDevice;
 }
 

--- a/libsrc/hyperion/LinearColorSmoothing.h
+++ b/libsrc/hyperion/LinearColorSmoothing.h
@@ -24,7 +24,7 @@ public:
 	/// @param LedUpdatFrequency The frequency at which the leds will be updated (Hz)
 	/// @param settingTime The time after which the updated led values have been fully applied (sec)
 	/// @param updateDelay The number of frames to delay outgoing led updates
-	LinearColorSmoothing(LedDevice *ledDevice, double ledUpdateFrequency, int settlingTime, unsigned updateDelay);
+	LinearColorSmoothing(LedDevice *ledDevice, double ledUpdateFrequency, int settlingTime, unsigned updateDelay, bool continuousOutput);
 
 	/// Destructor
 	virtual ~LinearColorSmoothing();
@@ -75,11 +75,14 @@ private:
 	/// The previously written led data
 	std::vector<ColorRgb> _previousValues;
 
-	/** The number of updates to keep in the output queue (delayed) before being output */
+	/// The number of updates to keep in the output queue (delayed) before being output
 	const unsigned _outputDelay;
-	/** The output queue */
+	/// The output queue
 	std::list<std::vector<ColorRgb> > _outputQueue;
 
-	// prevent sending data to device when no intput data is sent
+	/// Prevent sending data to device when no intput data is sent
 	bool _writeToLedsEnable;
+	
+	/// Flag for dis/enable continuous output to led device regardless there is new data or not
+	bool _continuousOutput;
 };

--- a/libsrc/leddevice/LedDevice.cpp
+++ b/libsrc/leddevice/LedDevice.cpp
@@ -4,3 +4,9 @@ LedDevice::LedDevice()
 	: _log(Logger::getInstance("LedDevice"))
 {
 }
+
+int LedDevice::open()
+{
+	//dummy implemention
+	return 0;
+}

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -65,112 +65,83 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	if (false) {}
 	else if (type == "adalight")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-		const int delay_ms       = deviceConfig["delayAfterConnect"].asInt();
-
-		LedDeviceAdalight* deviceAdalight = new LedDeviceAdalight(output, rate, delay_ms);
-		deviceAdalight->open();
-
-		device = deviceAdalight;
+		device = new LedDeviceAdalight(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt(),
+			deviceConfig.get("delayAfterConnect",1000).asInt()
+		);
 	}
 	else if (type == "adalightapa102")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-		const int delay_ms       = deviceConfig["delayAfterConnect"].asInt();
-
-		LedDeviceAdalightApa102* deviceAdalightApa102 = new LedDeviceAdalightApa102(output, rate, delay_ms);
-		deviceAdalightApa102->open();
-
-		device = deviceAdalightApa102;
+		device = new LedDeviceAdalightApa102(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt(),
+			deviceConfig.get("delayAfterConnect",1000).asInt()
+		);
 	}
 #ifdef ENABLE_SPIDEV
 	else if (type == "lpd6803" || type == "ldp6803")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-
-		LedDeviceLpd6803* deviceLdp6803 = new LedDeviceLpd6803(output, rate);
-		deviceLdp6803->open();
-
-		device = deviceLdp6803;
+		device = new LedDeviceLpd6803(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "lpd8806" || type == "ldp8806")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-
-		LedDeviceLpd8806* deviceLpd8806 = new LedDeviceLpd8806(output, rate);
-		deviceLpd8806->open();
-
-		device = deviceLpd8806;
+		device = new LedDeviceLpd8806(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "p9813")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-
-		LedDeviceP9813* deviceP9813 = new LedDeviceP9813(output, rate);
-		deviceP9813->open();
-
-		device = deviceP9813;
+		device = new LedDeviceP9813(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "apa102")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-
-		LedDeviceAPA102* deviceAPA102 = new LedDeviceAPA102(output, rate);
-		deviceAPA102->open();
-
-		device = deviceAPA102;
+		device = new LedDeviceAPA102(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "ws2801" || type == "lightberry")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-		const unsigned latchtime      = deviceConfig.get("latchtime",500000).asInt();
-
-		LedDeviceWs2801* deviceWs2801 = new LedDeviceWs2801(output, rate, latchtime);
-		deviceWs2801->open();
-
-		device = deviceWs2801;
+		device = new LedDeviceWs2801(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt(),
+			deviceConfig.get("latchtime",500000).asInt()
+		);
 	}
 	else if (type == "ws2812spi")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig.get("rate",2857143).asInt();
-
-		LedDeviceWs2812SPI* deviceWs2812SPI = new LedDeviceWs2812SPI(output, rate);
-		deviceWs2812SPI->open();
-
-		device = deviceWs2812SPI;
+		device = new LedDeviceWs2812SPI(
+			deviceConfig["output"].asString(),
+			deviceConfig.get("rate",2857143).asInt()
+		);
 	}
 	else if (type == "sk6812rgbw-spi")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig.get("rate",2857143).asInt();
-		const std::string& whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
-
-		LedDeviceSk6812SPI* deviceSk6812SPI = new LedDeviceSk6812SPI(output, rate, whiteAlgorithm);
-		deviceSk6812SPI->open();
-
-		device = deviceSk6812SPI;
+		device = new LedDeviceSk6812SPI(
+			deviceConfig["output"].asString(),
+			deviceConfig.get("rate",2857143).asInt(),
+			deviceConfig.get("white_algorithm","").asString()
+		);
 	}
 #endif
 #ifdef ENABLE_TINKERFORGE
 	else if (type=="tinkerforge")
 	{
-		const std::string host 	= deviceConfig.get("output", "127.0.0.1").asString();
-		const uint16_t port 		= deviceConfig.get("port", 4223).asInt();
-		const std::string  uid		= deviceConfig["uid"].asString();
-		const unsigned rate 	= deviceConfig["rate"].asInt();
+		device = new LedDeviceTinkerforge(
+			deviceConfig.get("output", "127.0.0.1").asString(),
+			deviceConfig.get("port", 4223).asInt(),
+			deviceConfig["uid"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 
-		LedDeviceTinkerforge* deviceTinkerforge = new LedDeviceTinkerforge(host, port, uid, rate);
-		deviceTinkerforge->open();
-
-		device = deviceTinkerforge;
 	}
 #endif
 	else if (type == "rawhid")
@@ -183,26 +154,17 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		auto VendorId = std::stoul(VendorIdString, nullptr, 16);
 		auto ProductId = std::stoul(ProductIdString, nullptr, 16);
 
-		LedDeviceRawHID* deviceHID = new LedDeviceRawHID(VendorId, ProductId, delay_ms);
-		deviceHID->open();
-
-		device = deviceHID;
+		device = new LedDeviceRawHID(VendorId, ProductId, delay_ms);
 	}
 	else if (type == "lightpack")
 	{
-		const std::string output = deviceConfig.get("output", "").asString();
-
-		LedDeviceLightpack* deviceLightpack = new LedDeviceLightpack();
-		deviceLightpack->open(output);
-
-		device = deviceLightpack;
+		device = new LedDeviceLightpack(
+			deviceConfig.get("output", "").asString()
+		);
 	}
 	else if (type == "multi-lightpack")
 	{
-		LedDeviceMultiLightpack* deviceLightpack = new LedDeviceMultiLightpack();
-		deviceLightpack->open();
-
-		device = deviceLightpack;
+		device = new LedDeviceMultiLightpack();
 	}
 	else if (type == "paintpack")
 	{
@@ -214,10 +176,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		auto VendorId = std::stoul(VendorIdString, nullptr, 16);
 		auto ProductId = std::stoul(ProductIdString, nullptr, 16);
 
-		LedDevicePaintpack * devicePainLightpack = new LedDevicePaintpack(VendorId, ProductId, delay_ms);
-		devicePainLightpack->open();
-
-		device = devicePainLightpack;
+		device = new LedDevicePaintpack(VendorId, ProductId, delay_ms);
 	}
 	else if (type == "piblaster")
 	{
@@ -225,41 +184,30 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		const std::string assignment = deviceConfig.get("assignment", "").asString();
 		const Json::Value gpioMapping = deviceConfig.get("gpiomap", Json::nullValue);
 
-		if (assignment.length() > 0) {
-			Error(log, "Piblaster: The piblaster configuration syntax has changed in this version.");
-			exit(EXIT_FAILURE);
+		if (! assignment.empty())
+		{
+			throw std::runtime_error("Piblaster: The piblaster configuration syntax has changed in this version.");
 		}
-		if (! gpioMapping.isNull() ) {
-			LedDevicePiBlaster * devicePiBlaster = new LedDevicePiBlaster(output, gpioMapping);
-			devicePiBlaster->open();
-
-			device = devicePiBlaster;
-		} else {
-			Error(log, "Piblaster: no gpiomap defined.");
-			exit(EXIT_FAILURE);
+		if (gpioMapping.isNull())
+		{
+			throw std::runtime_error("Piblaster: no gpiomap defined.");
 		}
+		device = new LedDevicePiBlaster(output, gpioMapping);
 	}
 	else if (type == "sedu")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-
-		LedDeviceSedu* deviceSedu = new LedDeviceSedu(output, rate);
-		deviceSedu->open();
-
-		device = deviceSedu;
+		device = new LedDeviceSedu(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "hyperion-usbasp-ws2801")
 	{
-			LedDeviceHyperionUsbasp * deviceHyperionUsbasp = new LedDeviceHyperionUsbasp(LedDeviceHyperionUsbasp::CMD_WRITE_WS2801);
-			deviceHyperionUsbasp->open();
-			device = deviceHyperionUsbasp;
+		device = new LedDeviceHyperionUsbasp(LedDeviceHyperionUsbasp::CMD_WRITE_WS2801);
 	}
 	else if (type == "hyperion-usbasp-ws2812")
 	{
-			LedDeviceHyperionUsbasp * deviceHyperionUsbasp = new LedDeviceHyperionUsbasp(LedDeviceHyperionUsbasp::CMD_WRITE_WS2812);
-			deviceHyperionUsbasp->open();
-			device = deviceHyperionUsbasp;
+		device = new LedDeviceHyperionUsbasp(LedDeviceHyperionUsbasp::CMD_WRITE_WS2812);
 	}
 	else if (type == "philipshue")
 	{
@@ -309,62 +257,54 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	}
 	else if (type == "udp")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-		const unsigned protocol  = deviceConfig["protocol"].asInt();
-		const unsigned maxPacket   = deviceConfig["maxpacket"].asInt();
-		device = new LedDeviceUdp(output, rate, protocol, maxPacket);
+		device = new LedDeviceUdp(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt(),
+			deviceConfig["protocol"].asInt(),
+			deviceConfig["maxpacket"].asInt()
+		);
 	}
 	else if (type == "udpraw")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate      = deviceConfig["rate"].asInt();
-		const unsigned latchtime      = deviceConfig.get("latchtime",500000).asInt();
-
-		LedDeviceUdpRaw* deviceUdpRaw = new LedDeviceUdpRaw(output, rate, latchtime);
-		deviceUdpRaw->open();
-		device = deviceUdpRaw;
+		device = new LedDeviceUdpRaw(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt(),
+			deviceConfig.get("latchtime",500000).asInt()
+		);
 	}
 	else if (type == "tpm2")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate = deviceConfig["rate"].asInt();
-
-		LedDeviceTpm2 * deviceTpm2 = new LedDeviceTpm2(output, rate);
-		deviceTpm2->open();
-		device = deviceTpm2;
+		device = new LedDeviceTpm2(
+			deviceConfig["output"].asString(),
+			deviceConfig["rate"].asInt()
+		);
 	}
 	else if (type == "atmo")
 	{
-		const std::string output = deviceConfig["output"].asString();
-		const unsigned rate = 38400;
-
-		LedDeviceAtmo * deviceAtmo = new LedDeviceAtmo(output, rate);
-		deviceAtmo->open();
-		device = deviceAtmo;
+		device = new LedDeviceAtmo(
+			deviceConfig["output"].asString(),
+			38400
+		);
 	}
 #ifdef ENABLE_WS2812BPWM
 	else if (type == "ws2812b")
 	{
-		LedDeviceWS2812b * ledDeviceWS2812b = new LedDeviceWS2812b();
-		device = ledDeviceWS2812b;
+		device = new LedDeviceWS2812b();
 	}
 #endif
 #ifdef ENABLE_WS281XPWM
 	else if (type == "ws281x")
 	{
-		const int gpio = deviceConfig.get("gpio", 18).asInt();
-		const int leds = deviceConfig.get("leds", 256).asInt();
-		const uint32_t freq = deviceConfig.get("freq", (Json::UInt)800000ul).asInt();
-		const int dmanum = deviceConfig.get("dmanum", 5).asInt();
-                const int pwmchannel = deviceConfig.get("pwmchannel", 0).asInt();
-		const int invert = deviceConfig.get("invert", 0).asInt();
-		const int rgbw = deviceConfig.get("rgbw", 0).asInt();
-		const std::string& whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
-
-		LedDeviceWS281x * ledDeviceWS281x = new LedDeviceWS281x(gpio, leds, freq, dmanum, pwmchannel, invert, 
-			rgbw, whiteAlgorithm);
-		device = ledDeviceWS281x;
+		device = new LedDeviceWS281x(
+			deviceConfig.get("gpio", 18).asInt();
+			leds = deviceConfig.get("leds", 256).asInt();
+			freq = deviceConfig.get("freq", (Json::UInt)800000ul).asInt();
+			dmanum = deviceConfig.get("dmanum", 5).asInt();
+			deviceConfig.get("pwmchannel", 0).asInt();
+			deviceConfig.get("invert", 0).asInt();
+			deviceConfig.get("rgbw", 0).asInt();
+			whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
+		);
 	}
 #endif
 	else
@@ -373,9 +313,12 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		{
 			Error(log, "Dummy device used, because unknown device %s set.", type.c_str());
 		}
-		const std::string output = deviceConfig.get("output", "/dev/null").asString();
-		device = new LedDeviceFile(output);
+		device = new LedDeviceFile(
+			deviceConfig.get("output", "/dev/null").asString()
+		);
 	}
 
+	device->open();
+	
 	return device;
 }

--- a/libsrc/leddevice/LedDeviceFadeCandy.cpp
+++ b/libsrc/leddevice/LedDeviceFadeCandy.cpp
@@ -26,14 +26,15 @@ LedDeviceFadeCandy::~LedDeviceFadeCandy()
 
 bool LedDeviceFadeCandy::setConfig(const Json::Value &deviceConfig)
 {
-	_host      = deviceConfig.get("output", "127.0.0.1").asString();
-	_port      = deviceConfig.get("port", 7890).asInt();
-	_channel   = deviceConfig.get("channel", 0).asInt();
-	_gamma     = deviceConfig.get("gamma", 1.0).asDouble();
-	_noDither  = ! deviceConfig.get("dither", false).asBool();
-	_noInterp  = ! deviceConfig.get("interpolation", false).asBool();
-	_manualLED = deviceConfig.get("manualLed", false).asBool();
-	_ledOnOff  = deviceConfig.get("ledOn", false).asBool();
+	_host        = deviceConfig.get("output", "127.0.0.1").asString();
+	_port        = deviceConfig.get("port", 7890).asInt();
+	_channel     = deviceConfig.get("channel", 0).asInt();
+	_gamma       = deviceConfig.get("gamma", 1.0).asDouble();
+	_noDither    = ! deviceConfig.get("dither", false).asBool();
+	_noInterp    = ! deviceConfig.get("interpolation", false).asBool();
+	_manualLED   = deviceConfig.get("manualLed", false).asBool();
+	_ledOnOff    = deviceConfig.get("ledOn", false).asBool();
+	_setFcConfig = deviceConfig.get("setFcConfig", false).asBool();
 
 	_whitePoint_r = 1.0;
 	_whitePoint_g = 1.0;
@@ -62,8 +63,11 @@ bool LedDeviceFadeCandy::tryConnect()
 		_client.connectToHost( _host.c_str(), _port);
 		if ( _client.waitForConnected(1000) )
 		{
-			sendFadeCandyConfiguration();
 			Info(_log,"fadecandy/opc: connected to %s:%i on channel %i", _host.c_str(), _port, _channel);
+			if (_setFcConfig)
+			{
+				sendFadeCandyConfiguration();
+			}
 		}
 	}
 
@@ -145,6 +149,7 @@ int LedDeviceFadeCandy::sendSysEx(uint8_t systemId, uint8_t commandId, QByteArra
 
 void LedDeviceFadeCandy::sendFadeCandyConfiguration()
 {
+	Debug(_log, "send configuration to fadecandy");
 	QString data = "{\"gamma\": "+QString::number(_gamma,'g',4)+", \"whitepoint\": ["+QString::number(_whitePoint_r,'g',4)+", "+QString::number(_whitePoint_g,'g',4)+", "+QString::number(_whitePoint_b,'g',4)+"]}";
 	sendSysEx(1, 1, data.toLocal8Bit() );
 

--- a/libsrc/leddevice/LedDeviceFadeCandy.h
+++ b/libsrc/leddevice/LedDeviceFadeCandy.h
@@ -29,6 +29,7 @@ public:
 	/// 	"type"          : "fadecandy",
 	/// 	"output"        : "localhost",
 	/// 	"colorOrder"    : "rgb",
+	/// 	"setFcConfig"   : false,
 	/// 	"gamma"         : 1.0,
 	/// 	"whitepoint"    : [1.0, 1.0, 1.0],
 	/// 	"dither"        : false,
@@ -74,6 +75,7 @@ private:
 	QByteArray  _opc_data;
 
 	// fadecandy sysEx
+	bool        _setFcConfig;
 	double      _gamma;
 	double      _whitePoint_r;
 	double      _whitePoint_g;

--- a/libsrc/leddevice/LedDeviceLightpack.cpp
+++ b/libsrc/leddevice/LedDeviceLightpack.cpp
@@ -32,17 +32,17 @@ enum DATA_VERSION_INDEXES{
 	INDEX_FW_VER_MINOR
 };
 
-LedDeviceLightpack::LedDeviceLightpack() :
-	LedDevice(),
-	_libusbContext(nullptr),
-	_deviceHandle(nullptr),
-	_busNumber(-1),
-	_addressNumber(-1),
-	_serialNumber(""),
-	_firmwareVersion({-1,-1}),
-	_ledCount(-1),
-	_bitsPerChannel(-1),
-	_ledBuffer()
+LedDeviceLightpack::LedDeviceLightpack(const std::string & serialNumber)
+	: LedDevice()
+	, _libusbContext(nullptr)
+	, _deviceHandle(nullptr)
+	, _busNumber(-1)
+	, _addressNumber(-1)
+	, _serialNumber(serialNumber)
+	, _firmwareVersion({-1,-1})
+	, _ledCount(-1)
+	, _bitsPerChannel(-1)
+	, _ledBuffer()
 {
 }
 
@@ -64,7 +64,7 @@ LedDeviceLightpack::~LedDeviceLightpack()
 	}
 }
 
-int LedDeviceLightpack::open(const std::string & serialNumber)
+int LedDeviceLightpack::open()
 {
 	int error;
 
@@ -86,7 +86,7 @@ int LedDeviceLightpack::open(const std::string & serialNumber)
 	for (ssize_t i = 0 ; i < deviceCount; ++i)
 	{
 		// try to open and initialize the device
-		error = testAndOpen(deviceList[i], serialNumber);
+		error = testAndOpen(deviceList[i], _serialNumber);
 
 		if (error == 0)
 		{

--- a/libsrc/leddevice/LedDeviceLightpack.h
+++ b/libsrc/leddevice/LedDeviceLightpack.h
@@ -20,7 +20,9 @@ public:
 	///
 	/// Constructs the LedDeviceLightpack
 	///
-	LedDeviceLightpack();
+	/// @param serialNumber serial output device
+	///
+	LedDeviceLightpack(const std::string & serialNumber = "");
 
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
@@ -32,7 +34,7 @@ public:
 	///
 	/// @return Zero on succes else negative
 	///
-	int open(const std::string & serialNumber = "");
+	int open();
 
 	///
 	/// Writes the RGB-Color values to the leds.

--- a/libsrc/leddevice/LedDeviceMultiLightpack.cpp
+++ b/libsrc/leddevice/LedDeviceMultiLightpack.cpp
@@ -42,8 +42,8 @@ int LedDeviceMultiLightpack::open()
 	// open each lightpack device
 	for (const std::string & serial : serialList)
 	{
-		LedDeviceLightpack * device = new LedDeviceLightpack();	
-		int error = device->open(serial);
+		LedDeviceLightpack * device = new LedDeviceLightpack(serial);	
+		int error = device->open();
 
 		if (error == 0)
 		{


### PR DESCRIPTION
**1.** Tell us something about your changes.
- refactoring leddevicefactory
- adalight: default for "delayAfterConnect" is 1s now - needed for most arduino's because of there special behaviour on open
- fadecandy: new option for disabling configuration send - if you want to keep your fadecandy defaults
- Hyperion.cpp: simplify createSmoothing discussed in #105
- smoothing:
 - add option for continuous output
 - when updatedelay>0 and continousOutput is disabled, buffer is flushed correctly after no input is detected
- ad doxygen to travis

**2.** If this changes affect the .conf file. Please provide the changed section
yes, smoothing gets a new param `"continuousOutput" : false`

**3.** Reference a issue (optional)
#111 #87 