### PR TITLE
Manual input source select via json

### DIFF
--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -128,10 +128,21 @@ public:
 	/// @param name uniq name of input source
 	void unRegisterPriority(const std::string name);
 	
+	/// gets current priority register
+	/// @return the priority register
 	const PriorityRegister& getPriorityRegister() { return _priorityRegister; }
 	
+	/// enable/disable automatic/priorized source selection
+	/// @param enable the state
 	void setSourceAutoSelectEnabled(bool enabled);
+	
+	/// set current input source to visible
+	/// @param priority the priority channel which should be vidible
+	/// @return true if success, false on error
 	bool setCurrentSourcePriority(int priority );
+	
+	/// gets current state of automatic/priorized source selection
+	/// @return the state
 	bool sourceAutoSelectEnabled() { return _sourceAutoSelectEnabled; };
 public slots:
 	///
@@ -330,10 +341,18 @@ private:
 	/// register of input sources and it's prio channel
 	PriorityRegister _priorityRegister;
 
+	/// flag for color transform enable
 	bool _transformEnabled;
+
+	/// flag for color adjustment enable
 	bool _adjustmentEnabled;
+
+	/// flag for color temperature enable
 	bool _temperatureEnabled;
-	
+
+	/// flag indicates state for autoselection of input source
 	bool _sourceAutoSelectEnabled;
+	
+	/// holds the current priority channel that is manualy selected
 	int _currentSourcePriority;
 };

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -129,6 +129,10 @@ public:
 	void unRegisterPriority(const std::string name);
 	
 	const PriorityRegister& getPriorityRegister() { return _priorityRegister; }
+	
+	void setSourceAutoSelectEnabled(bool enabled);
+	bool setCurrentSourcePriority(int priority );
+	bool sourceAutoSelectEnabled() { return _sourceAutoSelectEnabled; };
 public slots:
 	///
 	/// Writes a single color to all the leds for the given time and priority
@@ -329,4 +333,7 @@ private:
 	bool _transformEnabled;
 	bool _adjustmentEnabled;
 	bool _temperatureEnabled;
+	
+	bool _sourceAutoSelectEnabled;
+	int _currentSourcePriority;
 };

--- a/include/jsonserver/JsonServer.h
+++ b/include/jsonserver/JsonServer.h
@@ -49,14 +49,12 @@ private slots:
 	void closedConnection(JsonClientConnection * connection);
 
 private:
-	/// Hyperion instance
-	Hyperion * _hyperion;
-
 	/// The TCP server object
 	QTcpServer _server;
 
 	/// List with open connections
 	QSet<JsonClientConnection *> _openConnections;
-	
+
+	/// the logger instance
 	Logger * _log;
 };

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -657,14 +657,16 @@ void Hyperion::setSourceAutoSelectEnabled(bool enabled)
 
 bool Hyperion::setCurrentSourcePriority(int priority )
 {
-	if ( _muxer.hasPriority(priority))
+	bool priorityValid = _muxer.hasPriority(priority);
+	if (priorityValid)
 	{
 		DebugIf(_sourceAutoSelectEnabled, _log, "source auto select is disabled");
 		_sourceAutoSelectEnabled = false;
 		_currentSourcePriority = priority;
 		Info(_log, "set current input source to priority channel %d", _currentSourcePriority);
 	}
-	return _muxer.hasPriority(priority);
+
+	return priorityValid;
 }
 
 
@@ -782,7 +784,8 @@ void Hyperion::clearall()
 
 int Hyperion::getCurrentPriority() const
 {
-	return _muxer.getCurrentPriority();
+	
+	return _sourceAutoSelectEnabled || !_muxer.hasPriority(_currentSourcePriority) ? _muxer.getCurrentPriority() : _currentSourcePriority;
 }
 
 QList<int> Hyperion::getActivePriorities() const

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -6,10 +6,10 @@
 // Hyperion includes
 #include <hyperion/PriorityMuxer.h>
 
-PriorityMuxer::PriorityMuxer(int ledCount) :
-	_currentPriority(LOWEST_PRIORITY),
-	_activeInputs(),
-	_lowestPriorityInfo()
+PriorityMuxer::PriorityMuxer(int ledCount)
+	: _currentPriority(LOWEST_PRIORITY)
+	, _activeInputs()
+	, _lowestPriorityInfo()
 {
 	_lowestPriorityInfo.priority = LOWEST_PRIORITY;
 	_lowestPriorityInfo.timeoutTime_ms = -1;

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -46,6 +46,7 @@ const PriorityMuxer::InputInfo& PriorityMuxer::getInputInfo(const int priority) 
 	auto elemIt = _activeInputs.find(priority);
 	if (elemIt == _activeInputs.end())
 	{
+		std::cout << "error " << priority << std::endl;
 		throw std::runtime_error("HYPERION (prioritymux) ERROR: no such priority");
 	}
 	return elemIt.value();

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -58,7 +58,10 @@
 			"required" : true,
 			"properties":
 			{
-				"channelAdjustment_enable" : "boolean",
+				"channelAdjustment_enable" :
+				{
+					"type" : "boolean"
+				},
 				"channelAdjustment" :
 				{
 					"type" : "array",
@@ -173,7 +176,10 @@
 						"additionalProperties" : false
 					}
 				},
-				"temperature_enable" : "boolean",
+				"temperature_enable" :
+				{
+					"type" : "boolean"
+				},
 				"temperature" :
 				{
 					"type" : "array",
@@ -228,7 +234,10 @@
 						"additionalProperties" : false
 					}
 				},
-				"transform_enable" : "boolean",
+				"transform_enable" :
+				{
+					"type" : "boolean"
+				},
 				"transform" :
 				{
 					"type" : "array",

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -417,7 +417,8 @@ void JsonClientConnection::handleServerInfoCommand(const Json::Value &)
 	{
 		Json::Value & item = priorities[priorities.size()];
 		item["priority"] = entry.second;
-		item["active"] = "false";
+		item["active"] = false;
+		item["visible"] = false;
 		item["owner"] = entry.first;
 	}
 	

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -256,6 +256,8 @@ void JsonClientConnection::handleMessage(const std::string &messageString)
 		handleTemperatureCommand(message);
 	else if (command == "adjustment")
 		handleAdjustmentCommand(message);
+	else if (command == "sourceselect")
+		handleSourceSelectCommand(message);
 	else
 		handleNotImplemented();
 }
@@ -773,7 +775,20 @@ void JsonClientConnection::handleAdjustmentCommand(const Json::Value &message)
 
 	sendSuccessReply();
 }
+
+void JsonClientConnection::handleSourceSelectCommand(const Json::Value & message)
+{
+	bool autoselect = message["sourceselect"].get("auto",false).asBool();
+	if (autoselect)
+		_hyperion->setSourceAutoSelectEnabled(true);
+	else if (message["sourceselect"].isMember("priority"))
+	{
+		_hyperion->setCurrentSourcePriority(message["sourceselect"]["priority"].asInt());
+	}
 	
+	sendSuccessReply();
+}
+
 void JsonClientConnection::handleNotImplemented()
 {
 	sendErrorReply("Command not implemented");

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -32,7 +32,7 @@ public:
 	/// @param socket The Socket object for this connection
 	/// @param hyperion The Hyperion server
 	///
-	JsonClientConnection(QTcpSocket * socket, Hyperion * hyperion);
+	JsonClientConnection(QTcpSocket * socket);
 
 	///
 	/// Destructor
@@ -202,6 +202,7 @@ private:
 	
 	/// used for WebSocket detection and connection handling
 	bool _webSocketHandshakeDone;
-	
+
+	/// the logger instance
 	Logger * _log;
 };

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -129,6 +129,13 @@ private:
 	void handleAdjustmentCommand(const Json::Value & message);
 
 	///
+	/// Handle an incoming JSON SourceSelect message
+	///
+	/// @param message the incoming message
+	///
+	void handleSourceSelectCommand(const Json::Value & message);
+
+	///
 	/// Handle an incoming JSON message of unknown type
 	///
 	void handleNotImplemented();

--- a/libsrc/jsonserver/JsonSchemas.qrc
+++ b/libsrc/jsonserver/JsonSchemas.qrc
@@ -11,5 +11,6 @@
         <file alias="schema-temperature">schema/schema-temperature.json</file>
         <file alias="schema-adjustment">schema/schema-adjustment.json</file>
         <file alias="schema-effect">schema/schema-effect.json</file>
+        <file alias="schema-sourceselect">schema/schema-sourceselect.json</file>
     </qresource>
 </RCC>

--- a/libsrc/jsonserver/JsonServer.cpp
+++ b/libsrc/jsonserver/JsonServer.cpp
@@ -5,19 +5,18 @@
 #include <jsonserver/JsonServer.h>
 #include "JsonClientConnection.h"
 
-JsonServer::JsonServer(uint16_t port) :
-	QObject(),
-	_hyperion(Hyperion::getInstance()),
-	_server(),
-	_openConnections(),
-	_log(Logger::getInstance("JSONSERVER"))
+JsonServer::JsonServer(uint16_t port)
+	: QObject()
+	, _server()
+	, _openConnections()
+	, _log(Logger::getInstance("JSONSERVER"))
 {
 	if (!_server.listen(QHostAddress::Any, port))
 	{
 		throw std::runtime_error("JSONSERVER ERROR: could not bind to port");
 	}
 
-		QList<MessageForwarder::JsonSlaveAddress> list = _hyperion->getForwarder()->getJsonSlaves();
+		QList<MessageForwarder::JsonSlaveAddress> list = Hyperion::getInstance()->getForwarder()->getJsonSlaves();
 		for ( int i=0; i<list.size(); i++ )
 		{
 			if ( list.at(i).addr == QHostAddress::LocalHost && list.at(i).port == port ) {
@@ -52,7 +51,7 @@ void JsonServer::newConnection()
 	if (socket != nullptr)
 	{
 		Debug(_log, "New connection");
-		JsonClientConnection * connection = new JsonClientConnection(socket, _hyperion);
+		JsonClientConnection * connection = new JsonClientConnection(socket);
 		_openConnections.insert(connection);
 
 		// register slot for cleaning up after the connection closed

--- a/libsrc/jsonserver/schema/schema-sourceselect.json
+++ b/libsrc/jsonserver/schema/schema-sourceselect.json
@@ -1,0 +1,7 @@
+{
+    "type":"object",
+    "required":false,
+    "properties":{
+    },
+    "additionalProperties": true
+}

--- a/libsrc/jsonserver/schema/schema-sourceselect.json
+++ b/libsrc/jsonserver/schema/schema-sourceselect.json
@@ -2,6 +2,17 @@
     "type":"object",
     "required":false,
     "properties":{
-    },
-    "additionalProperties": true
+        "command": {
+            "type" : "string",
+            "required" : true,
+            "enum" : ["sourceselect"]
+        },
+        "priority": {
+            "type": "integer"
+        },
+        "auto": {
+            "type": "boolean"
+        }
+     },
+    "additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -5,7 +5,7 @@
         "command": {
             "type" : "string",
             "required" : true,
-            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment"]
+            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect"]
         }
     }
 }

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -192,6 +192,36 @@ void JsonConnection::clearAll()
 	parseReply(reply);
 }
 
+void JsonConnection::setSource(int priority)
+{
+	// create command
+	Json::Value command;
+	command["command"] = "sourceselect";
+	Json::Value & sourceselect = command["sourceselect"];
+	sourceselect["priority"] = priority;
+
+	// send command message
+	Json::Value reply = sendMessage(command);
+
+	// parse reply message
+	parseReply(reply);
+}
+
+void JsonConnection::setSourceAutoSelect()
+{
+	// create command
+	Json::Value command;
+	command["command"] = "sourceselect";
+	Json::Value & sourceselect = command["sourceselect"];
+	sourceselect["auto"] = true;
+
+	// send command message
+	Json::Value reply = sendMessage(command);
+
+	// parse reply message
+	parseReply(reply);
+}
+
 void JsonConnection::setTransform(std::string * transformId, double * saturation, double * value, double * saturationL, double * luminance, double * luminanceMin, ColorTransformValues *threshold, ColorTransformValues *gamma, ColorTransformValues *blacklevel, ColorTransformValues *whitelevel)
 {
 	std::cout << "Set color transforms" << std::endl;

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -7,9 +7,9 @@
 // hyperion-remote includes
 #include "JsonConnection.h"
 
-JsonConnection::JsonConnection(const std::string & a, bool printJson) :
-	_printJson(printJson),
-	_socket()
+JsonConnection::JsonConnection(const std::string & a, bool printJson)
+	: _printJson(printJson)
+	, _socket()
 {
 	QString address(a.c_str());
 	QStringList parts = address.split(":");
@@ -197,8 +197,7 @@ void JsonConnection::setSource(int priority)
 	// create command
 	Json::Value command;
 	command["command"] = "sourceselect";
-	Json::Value & sourceselect = command["sourceselect"];
-	sourceselect["priority"] = priority;
+	command["priority"] = priority;
 
 	// send command message
 	Json::Value reply = sendMessage(command);
@@ -212,8 +211,7 @@ void JsonConnection::setSourceAutoSelect()
 	// create command
 	Json::Value command;
 	command["command"] = "sourceselect";
-	Json::Value & sourceselect = command["sourceselect"];
-	sourceselect["auto"] = true;
+	command["auto"] = true;
 
 	// send command message
 	Json::Value reply = sendMessage(command);

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -84,6 +84,15 @@ public:
 	void clearAll();
 
 	///
+	/// Clear the given priority channel
+	///
+	/// @param priority The priority
+	///
+	void setSource(int priority);
+	
+	void setSourceAutoSelect();
+
+	///
 	/// Set the color transform of the leds
 	///
 	/// @note Note that providing a NULL will leave the settings on the server unchanged

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -56,7 +56,7 @@ int main(int argc, char * argv[])
 		IntParameter       & argDuration   = parameters.add<IntParameter>      ('d', "duration"  , "Specify how long the leds should be switched on in millseconds [default: infinity]");
 		ColorParameter     & argColor      = parameters.add<ColorParameter>    ('c', "color"     , "Set all leds to a constant color (either RRGGBB hex value or a color name. The color may be repeated multiple time like: RRGGBBRRGGBB)");
 		ImageParameter     & argImage      = parameters.add<ImageParameter>    ('i', "image"     , "Set the leds to the colors according to the given image file");
-        	StringParameter    & argEffect     = parameters.add<StringParameter>   ('e', "effect"    , "Enable the effect with the given name");
+		StringParameter    & argEffect     = parameters.add<StringParameter>   ('e', "effect"    , "Enable the effect with the given name");
 		StringParameter    & argEffectArgs = parameters.add<StringParameter>   (0x0, "effectArgs", "Arguments to use in combination with the specified effect. Should be a Json object string.");
 		SwitchParameter<>  & argServerInfo = parameters.add<SwitchParameter<> >('l', "list"      , "List server info and active effects with priority and duration");
 		SwitchParameter<>  & argClear      = parameters.add<SwitchParameter<> >('x', "clear"     , "Clear data for the priority channel provided by the -p option");
@@ -65,8 +65,8 @@ int main(int argc, char * argv[])
 		DoubleParameter    & argSaturation = parameters.add<DoubleParameter>   ('s', "saturation", "!DEPRECATED! Will be removed soon! Set the HSV saturation gain of the leds");
 		DoubleParameter    & argValue      = parameters.add<DoubleParameter>   ('v', "value"     , "!DEPRECATED! Will be removed soon! Set the HSV value gain of the leds");
 		DoubleParameter    & argSaturationL = parameters.add<DoubleParameter>  ('u', "saturationL", "Set the HSL saturation gain of the leds");
-		DoubleParameter    & argLuminance  = parameters.add<DoubleParameter>   ('m', "luminance" , "Set the HSL luminance gain of the leds");
-		DoubleParameter    & argLuminanceMin  = parameters.add<DoubleParameter>   ('n', "luminanceMin" , "Set the HSL luminance minimum of the leds (backlight)");
+		DoubleParameter    & argLuminance   = parameters.add<DoubleParameter>   ('m', "luminance" , "Set the HSL luminance gain of the leds");
+		DoubleParameter    & argLuminanceMin= parameters.add<DoubleParameter>   ('n', "luminanceMin" , "Set the HSL luminance minimum of the leds (backlight)");
 		TransformParameter & argGamma      = parameters.add<TransformParameter>('g', "gamma"     , "Set the gamma of the leds (requires 3 space seperated values)");
 		TransformParameter & argThreshold  = parameters.add<TransformParameter>('t', "threshold" , "Set the threshold of the leds (requires 3 space seperated values between 0.0 and 1.0)");
 		TransformParameter & argBlacklevel = parameters.add<TransformParameter>('b', "blacklevel", "!DEPRECATED! Will be removed soon! Set the blacklevel of the leds (requires 3 space seperated values which are normally between 0.0 and 1.0)");
@@ -74,13 +74,15 @@ int main(int argc, char * argv[])
 		SwitchParameter<>  & argPrint      = parameters.add<SwitchParameter<> >(0x0, "print"     , "Print the json input and output messages on stdout");
 		SwitchParameter<>  & argHelp       = parameters.add<SwitchParameter<> >('h', "help"      , "Show this help message and exit");
 		StringParameter    & argIdC        = parameters.add<StringParameter>   ('y', "qualifier" , "!DEPRECATED! Will be removed soon! Identifier(qualifier) of the correction to set");
-		CorrectionParameter & argCorrection  = parameters.add<CorrectionParameter>('Y', "correction" , "!DEPRECATED! Will be removed soon! Set the correction of the leds (requires 3 space seperated values between 0 and 255)");
+		CorrectionParameter & argCorrection= parameters.add<CorrectionParameter>('Y', "correction" , "!DEPRECATED! Will be removed soon! Set the correction of the leds (requires 3 space seperated values between 0 and 255)");
 		StringParameter    & argIdT        = parameters.add<StringParameter>   ('z', "qualifier" , "Identifier(qualifier) of the temperature correction to set");
-		CorrectionParameter & argTemperature  = parameters.add<CorrectionParameter>('Z', "temperature" , "Set the temperature correction of the leds (requires 3 space seperated values between 0 and 255)");
-		StringParameter    & argIdA         = parameters.add<StringParameter>   ('j', "qualifier" , "Identifier(qualifier) of the adjustment to set");
+		CorrectionParameter & argTemperature= parameters.add<CorrectionParameter>('Z', "temperature" , "Set the temperature correction of the leds (requires 3 space seperated values between 0 and 255)");
+		StringParameter    & argIdA      = parameters.add<StringParameter>    ('j', "qualifier" , "Identifier(qualifier) of the adjustment to set");
 		AdjustmentParameter & argRAdjust = parameters.add<AdjustmentParameter>('R', "redAdjustment" , "Set the adjustment of the red color (requires 3 space seperated values between 0 and 255)");
 		AdjustmentParameter & argGAdjust = parameters.add<AdjustmentParameter>('G', "greenAdjustment", "Set the adjustment of the green color (requires 3 space seperated values between 0 and 255)");
 		AdjustmentParameter & argBAdjust = parameters.add<AdjustmentParameter>('B', "blueAdjustment", "Set the adjustment of the blue color (requires 3 space seperated values between 0 and 255)");
+		IntParameter       & argSource   = parameters.add<IntParameter>      (0x0, "sourceSelect"  , "Set current active priority channel and deactivate auto source switching");
+		SwitchParameter<>  & argSourceAuto = parameters.add<SwitchParameter<> >(0x0, "sourceAutoSelect", "Enables auto source, if disabled prio by manual selecting input source");
 
 		// set the default values
 		argAddress.setDefault(defaultServerAddress.toStdString());
@@ -104,7 +106,7 @@ int main(int argc, char * argv[])
 		bool colorModding = colorTransform || colorAdjust || argCorrection.isSet() || argTemperature.isSet();
 		
 		// check that exactly one command was given
-        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), colorModding});
+        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet()});
 		if (commandCount != 1)
 		{
 			std::cerr << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:" << std::endl;
@@ -164,6 +166,14 @@ int main(int argc, char * argv[])
 		else if (argClearAll.isSet())
 		{
 			connection.clearAll();
+		}
+		else if (argSource.isSet())
+		{
+			connection.setSource(argSource.getValue());
+		}
+		else if (argSourceAuto.isSet())
+		{
+			connection.setSourceAutoSelect();
 		}
 		else if (colorModding)
 		{	


### PR DESCRIPTION
**1.** Tell us something about your changes.
currently input sources (grabbers, effect, udplistener ...) are selected by an automatic priority mechanism. Now it is possible to override this mechanism and manually select input source.
Selection is done via json interface or hyperion-remote.

To select e.g. priority channel 900 call:
`hyperion-remote --sourceSelect 900`

This will disable automatic/priorized source selection. To reactivate auto select call:
`hyperion-remote --sourceAutoSelect`

You can only select prio channels that are active.

The serverinfo json command adds new value "visible" to every priority. That is needed to determine what is currently visible.
```
   "priorities" : [
      {
         "active" : true,
         "duration_ms" : 184,
         "owner" : "X11 Grabber",
         "priority" : 900,
         "visible" : true
      },
      {
         "active" : true,
         "owner" : "EFFECT: /media/lager/home/Entwicklung/hyperion/hyperion.ng4/effects/mood-blobs.py",
         "priority" : 2147483646,
         "visible" : false
      },
      {
         "active" : "false",
         "owner" : "Boblight",
         "priority" : 710,
         "visible" : false
      },
      {
         "active" : "false",
         "owner" : "V4L2",
         "priority" : 890,
         "visible" : false
      }
   ],
```

additional changes:
- fix runtime crash in schema validation
- tiny refactoring of changed files


**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

