### PR TITLE
Update Json Interface (Enable/Disable components during runtime)

### DIFF
--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -12,6 +12,7 @@
 #include <utils/Image.h>
 #include <utils/ColorRgb.h>
 #include <utils/Logger.h>
+#include <utils/Components.h>
 
 // Hyperion includes
 #include <hyperion/LedString.h>
@@ -25,6 +26,9 @@
 #include <effectengine/EffectDefinition.h>
 #include <effectengine/ActiveEffectDefinition.h>
 
+// KodiVideoChecker includes
+#include <kodivideochecker/KODIVideoChecker.h>
+
 // Forward class declaration
 class LedDevice;
 class ColorTransform;
@@ -37,6 +41,7 @@ class RgbChannelAdjustment;
 class MultiColorTransform;
 class MultiColorCorrection;
 class MultiColorAdjustment;
+class KODIVideoChecker;
 ///
 /// The main class of Hyperion. This gives other 'users' access to the attached LedDevice through
 /// the priority muxer.
@@ -144,6 +149,14 @@ public:
 	/// gets current state of automatic/priorized source selection
 	/// @return the state
 	bool sourceAutoSelectEnabled() { return _sourceAutoSelectEnabled; };
+	
+	///
+	/// Enable/Disable components during runtime
+	///
+	/// @param component The component [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]
+	/// @param state The state of the component [true | false]
+	///
+	void setComponentState(const Components component, const bool state);
 public slots:
 	///
 	/// Writes a single color to all the leds for the given time and priority

--- a/include/utils/Components.h
+++ b/include/utils/Components.h
@@ -1,0 +1,30 @@
+#pragma once
+
+/**
+ * Enumeration of components in Hyperion.
+ */
+enum Components
+{
+	SMOOTHING,
+	BLACKBORDER,
+	KODICHECKER,
+	FORWARDER,
+	UDPLISTENER,
+	BOBLIGHTSERVER,
+	GRABBER
+};
+
+inline const char* componentToString(Components c)
+{
+	switch (c)
+	{
+		case SMOOTHING:		return "Smoothing option";
+		case BLACKBORDER:	return "Blackborder detector";
+		case KODICHECKER:	return "KodiVideoChecker";
+		case FORWARDER:		return "Json/Proto forwarder";
+		case UDPLISTENER:	return "UDP listener";
+		case BOBLIGHTSERVER:	return "Boblight server";
+		case GRABBER:		return "Framegrabber";
+		default:		return "";
+	}
+}

--- a/libsrc/hyperion/CMakeLists.txt
+++ b/libsrc/hyperion/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(hyperion
 )
 
 target_link_libraries(hyperion
+	kodivideochecker
 	blackborder
 	hyperion-utils
 	leddevice

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -669,6 +669,33 @@ bool Hyperion::setCurrentSourcePriority(int priority )
 	return priorityValid;
 }
 
+void Hyperion::setComponentState(const Components component, const bool state)
+{
+	switch(component)
+	{
+		case SMOOTHING:
+			break;
+		case BLACKBORDER:
+			break;
+		case KODICHECKER:
+		{
+			KODIVideoChecker* _kodiVideoChecker = KODIVideoChecker::getInstance();
+			if (_kodiVideoChecker != nullptr)
+				state ? _kodiVideoChecker->start() : _kodiVideoChecker->stop();
+			else
+ 				Debug(_log, "Can't get instance from: '%s'", componentToString(component));
+			break;
+		}
+		case FORWARDER:
+			break;
+		case UDPLISTENER:
+			break;
+		case BOBLIGHTSERVER:
+			break;
+		case GRABBER:
+			break;
+	}
+}
 
 void Hyperion::setColor(int priority, const ColorRgb &color, const int timeout_ms, bool clearEffects)
 {

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -258,6 +258,8 @@ void JsonClientConnection::handleMessage(const std::string &messageString)
 		handleAdjustmentCommand(message);
 	else if (command == "sourceselect")
 		handleSourceSelectCommand(message);
+	else if (command == "componentstate")
+		handleComponentStateCommand(message);
 	else
 		handleNotImplemented();
 }
@@ -799,6 +801,29 @@ void JsonClientConnection::handleSourceSelectCommand(const Json::Value & message
 	{
 		sendErrorReply("setting current priority failed");
 	}
+}
+
+void JsonClientConnection::handleComponentStateCommand(const Json::Value& message)
+{
+	const Json::Value & componentState = message["componentstate"];
+	std::string component = componentState.get("component", "").asString();
+	
+	if (component == "SMOOTHING")
+		_hyperion->setComponentState((Components)0, componentState.get("state", true).asBool());
+	else if (component == "BLACKBORDER")
+		_hyperion->setComponentState((Components)1, componentState.get("state", true).asBool());
+	else if (component == "KODICHECKER")
+		_hyperion->setComponentState((Components)2, componentState.get("state", true).asBool());
+	else if (component == "FORWARDER")
+		_hyperion->setComponentState((Components)3, componentState.get("state", true).asBool());
+	else if (component == "UDPLISTENER")
+		_hyperion->setComponentState((Components)4, componentState.get("state", true).asBool());
+	else if (component == "BOBLIGHTSERVER")
+		_hyperion->setComponentState((Components)5, componentState.get("state", true).asBool());
+	else if (component == "GRABBER")
+		_hyperion->setComponentState((Components)6, componentState.get("state", true).asBool());
+	
+	sendSuccessReply();
 }
 
 void JsonClientConnection::handleNotImplemented()

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -16,6 +16,7 @@
 // util includes
 #include <utils/jsonschema/JsonSchemaChecker.h>
 #include <utils/Logger.h>
+#include <utils/Components.h>
 
 class ImageProcessor;
 
@@ -134,6 +135,13 @@ private:
 	/// @param message the incoming message
 	///
 	void handleSourceSelectCommand(const Json::Value & message);
+	
+	///
+	/// Handle an incoming JSON Component State message
+	///
+	/// @param message the incoming message
+	///
+	void handleComponentStateCommand(const Json::Value & message);
 
 	///
 	/// Handle an incoming JSON message of unknown type

--- a/libsrc/jsonserver/JsonSchemas.qrc
+++ b/libsrc/jsonserver/JsonSchemas.qrc
@@ -12,5 +12,6 @@
         <file alias="schema-adjustment">schema/schema-adjustment.json</file>
         <file alias="schema-effect">schema/schema-effect.json</file>
         <file alias="schema-sourceselect">schema/schema-sourceselect.json</file>
+        <file alias="schema-componentstate">schema/schema-componentstate.json</file>
     </qresource>
 </RCC>

--- a/libsrc/jsonserver/schema/schema-componentstate.json
+++ b/libsrc/jsonserver/schema/schema-componentstate.json
@@ -1,0 +1,33 @@
+{
+	"type":"object",
+	"required":true,
+	"properties":
+	{
+		"command":
+		{
+			"type" : "string",
+			"required" : true,
+			"enum" : ["componentstate"]
+		},
+		"componentstate":
+		{
+			"type": "object",
+			"required": true,
+			"properties":
+			{
+				"component":
+				{
+					"enum" : ["SMOOTHING", "BLACKBORDER", "KODICHECKER", "FORWARDER", "UDPLISTENER", "BOBLIGHTSERVER", "GRABBER"],
+					"required": true
+				},
+				"state":
+				{
+					"type": "bool",
+					"required": true
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false
+}

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -5,7 +5,7 @@
         "command": {
             "type" : "string",
             "required" : true,
-            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect"]
+            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "componentstate"]
         }
     }
 }

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -192,6 +192,25 @@ void JsonConnection::clearAll()
 	parseReply(reply);
 }
 
+void JsonConnection::setComponentState(const std::string& component, const bool state)
+{
+	state ? std::cout << "Enable Component " : std::cout << "Disable Component ";
+	std::cout << component << std::endl;
+
+	// create command
+	Json::Value command;
+	command["command"] = "componentstate";
+	Json::Value & parameter = command["componentstate"];
+	parameter["component"] = component;
+	parameter["state"] = state;
+
+	// send command message
+	Json::Value reply = sendMessage(command);
+
+	// parse reply message
+	parseReply(reply);
+}
+
 void JsonConnection::setSource(int priority)
 {
 	// create command

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -82,6 +82,14 @@ public:
 	/// Clear all priority channels
 	///
 	void clearAll();
+	
+	///
+	/// Enable/Disable components during runtime
+	///
+	/// @param component The component [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]
+	/// @param state The state of the component [true | false]
+	///
+	void setComponentState(const std::string & component, const bool state);
 
 	///
 	/// Clear the given priority channel

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -61,6 +61,8 @@ int main(int argc, char * argv[])
 		SwitchParameter<>  & argServerInfo = parameters.add<SwitchParameter<> >('l', "list"      , "List server info and active effects with priority and duration");
 		SwitchParameter<>  & argClear      = parameters.add<SwitchParameter<> >('x', "clear"     , "Clear data for the priority channel provided by the -p option");
 		SwitchParameter<>  & argClearAll   = parameters.add<SwitchParameter<> >(0x0, "clearall"  , "Clear data for all active priority channels");
+		StringParameter    & argEnableComponent     = parameters.add<StringParameter>   ('E', "enable"    , "Enable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]");
+		StringParameter    & argDisableComponent     = parameters.add<StringParameter>   ('D', "disable"    , "Disable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]");
 		StringParameter    & argId         = parameters.add<StringParameter>   ('q', "qualifier" , "Identifier(qualifier) of the transform to set");
 		DoubleParameter    & argSaturation = parameters.add<DoubleParameter>   ('s', "saturation", "!DEPRECATED! Will be removed soon! Set the HSV saturation gain of the leds");
 		DoubleParameter    & argValue      = parameters.add<DoubleParameter>   ('v', "value"     , "!DEPRECATED! Will be removed soon! Set the HSV value gain of the leds");
@@ -106,7 +108,7 @@ int main(int argc, char * argv[])
 		bool colorModding = colorTransform || colorAdjust || argCorrection.isSet() || argTemperature.isSet();
 		
 		// check that exactly one command was given
-        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet()});
+        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), argEnableComponent.isSet(), argDisableComponent.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet()});
 		if (commandCount != 1)
 		{
 			std::cerr << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:" << std::endl;
@@ -116,6 +118,8 @@ int main(int argc, char * argv[])
 			std::cerr << "  " << argServerInfo.usageLine() << std::endl;
 			std::cerr << "  " << argClear.usageLine() << std::endl;
 			std::cerr << "  " << argClearAll.usageLine() << std::endl;
+			std::cerr << "  " << argEnableComponent.usageLine() << std::endl;
+			std::cerr << "  " << argDisableComponent.usageLine() << std::endl;
 			std::cerr << "or one or more of the available color modding operations:" << std::endl;
 			std::cerr << "  " << argId.usageLine() << std::endl;
 			std::cerr << "  " << argSaturation.usageLine() << std::endl;
@@ -166,6 +170,14 @@ int main(int argc, char * argv[])
 		else if (argClearAll.isSet())
 		{
 			connection.clearAll();
+		}
+		else if (argEnableComponent.isSet())
+		{
+			connection.setComponentState(argEnableComponent.getValue(), true);
+		}
+		else if (argDisableComponent.isSet())
+		{
+			connection.setComponentState(argDisableComponent.getValue(), false);
 		}
 		else if (argSource.isSet())
 		{


### PR DESCRIPTION
**1.** Tell us something about your changes.
With this code we are able to enable or disable components during runtime.
Available Components are:
SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER

Example:
To enable the Component "Kodi Video Checker" during runtime send the JSON Object:
{"command":"componentstate","componentstate":{"component":"KODICHECKER","state":true}}
or use
hyperion-remote --enable "KODICHECKER"

To disable the Component "KodiVideoChecker" during runtime send the JSON Object:
{"command":"componentstate","componentstate":{"component":"KODICHECKER","state":false}}
or use
hyperion-remote --disable "KODICHECKER"

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference a issue (optional)
#21 

NOTES:
Currently, only the Kodichecker Component is switchable.
The remaining Components coming soon.
 