### PR TITLE
Fixing "Required" Key in QJsonSchemaChecker

### DIFF
--- a/libsrc/utils/jsonschema/QJsonSchemaChecker.cpp
+++ b/libsrc/utils/jsonschema/QJsonSchemaChecker.cpp
@@ -180,7 +180,7 @@ void QJsonSchemaChecker::checkProperties(const QJsonObject & value, const QJsonO
 		{
 			validate(value[property], propertyValue.toObject());
 		}
-		else if (required != schema.end() && required.value().toBool())
+		else if (required != propertyValue.toObject().end() && required.value().toBool())
 		{
 			_error = true;
 			setMessage("missing member");
@@ -208,7 +208,7 @@ void QJsonSchemaChecker::checkAdditionalProperties(const QJsonObject & value, co
 			}
 			else
 			{
-				validate(value[property], schema.toObject());
+				validate(value[property].toObject(), schema.toObject());
 			}
 			_currentPath.pop_back();
 		}


### PR DESCRIPTION
**1.** Tell us something about your changes.
Leider ein Denkfehler.
Der "Required" Schlüssel wurde mit sich selbst verglichen.
Jetzt sollte der Vergleich zwischen Schema und Config so funktionieren wie vorgesehen.

Hier noch mal kurz erklärt:

Ist der Required Schlüssel im Schema "true" MUSS dieser Eintrag in der Config Datei vorhanden sein.
Ist der Required Schlüssel im Schema "false" MUSS dieser Eintrag NICHT zwingend in der Config Datei vorhanden sein.

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


