### PR TITLE
Added SIGPIPE handing.

### DIFF
--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv)
 	signal(SIGINT,  signal_handler);
 	signal(SIGTERM, signal_handler);
 	signal(SIGCHLD, signal_handler);
+	signal(SIGPIPE, signal_handler);
 
 	// force the locale
 	setlocale(LC_ALL, "C");


### PR DESCRIPTION
If you are grepping the debugging output and then hit ctrl-C, theres a good chance hyperiond never cleans up properly.