### PR TITLE
make "enable" work for blackborder detector

### DIFF
--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -35,6 +35,18 @@ namespace hyperion
 		BlackBorder getCurrentBorder() const;
 
 		///
+		/// Return activation state of black border detector
+		/// @return The current border
+		///
+		bool enabled() const;
+
+		///
+		/// Set activation state of black border detector
+		/// @param enable current state
+		///
+		void setEnabled(bool enable);
+
+		///
 		/// Processes the image. This performs detecion of black-border on the given image and
 		/// updates the current border accordingly. If the current border is updated the method call
 		/// will return true else false
@@ -48,6 +60,11 @@ namespace hyperion
 		{
 			// get the border for the single image
 			BlackBorder imageBorder;
+			if (!enabled())
+			{
+				return false;
+			}
+
 			if (_detectionMode == "default") {
 				imageBorder = _detector.process(image);
 			} else if (_detectionMode == "classic") {
@@ -69,7 +86,6 @@ namespace hyperion
 			return borderUpdated;
 		}
 
-
 	private:
 		///
 		/// Updates the current border based on the newly detected border. Returns true if the
@@ -80,6 +96,9 @@ namespace hyperion
 		///
 		bool updateBorder(const BlackBorder & newDetectedBorder);
 
+		/// flag for blackborder detector usage
+		bool _enabled;
+		
 		/// The number of unknown-borders detected before it becomes the current border
 		const unsigned _unknownSwitchCnt;
 

--- a/include/hyperion/ImageProcessor.h
+++ b/include/hyperion/ImageProcessor.h
@@ -39,7 +39,7 @@ public:
 	void setSize(const unsigned width, const unsigned height);
 
 	/// Enable or disable the black border detector
-	void enableBalckBorderDetector(bool enable);
+	void enableBlackBorderDetector(bool enable);
 
 	///
 	/// Processes the image to a list of led colors. This will update the size of the buffer-image
@@ -117,7 +117,7 @@ private:
 	template <typename Pixel_T>
 	void verifyBorder(const Image<Pixel_T> & image)
 	{
-		if(_enableBlackBorderRemoval && _borderProcessor->process(image))
+		if(_borderProcessor->enabled() && _borderProcessor->process(image))
 		{
 			Debug(Logger::getInstance("BLACKBORDER"), "BORDER SWITCH REQUIRED!!");
 
@@ -145,9 +145,6 @@ private:
 private:
 	/// The Led-string specification
 	const LedString _ledString;
-
-	/// Flag the enables(true)/disabled(false) blackborder detector
-	bool _enableBlackBorderRemoval;
 
 	/// The processor for black border detection
 	hyperion::BlackBorderProcessor * _borderProcessor;

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -9,7 +9,8 @@
 using namespace hyperion;
 
 BlackBorderProcessor::BlackBorderProcessor(const Json::Value &blackborderConfig)
-	: _unknownSwitchCnt(blackborderConfig.get("unknownFrameCnt", 600).asUInt())
+	: _enabled(blackborderConfig.get("enable", true).asBool())
+	, _unknownSwitchCnt(blackborderConfig.get("unknownFrameCnt", 600).asUInt())
 	, _borderSwitchCnt(blackborderConfig.get("borderFrameCnt", 50).asUInt())
 	, _maxInconsistentCnt(blackborderConfig.get("maxInconsistentCnt", 10).asUInt())
 	, _blurRemoveCnt(blackborderConfig.get("blurRemoveCnt", 1).asUInt())
@@ -20,12 +21,25 @@ BlackBorderProcessor::BlackBorderProcessor(const Json::Value &blackborderConfig)
 	, _consistentCnt(0)
 	, _inconsistentCnt(10)
 {
-	Debug(Logger::getInstance("BLACKBORDER"), "mode: %s", _detectionMode.c_str());
+	if (_enabled)
+	{
+		Debug(Logger::getInstance("BLACKBORDER"), "mode: %s", _detectionMode.c_str());
+	}
 }
 
 BlackBorder BlackBorderProcessor::getCurrentBorder() const
 {
 	return _currentBorder;
+}
+
+bool BlackBorderProcessor::enabled() const
+{
+	return _enabled;
+}
+
+void BlackBorderProcessor::setEnabled(bool enable)
+{
+	_enabled = enable;
 }
 
 bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -66,7 +66,7 @@ Effect::Effect(PyThreadState * mainThreadState, int priority, int timeout, const
 	_colors.resize(_imageProcessor->getLedCount(), ColorRgb::BLACK);
 
 	// disable the black border detector for effects
-	_imageProcessor->enableBalckBorderDetector(false);
+	_imageProcessor->enableBlackBorderDetector(false);
 
 	// connect the finished signal
 	connect(this, SIGNAL(finished()), this, SLOT(effectFinished()));

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -11,7 +11,6 @@ using namespace hyperion;
 //ImageProcessor::ImageProcessor(const LedString& ledString, bool enableBlackBorderDetector, uint8_t blackborderThreshold) :
 ImageProcessor::ImageProcessor(const LedString& ledString, const Json::Value & blackborderConfig) :
 	_ledString(ledString),
-	_enableBlackBorderRemoval(blackborderConfig.get("enable", true).asBool()),
 	_borderProcessor(new BlackBorderProcessor(blackborderConfig) ),
 	_imageToLeds(nullptr)
 {
@@ -44,9 +43,9 @@ void ImageProcessor::setSize(const unsigned width, const unsigned height)
 	_imageToLeds = new ImageToLedsMap(width, height, 0, 0, _ledString.leds());
 }
 
-void ImageProcessor::enableBalckBorderDetector(bool enable)
+void ImageProcessor::enableBlackBorderDetector(bool enable)
 {
-	_enableBlackBorderRemoval = enable;
+	_borderProcessor->setEnabled(enable);
 }
 
 bool ImageProcessor::getScanParameters(size_t led, double &hscanBegin, double &hscanEnd, double &vscanBegin, double &vscanEnd) const


### PR DESCRIPTION
**1.** Tell us something about your changes.
... make "enable" work for blackborder detector
If you look with --debug, then you will see following message in state enabled=false too:
`//[HYPERIOND BLACKBORDER] <DEBUG> <BlackBorderDetector.cpp:26:calculateThreshold()> threshold set to 0.000000 (0)`

bb is deactivated, but the bb detector object is created - but do nothing, just prints that line. If you enable bb, then you will see more messages ....

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference a issue (optional)
#3 #107 
Note: For further discussions use our forum: forum.hyperion-project.org


