### PR TITLE
hyperion won't fail, if v4l2 has invalid device + auto device

### DIFF
--- a/include/grabber/V4L2Grabber.h
+++ b/include/grabber/V4L2Grabber.h
@@ -3,6 +3,7 @@
 // stl includes
 #include <string>
 #include <vector>
+#include <map>
 
 // Qt includes
 #include <QObject>
@@ -61,6 +62,8 @@ private slots:
 	int read_frame();
 
 private:
+	void getV4Ldevices();
+	
 	bool init();
 	void uninit();
 
@@ -105,10 +108,11 @@ private:
 	};
 
 private:
-	const std::string _deviceName;
+	std::string _deviceName;
+	std::map<std::string,std::string> _v4lDevices;
 	int _input;
 	VideoStandard _videoStandard;
-	const io_method _ioMethod;
+	io_method _ioMethod;
 	int _fileDescriptor;
 	std::vector<buffer> _buffers;
 

--- a/include/grabber/V4L2Grabber.h
+++ b/include/grabber/V4L2Grabber.h
@@ -50,7 +50,7 @@ public slots:
 					double blueSignalThreshold,
 					int noSignalCounterThreshold);
 
-	void start();
+	bool start();
 
 	void stop();
 
@@ -61,6 +61,9 @@ private slots:
 	int read_frame();
 
 private:
+	bool init();
+	void uninit();
+
 	void open_device();
 
 	void close_device();
@@ -103,6 +106,8 @@ private:
 
 private:
 	const std::string _deviceName;
+	int _input;
+	VideoStandard _videoStandard;
 	const io_method _ioMethod;
 	int _fileDescriptor;
 	std::vector<buffer> _buffers;
@@ -125,4 +130,5 @@ private:
 	ImageResampler _imageResampler;
 	
 	Logger * _log;
+	bool _initialized;
 };

--- a/include/grabber/V4L2Wrapper.h
+++ b/include/grabber/V4L2Wrapper.h
@@ -30,7 +30,7 @@ public:
 	virtual ~V4L2Wrapper();
 
 public slots:
-	void start();
+	bool start();
 
 	void stop();
 

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -68,9 +68,13 @@ V4L2Wrapper::~V4L2Wrapper()
 	delete _processor;
 }
 
-void V4L2Wrapper::start()
+bool V4L2Wrapper::start()
 {
-	_grabber.start();
+	bool grabber_started = _grabber.start();
+	if ( ! grabber_started )
+		_timer.stop();
+	
+	return grabber_started;
 }
 
 void V4L2Wrapper::stop()

--- a/src/hyperion-v4l2/hyperion-v4l2.cpp
+++ b/src/hyperion-v4l2/hyperion-v4l2.cpp
@@ -164,8 +164,8 @@ int main(int argc, char** argv)
 		{
 			ProtoConnectionWrapper handler(argAddress.getValue(), argPriority.getValue(), 1000, argSkipReply.isSet());
 			QObject::connect(&grabber, SIGNAL(newFrame(Image<ColorRgb>)), &handler, SLOT(receiveImage(Image<ColorRgb>)));
-			grabber.start();
-			QCoreApplication::exec();
+			if (grabber.start())
+				QCoreApplication::exec();
 			grabber.stop();
 		}
 	}

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -360,8 +360,6 @@ void HyperionDaemon::createGrabberV4L2()
 	if (_config.isMember("grabber-v4l2"))
 	{
 		const Json::Value & grabberConfig = _config["grabber-v4l2"];
-		if (grabberConfig.get("enable", true).asBool())
-		{
 			_v4l2Grabber = new V4L2Wrapper(
 						grabberConfig.get("device", "/dev/video0").asString(),
 						grabberConfig.get("input", 0).asInt(),
@@ -381,11 +379,12 @@ void HyperionDaemon::createGrabberV4L2()
 						grabberConfig.get("cropRight", 0).asInt(),
 						grabberConfig.get("cropTop", 0).asInt(),
 						grabberConfig.get("cropBottom", 0).asInt());
+			Debug(_log, "V4L2 grabber created");
 
-			QObject::connect(_v4l2Grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)) );
-
-			_v4l2Grabber->start();
-			Info(_log, "V4L2 grabber created and started");
+		QObject::connect(_v4l2Grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)) );
+		if (grabberConfig.get("enable", true).asBool() && _v4l2Grabber->start())
+		{
+			Info(_log, "V4L2 grabber started");
 		}
 	}
 #else


### PR DESCRIPTION
**1.** Tell us something about your changes.
as the title said: hyperion won't fail, if v4l2 has invalid device.
If invalid device is detected, error messages is printed and v4l2 capture device is disabled.

and add auto device: uses the first valid device. Set "auto" as device in config

**2.** If this changes affect the .conf file. Please provide the changed section
```
	"grabber-v4l2" : 
	{
		"enable" : true,
		"device" : "auto",
```

Instead ”/dev/video0” type ”auto”

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


