### PR TITLE
sourceOff feature + small json refactoring

### DIFF
--- a/assets/webconfig/select/index.html
+++ b/assets/webconfig/select/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<title>Hyperion web control</title>
+
+	<!-- bootstrap -->
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+	<!-- Optional theme -->
+<!-- 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous"> -->
+	<link href="starter-template.css" rel="stylesheet">
+
+	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+</head>
+<body>
+
+	<nav class="navbar navbar-inverse navbar-fixed-top">
+		<div class="container">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+<!--					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>-->
+				</button>
+				<a class="navbar-brand" href="#">Hyperion</a>
+			</div>
+			<div id="navbar" class="collapse navbar-collapse">
+				<ul class="nav navbar-nav">
+					<li class="active"><a href="#">Source Selection</a></li>
+<!-- 					<li><a href="#about">About</a></li> -->
+				</ul>
+			</div><!--/.nav-collapse -->
+		</div>
+	</nav>
+
+	<div class="container">
+		<div class="starter-template">
+			<div id="inputs"></div>
+		</div>
+	</div><!-- /.container -->
+
+
+	<!-- ====================================================================== -->
+	<script>
+	var webSocket = new WebSocket('ws://'+document.location.hostname+':19444');
+	var serverInfo;
+	
+	function setSource( prio )
+	{
+		if ( prio == "auto" )
+			webSocket.send('{"command":"sourceselect", "auto" : true}');
+		else
+			webSocket.send('{"command":"sourceselect", "priority" : '+prio+'}');
+		updateButtons();
+	}
+
+	function updateButtons()
+	{
+		webSocket.send('{"command":"serverinfo"}');
+	}
+	
+	webSocket.onerror = function(event) {
+		alert(event.data);
+	};
+
+	webSocket.onopen = function(event) {
+		updateButtons();
+		setInterval(function() {updateButtons();}, 3000);
+	};
+
+	webSocket.onmessage = function(event) {
+		serverInfo = JSON.parse( event.data );
+		var data = "";
+		var i;
+ 		for(i = 0; i < serverInfo.info.priorities.length; i++) {
+			var owner    = serverInfo.info.priorities[i].owner;
+			var active   = serverInfo.info.priorities[i].active;
+			var visible  = serverInfo.info.priorities[i].visible;
+			var priority = serverInfo.info.priorities[i].priority;
+			var btn_type = "default";
+			if (active) btn_type = "warning";
+			if (visible) btn_type = "success";
+			
+ 			data += '<button id="srcBtn'+i+'" type="button" class="btn btn-lg btn-'+btn_type+'" style="margin:10px;min-width:200px" title="prio '+priority+'" onclick="setSource('+priority+');">'+owner+'</button><br/>';
+		}
+		data += '<button id="srcBtn'+i+'" type="button" class="btn btn-lg btn-info" style="margin:10px;min-width:200px" onclick="setSource(\'auto\');">auto select</button><br/>';
+		$('#inputs').html(data);
+	};
+	</script>
+</body>
+</html>

--- a/assets/webconfig/select/starter-template.css
+++ b/assets/webconfig/select/starter-template.css
@@ -1,0 +1,8 @@
+body {
+  padding-top: 50px;
+}
+.starter-template {
+  padding: 40px 15px;
+  text-align: center;
+}
+ 

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -268,18 +268,18 @@
 	},
 
 	/// Initial Effect sets a "booteffect" or "color" (foreground-effect) and optional set a "effect" or "color" during inactive grabbers and network receivers (background-effect) 
-	///  * background-effect      : 2 options: set a effect (example: "Rainbow swirl fast") or set a color (RGB) (example: [255,134,0])
+	///  * background-effect      : 2 options: set a effect (example: ["Rainbow swirl fast"]) or set a color (RGB) (example: [255,134,0])
 	///  * background-effect-args : Set optional effect arguments (Have a look at the select effect to get the possible values), define it only when needed
-	///  * foreground-effect      : 2 options: set a effect (example: "Rainbow swirl fast") or set a color (RGB) (example: [255,134,0])
+	///  * foreground-effect      : 2 options: set a effect (example: ["Rainbow swirl fast"]) or set a color (RGB) (example: [255,134,0])
 	///  * foreground-effect-args : Set optional effect arguments (Have a look at the select effect to get the possible values), define it only when needed
 	///  * foreground-duration_ms : The duration of the selected foreground-effect or color (0=endless)
 	///                       HINT: "foreground-effect" starts always with priority 0, so it blocks all remotes and grabbers if the loop is endless
 	///                       HINT: Set a empty value if you want to disable a component (example: "")
 	"initialEffect" :
 	{
-		"background-effect"      : "Full color mood blobs",
+		"background-effect"      : ["Full color mood blobs"],
 		//"background-effect-args" : {},
-		"foreground-effect"      : "Rainbow swirl fast",
+		"foreground-effect"      : ["Rainbow swirl fast"],
 		//"foreground-effect-args" : {},
 		"foreground-duration_ms" : 3000
 	},

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -150,8 +150,8 @@
 
 	"initialEffect" :
 	{
-		"background-effect"      : "Full color mood blobs",
-		"foreground-effect"      : "Rainbow swirl fast",
+		"background-effect"      : ["Full color mood blobs"],
+		"foreground-effect"      : ["Rainbow swirl fast"],
 		"foreground-duration_ms" : 3000
 	},
 

--- a/include/hyperion/PriorityMuxer.h
+++ b/include/hyperion/PriorityMuxer.h
@@ -34,6 +34,9 @@ public:
 		std::vector<ColorRgb> ledColors;
 	};
 
+	/// The lowest possible priority, which is used when no priority channels are active
+	const static int LOWEST_PRIORITY = std::numeric_limits<int>::max();
+
 	///
 	/// Constructs the PriorityMuxer for the given number of leds (used to switch to black when
 	/// there are no priority channels
@@ -118,6 +121,4 @@ private:
 	/// The information of the lowest priority channel
 	InputInfo _lowestPriorityInfo;
 
-	/// The lowest possible priority, which is used when no priority channels are active
-	const static int LOWEST_PRIORITY = std::numeric_limits<int>::max();
 };

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -679,14 +679,15 @@ void Hyperion::setComponentState(const Components component, const bool state)
 			break;
 		case KODICHECKER:
 		{
-			KODIVideoChecker* _kodiVideoChecker = KODIVideoChecker::getInstance();
-			if (_kodiVideoChecker != nullptr)
-				state ? _kodiVideoChecker->start() : _kodiVideoChecker->stop();
+			KODIVideoChecker* kodiVideoChecker = KODIVideoChecker::getInstance();
+			if (kodiVideoChecker != nullptr)
+				state ? kodiVideoChecker->start() : kodiVideoChecker->stop();
 			else
  				Debug(_log, "Can't get instance from: '%s'", componentToString(component));
 			break;
 		}
 		case FORWARDER:
+			//_messageForwarder
 			break;
 		case UDPLISTENER:
 			break;

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -557,6 +557,8 @@ Hyperion::Hyperion(const Json::Value &jsonConfig, const std::string configFile)
 	, _hwLedCount(_ledString.leds().size())
 	, _sourceAutoSelectEnabled(true)
 {
+	registerPriority("Off", PriorityMuxer::LOWEST_PRIORITY);
+	
 	if (!_raw2ledAdjustment->verifyAdjustments())
 	{
 		throw std::runtime_error("Color adjustment incorrectly set");

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -14,6 +14,8 @@ PriorityMuxer::PriorityMuxer(int ledCount)
 	_lowestPriorityInfo.priority = LOWEST_PRIORITY;
 	_lowestPriorityInfo.timeoutTime_ms = -1;
 	_lowestPriorityInfo.ledColors = std::vector<ColorRgb>(ledCount, {0, 0, 0});
+	
+	_activeInputs[_currentPriority] = _lowestPriorityInfo;
 }
 
 PriorityMuxer::~PriorityMuxer()
@@ -38,11 +40,6 @@ bool PriorityMuxer::hasPriority(const int priority) const
 
 const PriorityMuxer::InputInfo& PriorityMuxer::getInputInfo(const int priority) const
 {
-	if (priority == LOWEST_PRIORITY)
-	{
-		return _lowestPriorityInfo;
-	}
-
 	auto elemIt = _activeInputs.find(priority);
 	if (elemIt == _activeInputs.end())
 	{
@@ -63,14 +60,10 @@ void PriorityMuxer::setInput(const int priority, const std::vector<ColorRgb>& le
 
 void PriorityMuxer::clearInput(const int priority)
 {
-	_activeInputs.remove(priority);
-	if (_currentPriority == priority)
+	if (priority < LOWEST_PRIORITY)
 	{
-		if (_activeInputs.empty())
-		{
-			_currentPriority = LOWEST_PRIORITY;
-		}
-		else
+		_activeInputs.remove(priority);
+		if (_currentPriority == priority)
 		{
 			QList<int> keys = _activeInputs.keys();
 			_currentPriority = *std::min_element(keys.begin(), keys.end());
@@ -82,6 +75,7 @@ void PriorityMuxer::clearAll()
 {
 	_activeInputs.clear();
 	_currentPriority = LOWEST_PRIORITY;
+	_activeInputs[_currentPriority] = _lowestPriorityInfo;
 }
 
 void PriorityMuxer::setCurrentTime(const int64_t& now)

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -33,7 +33,7 @@ QList<int> PriorityMuxer::getPriorities() const
 
 bool PriorityMuxer::hasPriority(const int priority) const
 {
-	return _activeInputs.contains(priority);
+	return (priority == LOWEST_PRIORITY) ? true : _activeInputs.contains(priority);
 }
 
 const PriorityMuxer::InputInfo& PriorityMuxer::getInputInfo(const int priority) const
@@ -46,8 +46,7 @@ const PriorityMuxer::InputInfo& PriorityMuxer::getInputInfo(const int priority) 
 	auto elemIt = _activeInputs.find(priority);
 	if (elemIt == _activeInputs.end())
 	{
-		std::cout << "error " << priority << std::endl;
-		throw std::runtime_error("HYPERION (prioritymux) ERROR: no such priority");
+		throw std::runtime_error("HYPERION (prioritymuxer) ERROR: no such priority");
 	}
 	return elemIt.value();
 }

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -6,13 +6,11 @@
 		"logger" :
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"level" :
 				{
-					"type" : "string",
-					"required" : true
+					"enum" : ["silent", "warn", "verbose", "debug"]
 				}
 			},
 			"additionalProperties" : false
@@ -50,7 +48,7 @@
 					"required" : false
 				}
 			},
-			"additionalProperties" : false
+			"additionalProperties" : true
 		},
 		"color" :
 		{
@@ -364,44 +362,37 @@
 		"smoothing":
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"type" :
 				{
-					"enum" : ["none", "linear"],
-					"required" : true
+					"enum" : ["linear"]
 				},
 				"time_ms" :
 				{
 					"type" : "integer",
-					"required" : false,
 					"minimum" : 25,
 					"maximum": 600
 				},
 				"updateFrequency" :
 				{
 					"type" : "number",
-					"required" : false,
 					"minimum" : 1.000,
 					"maximum": 100.000
 				},
 				"updateDelay" :
 				{
 					"type" : "integer",
-					"required" : false,
 					"minimum" : 0,
 					"maximum": 2048
 				},
 				"continuousOutput" :
 				{
-					"type" : "boolean",
-					"required" : false
+					"type" : "boolean"
 				}
 			},
 			"additionalProperties" : false
@@ -503,88 +494,120 @@
 		"framegrabber" :
 		{
 			"type" : "object",
-			"required" : false,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"type" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" : "string"
 				},
 				"width" :
 				{
-					"type" : "integer",
-					"required" : false
+					"type" : "integer"
 				},
 				"height" :
 				{
-					"type" : "integer",
-					"required" : false
+					"type" : "integer"
 				},
 				"frequency_Hz" :
 				{
 					"type" : "integer",
-					"required" : true
+					"minimum" : 0
 				},
 				"priority" :
 				{
+					"type" : "integer"
+				},
+				"cropLeft" :
+				{
 					"type" : "integer",
-					"required" : true
+					"minimum" : 0
+				},
+				"cropRight" :
+				{
+					"type" : "integer",
+					"minimum" : 0
+				},
+				"cropTop" :
+				{
+					"type" : "integer",
+					"minimum" : 0
+				},
+				"cropBottom" :
+				{
+					"type" : "integer",
+					"minimum" : 0
+				},
+				"useXGetImage" :
+				{
+					"type" : "boolean"
+				},
+				"horizontalPixelDecimation" :
+				{
+					"type" : "integer",
+					"minimum" : 0
+				},
+				"verticalPixelDecimation" :
+				{
+					"type" : "integer",
+					"minimum" : 0
+				},
+				"device" :
+				{
+					"type" : "string"
+				},
+				"display" :
+				{
+					"type" : "integer",
+					"minimum" : 0
 				}
 			},
-			"additionalProperties" : true
+			"additionalProperties" : false
 		},
 		"blackborderdetector" :
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"threshold" :
 				{
 					"type" : "number",
-					"required" : true,
 					"minimum" : 0.0,
 					"maximum" : 1.0
 				},
 				"unknownFrameCnt"    :
 				{
 					"type" : "number",
-					"required" : false,
 					"minimum" : 0
 				},
 				"borderFrameCnt" :
 				{
 					"type" : "number",
-					"required" : false,
 					"minimum" : 0
 				},
 				"maxInconsistentCnt" :
 				{
 					"type" : "number",
-					"required" : false,
 					"minimum" : 0
 				},
 				"blurRemoveCnt" :
 				{
 					"type" : "number",
-					"required" : false,
 					"minimum" : 0
 				},
 				"mode" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" :
+					{
+						"enum" : ["default", "classic", "osd"]
+					}
 				}
 			},
 			"additionalProperties" : false
@@ -592,58 +615,47 @@
 		"kodiVideoChecker" :
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"kodiAddress" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" : "string"
 				},
 				"kodiTcpPort" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"grabVideo" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"grabPictures" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"grabAudio" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"grabMenu" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"grabPause" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"grabScreensaver" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"enable3DDetection" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				}
 			},
 			"additionalProperties" : false
@@ -651,34 +663,28 @@
 		"initialEffect" :
 		{
 			"type" : "object",
-			"required" : false,
 			"properties" :
 			{
 				"background-effect" :
 				{
-					"type" : "string",
-					"required" : false
+					"type" : "array"
 				},
 				"background-effect-args" :
 				{
-					"type" : "object",
-					"required" : false
+					"type" : "object"
 				},
 				"foreground-effect" :
 				{
-					"type" : "string",
-					"required" : false
+					"type" : "array"
 				},
 				"foreground-effect-args" :
 				{
-					"type" : "object",
-					"required" : false
+					"type" : "object"
 				},
 				"foreground-duration_ms" :
 				{
-					"type" : "integer",
-					"required" : false
-				}				
+					"type" : "integer"
+				}
 			},
 			"additionalProperties" : false
 		},		
@@ -741,13 +747,11 @@
 		"boblightServer" :
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"port" :
 				{
@@ -758,8 +762,7 @@
 				},
 				"priority" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				}
 			},
 			"additionalProperties" : false
@@ -767,13 +770,11 @@
 		"udpListener" :
 		{
 			"type" : "object",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"address" :
 				{
@@ -783,24 +784,20 @@
 				"port" :
 				{
 					"type" : "integer",
-					"required" : true,
 					"minimum" : 0,
 					"maximum" : 65535
 				},
 				"priority" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"timeout" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"shared" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				}
 			},
 			"additionalProperties" : false
@@ -832,13 +829,11 @@
 		"effects" :
 		{
 			"type" : "object",
-			"required" : false,
 			"properties" :
 			{
 				"paths" :
 				{
-					"type" : "array",
-					"required" : false
+					"type" : "array"
 				}
 			},
 			"additionalProperties" : false
@@ -906,8 +901,7 @@
 		},
 		"endOfJson" :
 		{
-			"type" : "string",
-			"required" : false
+			"type" : "string"
 		}
 	},
 	"additionalProperties" : false

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -13,6 +13,7 @@
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QHostInfo>
+#include <QString>
 
 // hyperion util includes
 #include <hyperion/ImageProcessorFactory.h>
@@ -820,7 +821,7 @@ void JsonClientConnection::handleConfigGetCommand(const Json::Value &)
 void JsonClientConnection::handleComponentStateCommand(const Json::Value& message)
 {
 	const Json::Value & componentState = message["componentstate"];
-	std::string component = componentState.get("component", "").asString();
+	QString component = QString::fromStdString(componentState.get("component", "").asString()).toUpper();
 	
 	if (component == "SMOOTHING")
 		_hyperion->setComponentState((Components)0, componentState.get("state", true).asBool());

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -1,6 +1,7 @@
 // stl includes
 #include <clocale>
 #include <initializer_list>
+#include <limits>
 
 // Qt includes
 #include <QCoreApplication>
@@ -85,6 +86,7 @@ int main(int argc, char * argv[])
 		AdjustmentParameter & argBAdjust = parameters.add<AdjustmentParameter>('B', "blueAdjustment", "Set the adjustment of the blue color (requires 3 space seperated values between 0 and 255)");
 		IntParameter       & argSource   = parameters.add<IntParameter>      (0x0, "sourceSelect"  , "Set current active priority channel and deactivate auto source switching");
 		SwitchParameter<>  & argSourceAuto = parameters.add<SwitchParameter<> >(0x0, "sourceAutoSelect", "Enables auto source, if disabled prio by manual selecting input source");
+		SwitchParameter<>  & argSourceOff = parameters.add<SwitchParameter<> >(0x0, "sourceOff", "select no source, this results in leds activly set to black (=off)");
 		SwitchParameter<>  & argConfigGet   = parameters.add<SwitchParameter<> >(0x0, "configget"  , "Print the current loaded Hyperion configuration file");
 
 		// set the default values
@@ -109,7 +111,7 @@ int main(int argc, char * argv[])
 		bool colorModding = colorTransform || colorAdjust || argCorrection.isSet() || argTemperature.isSet();
 		
 		// check that exactly one command was given
-        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), argEnableComponent.isSet(), argDisableComponent.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet(), argConfigGet.isSet()});
+        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), argEnableComponent.isSet(), argDisableComponent.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet(), argSourceOff.isSet(), argConfigGet.isSet()});
 		if (commandCount != 1)
 		{
 			std::cerr << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:" << std::endl;
@@ -182,6 +184,10 @@ int main(int argc, char * argv[])
 		else if (argDisableComponent.isSet())
 		{
 			connection.setComponentState(argDisableComponent.getValue(), false);
+		}
+		else if (argSourceOff.isSet())
+		{
+			connection.setSource(std::numeric_limits<int>::max());
 		}
 		else if (argSource.isSet())
 		{

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -178,7 +178,6 @@ void HyperionDaemon::startInitialEffect()
 	// create boot sequence if the configuration is present
 	if (_config.isMember("initialEffect"))
 	{
-		//const Json::Value effectConfig = _config["initialEffect"];
 		const QJsonObject & effectConfig = _qconfig["initialEffect"].toObject();
 		const int FG_PRIORITY = 0;
 		const int DURATION_INFINITY = 0;

--- a/src/hyperiond/hyperiond.h
+++ b/src/hyperiond/hyperiond.h
@@ -51,10 +51,9 @@
 class HyperionDaemon : public QObject
 {
 public:
-	HyperionDaemon(std::string configFile, QObject *parent=nullptr);
+	HyperionDaemon(QString configFile, QObject *parent=nullptr);
 	~HyperionDaemon();
 	
-	void loadConfig(const std::string & configFile); // DEPRECATED | Remove this only when the conversion have been completed from JsonCpp to QTJson
 	void loadConfig(const QString & configFile);
 	void run();
 

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -7,6 +7,7 @@
 #include <QCoreApplication>
 #include <QLocale>
 #include <QFile>
+#include <QString>
 
 #include "HyperionConfig.h"
 
@@ -143,7 +144,7 @@ int main(int argc, char** argv)
 	HyperionDaemon* hyperiond = nullptr;
 	try
 	{
-		hyperiond = new HyperionDaemon(configFiles[argvId], &app);
+		hyperiond = new HyperionDaemon(QString::fromStdString(configFiles[argvId]), &app);
 		hyperiond->run();
 	}
 	catch (std::exception& e)


### PR DESCRIPTION
**1.** Tell us something about your changes.
add --sourceOff to hyperion-remote - this will select "off" source and set all leds to black
to switch leds back to "on" use --sourceAutoSelect or select a specific source --sourceSelect
-> this is useful for the 24/7 people that complain that their leds blink when nothing is on. (because we send actively black color, leds should stay off)

some tiny refactoring of new json stuff

make schema checker not so strict, do not require values that have defaults (not finished yet)
-> the goal should be that we can start with an empty config and hyperion runs (with default values)
-> this is neccessary for inital setup where the user hasn't configured anything

initialEffect config:
effect is always an array, regardless if it is a color or an effect name
-> this will make transition to qjson a bit easier
made transition to qjson - atm the effect-args are still jsoncpp. To change this effectengine has to be migrated too

webui:
added an example for interactively choosing the input source. Example uses jquery and bootstrap.
 call http://your_hyperion_host:8099/select/index.html
current example needed json server on port 19444
hint: don't forgett to copy latest assets/webconfig files to configured wencnfig dir

**2.** If this changes affect the .conf file. Please provide the changed section
yes, initialEffect effect names now as array with one element: ["rainbow"] instead of "rainbow"

**3.** Reference a issue (optional)

@Paulchen-Panther the component state thingy needs some rework. I thing I will make hyperiond class as instance and use this instead of hyperion class. Why? because there we have all the needed objects available. I will do this next week - and I have to say big thanks for new qjson stuff, this is great!
