### PR TITLE
Fix segmentation fault in usbasp led driver

### DIFF
--- a/libsrc/leddevice/LedDeviceHyperionUsbasp.cpp
+++ b/libsrc/leddevice/LedDeviceHyperionUsbasp.cpp
@@ -45,7 +45,7 @@ int LedDeviceHyperionUsbasp::open()
 	// initialize the usb context
 	if ((error = libusb_init(&_libusbContext)) != LIBUSB_SUCCESS)
 	{
-		Error(_log, "Error while initializing USB context(%s):%s", error, libusb_error_name(error));
+		Error(_log, "Error while initializing USB context(%d):%s", error, libusb_error_name(error));
 		_libusbContext = nullptr;
 		return -1;
 	}
@@ -86,7 +86,7 @@ int LedDeviceHyperionUsbasp::testAndOpen(libusb_device * device)
 	int error = libusb_get_device_descriptor(device, &deviceDescriptor);
 	if (error != LIBUSB_SUCCESS)
 	{
-		Error(_log, "Error while retrieving device descriptor(%s): %s", error, libusb_error_name(error));
+		Error(_log, "Error while retrieving device descriptor(%d): %s", error, libusb_error_name(error));
 		return -1;
 	}
 
@@ -99,7 +99,7 @@ int LedDeviceHyperionUsbasp::testAndOpen(libusb_device * device)
 		int busNumber = libusb_get_bus_number(device);
 		int addressNumber = libusb_get_device_address(device);
 
-		Info(_log, "%s found: bus=%s address=%s", _usbProductDescription.c_str(), busNumber, addressNumber);
+		Info(_log, "%s found: bus=%d address=%d", _usbProductDescription.c_str(), busNumber, addressNumber);
 
 		try
 		{
@@ -110,7 +110,7 @@ int LedDeviceHyperionUsbasp::testAndOpen(libusb_device * device)
 		catch(int e)
 		{
 			_deviceHandle = nullptr;
-			Error(_log, "Unable to open %s. Searching for other device(%s): %s", _usbProductDescription.c_str(), e, libusb_error_name(e));
+			Error(_log, "Unable to open %s. Searching for other device(%d): %s", _usbProductDescription.c_str(), e, libusb_error_name(e));
 		}
 	}
 
@@ -155,7 +155,7 @@ libusb_device_handle * LedDeviceHyperionUsbasp::openDevice(libusb_device *device
 	int error = libusb_open(device, &handle);
 	if (error != LIBUSB_SUCCESS)
 	{
-		Error(log, "unable to open device(%s): %s",error,libusb_error_name(error));
+		Error(log, "unable to open device(%d): %s",error,libusb_error_name(error));
 		throw error;
 	}
 
@@ -165,7 +165,7 @@ libusb_device_handle * LedDeviceHyperionUsbasp::openDevice(libusb_device *device
 		error = libusb_detach_kernel_driver(handle, 0);
 		if (error != LIBUSB_SUCCESS)
 		{
-			Error(log, "unable to detach kernel driver(%s): %s",error,libusb_error_name(error));
+			Error(log, "unable to detach kernel driver(%d): %s",error,libusb_error_name(error));
 			libusb_close(handle);
 			throw error;
 		}
@@ -174,7 +174,7 @@ libusb_device_handle * LedDeviceHyperionUsbasp::openDevice(libusb_device *device
 	error = libusb_claim_interface(handle, 0);
 	if (error != LIBUSB_SUCCESS)
 	{
-		Error(log, "unable to claim interface(%s): %s", error, libusb_error_name(error));
+		Error(log, "unable to claim interface(%d): %s", error, libusb_error_name(error));
 		libusb_attach_kernel_driver(handle, 0);
 		libusb_close(handle);
 		throw error;


### PR DESCRIPTION
**1.** Tell us something about your changes.
The usbasp device driver had data type errors in the log calls causing it to segfault with logging enabled.

**2.** If this changes affect the .conf file. Please provide the changed section
nope

**3.** Reference a issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


