### PR TITLE
Amlogic box uses aml and fb buffer

### DIFF
--- a/libsrc/grabber/amlogic/AmlogicWrapper.cpp
+++ b/libsrc/grabber/amlogic/AmlogicWrapper.cpp
@@ -11,16 +11,16 @@
 #include <grabber/AmlogicGrabber.h>
 
 
-AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const int priority) :
-	_updateInterval_ms(1000/updateRate_Hz),
-	_timeout_ms(2 * _updateInterval_ms),
-	_priority(priority),
-	_timer(),
-	_image(grabWidth, grabHeight),
-	_frameGrabber(new AmlogicGrabber(grabWidth, grabHeight)),
-	_processor(ImageProcessorFactory::getInstance().newImageProcessor()),
-	_ledColors(Hyperion::getInstance()->getLedCount(), ColorRgb{0,0,0}),
-	_hyperion(Hyperion::getInstance())
+AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const int priority)
+	: _updateInterval_ms(1000/updateRate_Hz)
+	, _timeout_ms(2 * _updateInterval_ms)
+	, _priority(priority)
+	, _timer()
+	, _image(grabWidth, grabHeight)
+	, _frameGrabber(new AmlogicGrabber(grabWidth, grabHeight))
+	, _processor(ImageProcessorFactory::getInstance().newImageProcessor())
+	, _ledColors(Hyperion::getInstance()->getLedCount(), ColorRgb{0,0,0})
+	, _hyperion(Hyperion::getInstance())
 {
 	// Configure the timer to generate events every n milliseconds
 	_timer.setInterval(_updateInterval_ms);

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -4,16 +4,18 @@
 #include <cstdio>
 #include <cassert>
 #include <cstdlib>
-#include <fcntl.h>
-#include <unistd.h>
 #include <cstring>
 #include <sstream>
+
+#include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <linux/videodev2.h>
+
 #include <QDirIterator>
 #include <QFileInfo>
 
@@ -97,12 +99,11 @@ bool V4L2Grabber::init()
 			_deviceName = "unknown";
 			for (auto& dev: _v4lDevices)
 			{
-				//Debug(_log, "check v4l2 device: %s (%s)",dev.first.c_str(), dev.second.c_str());
 				_deviceName = dev.first;
 				if ( init() )
 				{
 					Info(_log, "found usable v4l2 device: %s (%s)",dev.first.c_str(), dev.second.c_str());
-					break;
+					return _initialized;
 				}
 			}
 		}

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -255,7 +255,7 @@ void HyperionDaemon::startNetworkServices()
 	{
 		const Json::Value & boblightServerConfig = _config["boblightServer"];
 		_boblightServer = new BoblightServer(
-			boblightServerConfig.get("priority",899).asInt(),
+			boblightServerConfig.get("priority",710).asInt(),
 			boblightServerConfig["port"].asUInt()
 		);
 		Debug(_log, "Boblight server created");

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -412,7 +412,7 @@ void HyperionDaemon::createGrabberAmlogic(const Json::Value & grabberConfig)
 				grabberConfig["width"].asUInt(),
 				grabberConfig["height"].asUInt(),
 				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt());
+				grabberConfig.get("priority",900).asInt()-1 );
 
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _amlGrabber, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)),       _amlGrabber, SLOT(setVideoMode(VideoMode)));

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -96,8 +96,8 @@ void HyperionDaemon::run()
 	createGrabberV4L2();
 	createSystemFrameGrabber();
 
-	#if !defined(ENABLE_DISPMANX) && !defined(ENABLE_OSX) && !defined(ENABLE_FB)
-		ErrorIf(_config.isMember("framegrabber"), _log, "No grabber can be instantiated, because all grabbers have been left out from the build");
+	#if !defined(ENABLE_DISPMANX) && !defined(ENABLE_OSX) && !defined(ENABLE_FB) && !defined(ENABLE_X11) && !defined(ENABLE_AMLOGIC)
+		WarningIf(_config.isMember("framegrabber"), _log, "No grabber can be instantiated, because all grabbers have been left out from the build");
 	#endif
 
 }
@@ -367,7 +367,7 @@ void HyperionDaemon::createSystemFrameGrabber()
 			
 			if (type == "framebuffer")   createGrabberFramebuffer(grabberConfig);
 			else if (type == "dispmanx") createGrabberDispmanx(grabberConfig);
-			else if (type == "amlogic")  createGrabberAmlogic(grabberConfig);
+			else if (type == "amlogic")  { createGrabberAmlogic(grabberConfig); createGrabberFramebuffer(grabberConfig); }
 			else if (type == "osx")      createGrabberOsx(grabberConfig);
 			else if (type == "x11")      createGrabberX11(grabberConfig);
 			else WarningIf( type != "", _log, "unknown framegrabber type '%s'", type.c_str());

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -327,6 +327,16 @@ void HyperionDaemon::createSystemFrameGrabber()
 		const Json::Value & grabberConfig = _config["framegrabber"];
 		if (grabberConfig.get("enable", true).asBool())
 		{
+			_grabber_width     = grabberConfig.get("width", 96).asUInt();
+			_grabber_height    = grabberConfig.get("height", 96).asUInt();
+			_grabber_frequency = grabberConfig.get("frequency_Hz",10).asUInt();
+			_grabber_priority  = grabberConfig.get("priority",900).asInt();
+
+			_grabber_cropLeft   = grabberConfig.get("cropLeft", 0).asUInt();
+			_grabber_cropRight  = grabberConfig.get("cropRight", 0).asUInt();
+			_grabber_cropTop    = grabberConfig.get("cropTop", 0).asUInt();
+			_grabber_cropBottom = grabberConfig.get("cropBottom", 0).asUInt();
+
 			#ifdef ENABLE_OSX
 				std::string type = "osx";
 			#else
@@ -362,12 +372,12 @@ void HyperionDaemon::createSystemFrameGrabber()
 				{
 					type == "framebuffer";
 				}
-				InfoIf( type != "auto", _log, "set screen capture device to '%s'", type.c_str());
+				Info(  _log, "set screen capture device to '%s'", type.c_str());
 			}
 			
 			if (type == "framebuffer")   createGrabberFramebuffer(grabberConfig);
-			else if (type == "dispmanx") createGrabberDispmanx(grabberConfig);
-			else if (type == "amlogic")  { createGrabberAmlogic(grabberConfig); createGrabberFramebuffer(grabberConfig); }
+			else if (type == "dispmanx") createGrabberDispmanx();
+			else if (type == "amlogic")  { createGrabberAmlogic(); createGrabberFramebuffer(grabberConfig); }
 			else if (type == "osx")      createGrabberOsx(grabberConfig);
 			else if (type == "x11")      createGrabberX11(grabberConfig);
 			else WarningIf( type != "", _log, "unknown framegrabber type '%s'", type.c_str());
@@ -377,20 +387,11 @@ void HyperionDaemon::createSystemFrameGrabber()
 }
 
 
-void HyperionDaemon::createGrabberDispmanx(const Json::Value & grabberConfig)
+void HyperionDaemon::createGrabberDispmanx()
 {
 #ifdef ENABLE_DISPMANX
-	// Construct and start the dispmanx grabber if the configuration is present
-	_dispmanx = new DispmanxWrapper(
-				grabberConfig["width"].asUInt(),
-				grabberConfig["height"].asUInt(),
-				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt());
-			_dispmanx->setCropping(
-				grabberConfig.get("cropLeft", 0).asInt(),
-				grabberConfig.get("cropRight", 0).asInt(),
-				grabberConfig.get("cropTop", 0).asInt(),
-				grabberConfig.get("cropBottom", 0).asInt());
+	_dispmanx = new DispmanxWrapper(_grabber_width, _grabber_height, _grabber_frequency, _grabber_priority);
+	_dispmanx->setCropping(_grabber_cropLeft, _grabber_cropRight, _grabber_cropTop, _grabber_cropBottom);
 
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _dispmanx, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)), _dispmanx, SLOT(setVideoMode(VideoMode)));
@@ -404,15 +405,10 @@ void HyperionDaemon::createGrabberDispmanx(const Json::Value & grabberConfig)
 }
 
 
-void HyperionDaemon::createGrabberAmlogic(const Json::Value & grabberConfig)
+void HyperionDaemon::createGrabberAmlogic()
 {
 #ifdef ENABLE_AMLOGIC
-	// Construct and start the amlogic grabber if the configuration is present
-	_amlGrabber = new AmlogicWrapper(
-				grabberConfig["width"].asUInt(),
-				grabberConfig["height"].asUInt(),
-				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt()-1 );
+	_amlGrabber = new AmlogicWrapper(_grabber_width, _grabber_height, _grabber_frequency, _grabber_priority-1);
 
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _amlGrabber, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)),       _amlGrabber, SLOT(setVideoMode(VideoMode)));
@@ -428,18 +424,12 @@ void HyperionDaemon::createGrabberAmlogic(const Json::Value & grabberConfig)
 void HyperionDaemon::createGrabberX11(const Json::Value & grabberConfig)
 {
 #ifdef ENABLE_X11
-	// Construct and start the amlogic grabber if the configuration is present
 	_x11Grabber = new X11Wrapper(
 				grabberConfig.get("useXGetImage",false).asBool(),
-				grabberConfig.get("cropLeft", 0).asInt(),
-				grabberConfig.get("cropRight", 0).asInt(),
-				grabberConfig.get("cropTop", 0).asInt(),
-				grabberConfig.get("cropBottom", 0).asInt(),
+				_grabber_cropLeft, _grabber_cropRight, _grabber_cropTop, _grabber_cropBottom,
 				grabberConfig.get("horizontalPixelDecimation", 8).asInt(),
 				grabberConfig.get("verticalPixelDecimation", 8).asInt(),
-				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt()
-	);
+				_grabber_frequency, _grabber_priority );
 
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _x11Grabber, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)),       _x11Grabber, SLOT(setVideoMode(VideoMode)));
@@ -459,11 +449,8 @@ void HyperionDaemon::createGrabberFramebuffer(const Json::Value & grabberConfig)
 	// Construct and start the framebuffer grabber if the configuration is present
 	_fbGrabber = new FramebufferWrapper(
 				grabberConfig.get("device", "/dev/fb0").asString(),
-				grabberConfig["width"].asUInt(),
-				grabberConfig["height"].asUInt(),
-				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt());
-
+				_grabber_width, _grabber_height, _grabber_frequency, _grabber_priority);
+	
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _fbGrabber, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)), _fbGrabber, SLOT(setVideoMode(VideoMode)));
 	QObject::connect(_fbGrabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)) );
@@ -482,11 +469,8 @@ void HyperionDaemon::createGrabberOsx(const Json::Value & grabberConfig)
 	// Construct and start the osx grabber if the configuration is present
 	_osxGrabber = new OsxWrapper(
 				grabberConfig.get("display", 0).asUInt(),
-				grabberConfig["width"].asUInt(),
-				grabberConfig["height"].asUInt(),
-				grabberConfig.get("frequency_Hz",10).asUInt(),
-				grabberConfig.get("priority",900).asInt());
-
+				_grabber_width, _grabber_height, _grabber_frequency, _grabber_priority);
+	
 	QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _osxGrabber, SLOT(setGrabbingMode(GrabbingMode)));
 	QObject::connect(_kodiVideoChecker, SIGNAL(videoMode(VideoMode)), _osxGrabber, SLOT(setVideoMode(VideoMode)));
 	QObject::connect(_osxGrabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)) );

--- a/src/hyperiond/hyperiond.h
+++ b/src/hyperiond/hyperiond.h
@@ -65,8 +65,8 @@ public:
 	void createSystemFrameGrabber();
 
 private:
-	void createGrabberDispmanx(const Json::Value & grabberConfig);
-	void createGrabberAmlogic(const Json::Value & grabberConfig);
+	void createGrabberDispmanx();
+	void createGrabberAmlogic();
 	void createGrabberFramebuffer(const Json::Value & grabberConfig);
 	void createGrabberOsx(const Json::Value & grabberConfig);
 	void createGrabberX11(const Json::Value & grabberConfig);
@@ -86,4 +86,13 @@ private:
 	OsxWrapper*         _osxGrabber;
 	WebConfig*          _webConfig;
 	Hyperion*           _hyperion;
+	
+	unsigned            _grabber_width;
+	unsigned            _grabber_height;
+	unsigned            _grabber_frequency;
+	int                 _grabber_priority;
+	unsigned            _grabber_cropLeft;
+	unsigned            _grabber_cropRight;
+	unsigned            _grabber_cropTop;
+    unsigned            _grabber_cropBottom;
 };


### PR DESCRIPTION
**1.** Tell us something about your changes.
**Amlogic box uses aml and fb buffer**
on amlogic (wetek) systems you need 2 grabbers. aml and fb. Now both are started, with same settings. This is the same as before adding the amlgrabber section with same settings of framegabber section. The prio of aml is decreased by 1, because aml and fb arn't allowed to e on same channel.

In framegrabber section set type to "auto" or "amlogic". If you want FB only use "framebuffer" as type.

**hyperiond**
refactoring of hyperiond.cpp grabber config code.

**json client**
now all input sources (grabber, network, effects) are shown in hyperion-remote --list. Entries marked as active=true/false to show their state.
example:
```
   "priorities" : [
      {
         "active" : "true",
         "duration_ms" : 178,
         "owner" : "X11 Grabber",
         "priority" : 900
      },
      {
         "active" : "true",
         "owner" : "EFFECT: /usr/share/hyperion/effects/mood-blobs.py",
         "priority" : 2147483646
      },
      {
         "active" : "false",
         "owner" : "Boblight",
         "priority" : 710
      },
      {
         "active" : "false",
         "owner" : "V4L2",
         "priority" : 890
      }
   ],

```
(small todo ... sort output by priority)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org
