### PR TITLE
KODIVideoChecker Fix

### DIFF
--- a/include/kodivideochecker/KODIVideoChecker.h
+++ b/include/kodivideochecker/KODIVideoChecker.h
@@ -112,6 +112,9 @@ private:
 
 	/// The JSON-RPC message to check the kodi version
 	QString _getKodiVersion;
+	
+	/// The JSON-RPC message to check the current Playback State
+	const QString _getCurrentPlaybackState; 
 
 	/// The QT TCP Socket with connection to KODI
 	QTcpSocket _socket;
@@ -142,6 +145,12 @@ private:
 
 	/// Previous emitted video mode
 	VideoMode _previousVideoMode;
+	
+	/// Current Playback State
+	bool _currentPlaybackState;
+	
+	/// Current Kodi PlayerID
+	int _currentPlayerID;
 
 	/// KODI version number
 	int _kodiVersion;

--- a/libsrc/kodivideochecker/KODIVideoChecker.cpp
+++ b/libsrc/kodivideochecker/KODIVideoChecker.cpp
@@ -287,10 +287,6 @@ void KODIVideoChecker::receiveReply()
 						{
 							// result of Player.PlayPause 
 							_currentPlaybackState = static_cast<bool>(doc.object()["result"].toObject()["speed"].toInt());
-// 							if (doc.object()["result"].toObject()["speed"].toInt() == 0)
-// 								_currentPlaybackState = false;	//Pause
-// 							else
-// 								_currentPlaybackState = true;	//Play
 						}
 						else
 						{


### PR DESCRIPTION
**1.** Tell us something about your changes.
Es sollten jetzt alle zustände (Video, Audio, Picture, Pause, Menu, Screensaver) von Kodi erfasst werden. Auch wenn sich Kodi im Anmeldemodus befindet (Passwort). Der Pause zustand wird nun auch richtig erkannt, nach dem der screensaver aktiviert oder daktiviert wird.
Feedback ist erwünscht.

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

