### PR TITLE
fix logger crash

### DIFF
--- a/libsrc/utils/Logger.cpp
+++ b/libsrc/utils/Logger.cpp
@@ -122,11 +122,11 @@ void Logger::Message(LogLevel level, const char* sourceFile, const char* func, u
 	  || (GLOBAL_MIN_LOG_LEVEL > Logger::UNSET && level < GLOBAL_MIN_LOG_LEVEL) ) // global level set, use global level
 		return;
 
-
-	char msg[512];
+	const size_t max_msg_length = 1024;
+	char msg[max_msg_length];
 	va_list args;
 	va_start (args, fmt);
-	vsprintf (msg,fmt, args);
+	vsnprintf (msg, max_msg_length, fmt, args);
 	va_end (args);
 
 	std::string location;


### PR DESCRIPTION
**1.** Tell us something about your changes.
make logger don't crash when long messages put to logger. Currently longest message is 1024 chars. Longer messages are truncated

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference a issue (optional)
#131
Note: For further discussions use our forum: forum.hyperion-project.org


