### PR TITLE
Add enable option to grabbers

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -190,6 +190,7 @@
 	///   * ATTENTION    : Power-of-Two resolution is not supported and leads to unexpected behaviour! 
 	"framegrabber" :
 	{
+		"enable"       : true,
 		"width"        : 96,
 		"height"       : 96,
 		"frequency_Hz" : 10.0,

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -58,7 +58,8 @@
 	/// Next to the list with color transforms there is also a smoothing option.
 	///  * 'smoothing' : Smoothing of the colors in the time-domain with the following tuning 
 	///                  parameters:
-	///            - 'type'            The type of smoothing algorithm ('linear' or 'none')
+	///            - 'enable'          Enable or disable the smoothing (true/false)
+	///			   - 'type'            The type of smoothing algorithm ('linear')
 	///            - 'time_ms'         The time constant for smoothing algorithm in milliseconds
 	///            - 'updateFrequency' The update frequency of the leds in Hz
 	///            - 'updateDelay'     The delay of the output to leds (in periods of smoothing)
@@ -136,7 +137,7 @@
 			"enable"          : true,
 			"type"            : "linear",
 			"time_ms"         : 200,
-			"updateFrequency" : 20.0000,
+			"updateFrequency" : 25.0000,
 			"updateDelay"     : 0
 		}
 	},
@@ -181,6 +182,7 @@
 	},
 
 	///  The configuration for the frame-grabber, contains the following items: 
+	///   * enable       : true if the framegrabber (platform grabber) should be activated
 	///   * width        : The width of the grabbed frames [pixels]
 	///   * height       : The height of the grabbed frames [pixels]
 	///   * frequency_Hz : The frequency of the frame grab [Hz]
@@ -188,8 +190,8 @@
 	///   * ATTENTION    : Power-of-Two resolution is not supported and leads to unexpected behaviour! 
 	"framegrabber" :
 	{
-		"width"        : 64,
-		"height"       : 64,
+		"width"        : 96,
+		"height"       : 96,
 		"frequency_Hz" : 10.0,
 		"priority"     : 890
 	},

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -58,19 +58,12 @@
 	/// Next to the list with color transforms there is also a smoothing option.
 	///  * 'smoothing' : Smoothing of the colors in the time-domain with the following tuning 
 	///                  parameters:
-<<<<<<< HEAD
 	///            - 'enable'          Enable or disable the smoothing (true/false)
-	///			   - 'type'            The type of smoothing algorithm ('linear')
-	///            - 'time_ms'         The time constant for smoothing algorithm in milliseconds
-	///            - 'updateFrequency' The update frequency of the leds in Hz
-	///            - 'updateDelay'     The delay of the output to leds (in periods of smoothing)
-=======
 	///            - 'type'             The type of smoothing algorithm ('linear' or 'none')
 	///            - 'time_ms'          The time constant for smoothing algorithm in milliseconds
 	///            - 'updateFrequency'  The update frequency of the leds in Hz
 	///            - 'updateDelay'      The delay of the output to leds (in periods of smoothing)
 	///            - 'continuousOutput' Flag for enabling continuous output to Leds regardless of new input or not
->>>>>>> refs/remotes/hyperion-project/master
 	"color" :
 	{
 		"channelAdjustment" :
@@ -142,20 +135,12 @@
 
 		"smoothing" :
 		{
-<<<<<<< HEAD
-			"enable"          : true,
-			"type"            : "linear",
-			"time_ms"         : 200,
-			"updateFrequency" : 25.0000,
-			"updateDelay"     : 0
-=======
 			"enable"           : true,
 			"type"             : "linear",
 			"time_ms"          : 200,
-			"updateFrequency"  : 20.0000,
+			"updateFrequency"  : 25.0000,
 			"updateDelay"      : 0,
 			"continuousOutput" : true
->>>>>>> refs/remotes/hyperion-project/master
 		}
 	},
 

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -83,20 +83,12 @@
 		],
 		"smoothing" :
 		{
-<<<<<<< HEAD
-			"enable"          : true,
-			"type"            : "linear",
-			"time_ms"         : 200,
-			"updateFrequency" : 25.0000,
-			"updateDelay"     : 0
-=======
 			"enable"           : true,
 			"type"             : "linear",
 			"time_ms"          : 200,
-			"updateFrequency"  : 20.0000,
+			"updateFrequency"  : 25.0000,
 			"updateDelay"      : 0,
 			"continuousOutput" : false
->>>>>>> refs/remotes/hyperion-project/master
 		}
 	},
 	

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -86,7 +86,7 @@
 			"enable"          : true,
 			"type"            : "linear",
 			"time_ms"         : 200,
-			"updateFrequency" : 20.0000,
+			"updateFrequency" : 25.0000,
 			"updateDelay"     : 0
 		}
 	},
@@ -114,8 +114,9 @@
 
 	"framegrabber" :
 	{
-		"width" : 128,
-		"height" : 128,
+		"enable" : true,
+		"width" : 96,
+		"height" : 96,
 		"frequency_Hz" : 10.0,
 		"priority" : 890
 	},
@@ -129,7 +130,7 @@
 
 	"kodiVideoChecker" :
 	{
-		"enable"            : true,
+		"enable"            : false,
 		"kodiAddress"       : "localhost",
 		"kodiTcpPort"       : 9090,
 		"grabVideo"         : true,

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -397,9 +397,9 @@ void HyperionDaemon::createGrabberAmlogic()
 {
 #ifdef ENABLE_AMLOGIC
 	// Construct and start the amlogic grabber if the configuration is present
-	if (_config.isMember("framegrabber"))
+	if (_config.isMember("amlgrabber"))
 	{
-		const Json::Value & grabberConfig = _config["framegrabber"];
+		const Json::Value & grabberConfig = _config["amlgrabber"];
 		if (grabberConfig.get("enable", true).asBool())
 		{
 			_amlGrabber = new AmlogicWrapper(
@@ -417,7 +417,7 @@ void HyperionDaemon::createGrabberAmlogic()
 		}
 	}
 #else
-	ErrorIf(_config.isMember("framegrabber"), _log, "The AMLOGIC grabber can not be instantiated, because it has been left out from the build");
+	ErrorIf(_config.isMember("amlgrabber"), _log, "The AMLOGIC grabber can not be instantiated, because it has been left out from the build");
 #endif
 }
 

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -426,9 +426,9 @@ void HyperionDaemon::createGrabberFramebuffer()
 {
 #ifdef ENABLE_FB
 	// Construct and start the framebuffer grabber if the configuration is present
-	if (_config.isMember("framegrabber"))
+	if (_config.isMember("framebuffergrabber"))
 	{
-		const Json::Value & grabberConfig = _config["framegrabber"];
+		const Json::Value & grabberConfig = _config["framebuffergrabber"];
 		if (grabberConfig.get("enable", true).asBool())
 		{
 			_fbGrabber = new FramebufferWrapper(
@@ -447,7 +447,7 @@ void HyperionDaemon::createGrabberFramebuffer()
 		}
 	}
 #else
-	ErrorIf(_config.isMember("framegrabber"), _log, "The framebuffer grabber can not be instantiated, because it has been left out from the build");
+	ErrorIf(_config.isMember("framebuffergrabber"), _log, "The framebuffer grabber can not be instantiated, because it has been left out from the build");
 #endif
 }
 
@@ -456,9 +456,9 @@ void HyperionDaemon::createGrabberOsx()
 {
 #ifdef ENABLE_OSX
 	// Construct and start the osx grabber if the configuration is present
-	if (_config.isMember("framegrabber"))
+	if (_config.isMember("osxgrabber"))
 	{
-		const Json::Value & grabberConfig = _config["framegrabber"];
+		const Json::Value & grabberConfig = _config["osxgrabber"];
 		if (grabberConfig.get("enable", true).asBool())
 		{
 			_osxGrabber = new OsxWrapper(
@@ -477,6 +477,6 @@ void HyperionDaemon::createGrabberOsx()
 		}
 	}
 #else
-	ErrorIf(_config.isMember("framegrabber"), _log, "The osx grabber can not be instantiated, because it has been left out from the build");
+	ErrorIf(_config.isMember("osxgrabber"), _log, "The osx grabber can not be instantiated, because it has been left out from the build");
 #endif
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.
- some optimizations, sadly you need for kodi the enabled remote option, cause of this i suggest to disable it.
- raised a little bit the grabber value (value of 16) to take account of the usage of more leds
- raised smoothing from 20 to 25 fps to prevent stutter (assumed SPI/PWM gpio) this won't work for all devices.

Issue https://github.com/hyperion-project/hyperion.ng/issues/3