### PR TITLE
rework kodi grabbing mode for all grabbers

### DIFF
--- a/include/grabber/AmlogicWrapper.h
+++ b/include/grabber/AmlogicWrapper.h
@@ -4,7 +4,6 @@
 #include <utils/Image.h>
 #include <utils/ColorBgr.h>
 #include <utils/ColorRgb.h>
-#include <utils/GrabbingMode.h>
 #include <utils/VideoMode.h>
 #include <hyperion/GrabberWrapper.h>
 
@@ -42,12 +41,6 @@ public slots:
 	/// Performs a single frame grab and computes the led-colors
 	///
 	virtual void action();
-
-	///
-	/// Set the grabbing mode
-	/// @param[in] mode The new grabbing mode
-	///
-	void setGrabbingMode(const GrabbingMode mode);
 
 	///
 	/// Set the video mode (2D/3D)

--- a/include/grabber/DispmanxWrapper.h
+++ b/include/grabber/DispmanxWrapper.h
@@ -45,11 +45,8 @@ public slots:
 	void setCropping(const unsigned cropLeft, const unsigned cropRight,
 		const unsigned cropTop, const unsigned cropBottom);
 
-	///
-	/// Set the grabbing mode
-	/// @param[in] mode The new grabbing mode
-	///
-	void setGrabbingMode(const GrabbingMode mode);
+	virtual void kodiPlay();
+	virtual void kodiPlause();
 
 	///
 	/// Set the video mode (2D/3D)

--- a/include/grabber/FramebufferWrapper.h
+++ b/include/grabber/FramebufferWrapper.h
@@ -42,12 +42,6 @@ public slots:
 	virtual void action();
 
 	///
-	/// Set the grabbing mode
-	/// @param[in] mode The new grabbing mode
-	///
-	void setGrabbingMode(const GrabbingMode mode);
-
-	///
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///

--- a/include/grabber/OsxWrapper.h
+++ b/include/grabber/OsxWrapper.h
@@ -44,12 +44,6 @@ public slots:
 	virtual void action();
 
 	///
-	/// Set the grabbing mode
-	/// @param[in] mode The new grabbing mode
-	///
-	void setGrabbingMode(const GrabbingMode mode);
-
-	///
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///

--- a/include/grabber/V4L2Wrapper.h
+++ b/include/grabber/V4L2Wrapper.h
@@ -32,10 +32,7 @@ public slots:
 
 	void stop();
 
-	void setCropping(int cropLeft,
-					 int cropRight,
-					 int cropTop,
-					 int cropBottom);
+	void setCropping(int cropLeft, int cropRight, int cropTop, int cropBottom);
 
 	void set3D(VideoMode mode);
 

--- a/include/grabber/X11Wrapper.h
+++ b/include/grabber/X11Wrapper.h
@@ -3,7 +3,6 @@
 // Utils includes
 #include <utils/Image.h>
 #include <utils/ColorRgb.h>
-#include <utils/GrabbingMode.h>
 #include <utils/VideoMode.h>
 #include <hyperion/GrabberWrapper.h>
 
@@ -45,12 +44,6 @@ public slots:
 	/// Performs a single frame grab and computes the led-colors
 	///
 	virtual void action();
-
-	///
-	/// Set the grabbing mode
-	/// @param[in] mode The new grabbing mode
-	///
-	void setGrabbingMode(const GrabbingMode mode);
 
 	///
 	/// Set the video mode (2D/3D)

--- a/include/hyperion/GrabberWrapper.h
+++ b/include/hyperion/GrabberWrapper.h
@@ -6,6 +6,7 @@
 
 #include <utils/Logger.h>
 #include <utils/Components.h>
+#include <utils/GrabbingMode.h>
 #include <hyperion/Hyperion.h>
 
 class ImageProcessor;
@@ -18,17 +19,39 @@ public:
 	
 	virtual ~GrabberWrapper();
 	
+	///
+	/// Starts the grabber wich produces led values with the specified update rate
+	///
 	virtual bool start();
+
+	///
+	/// Stop grabber
+	///
 	virtual void stop();
 
 public slots:
 	void componentStateChanged(const hyperion::Components component, bool enable);
+	
+	///
+	/// virtual method, should perform single frame grab and computes the led-colors
+	///
 	virtual void action() = 0;
+
+	///
+	/// Set the grabbing mode
+	/// @param[in] mode The new grabbing mode
+	///
+	void setGrabbingMode(const GrabbingMode mode);
 
 signals:
 	void emitImage(int priority, const Image<ColorRgb> & image, const int timeout_ms);
 
 protected:
+
+	virtual void kodiPlay();
+	virtual void kodiOff();
+	virtual void kodiPause();
+
 	std::string _grabberName;
 	
 	/// Pointer to Hyperion for writing led values

--- a/libsrc/grabber/amlogic/AmlogicWrapper.cpp
+++ b/libsrc/grabber/amlogic/AmlogicWrapper.cpp
@@ -50,29 +50,6 @@ void AmlogicWrapper::action()
 	_hyperion->setColors(_priority, _ledColors, _timeout_ms);
 }
 
-void AmlogicWrapper::setGrabbingMode(const GrabbingMode mode)
-{
-	switch (mode)
-	{
-	case GRABBINGMODE_VIDEO:
-	case GRABBINGMODE_PAUSE:
-//		_grabber->setFlags(DISPMANX_SNAPSHOT_NO_RGB|DISPMANX_SNAPSHOT_FILL);
-		start();
-		break;
-	case GRABBINGMODE_AUDIO:
-	case GRABBINGMODE_PHOTO:
-	case GRABBINGMODE_MENU:
-	case GRABBINGMODE_SCREENSAVER:
-	case GRABBINGMODE_INVALID:
-//		_grabber->setFlags(0);
-		start();
-		break;
-	case GRABBINGMODE_OFF:
-		stop();
-		break;
-	}
-}
-
 void AmlogicWrapper::setVideoMode(const VideoMode mode)
 {
 	_grabber->setVideoMode(mode);

--- a/libsrc/grabber/dispmanx/DispmanxWrapper.cpp
+++ b/libsrc/grabber/dispmanx/DispmanxWrapper.cpp
@@ -46,27 +46,17 @@ void DispmanxWrapper::action()
 	_hyperion->setColors(_priority, _ledColors, _timeout_ms);
 }
 
-void DispmanxWrapper::setGrabbingMode(const GrabbingMode mode)
+void DispmanxWrapper::kodiPlay()
 {
-	switch (mode)
-	{
-	case GRABBINGMODE_VIDEO:
-	case GRABBINGMODE_PAUSE:
-		_grabber->setFlags(DISPMANX_SNAPSHOT_NO_RGB|DISPMANX_SNAPSHOT_FILL);
-		start();
-		break;
-	case GRABBINGMODE_AUDIO:
-	case GRABBINGMODE_PHOTO:
-	case GRABBINGMODE_MENU:
-	case GRABBINGMODE_SCREENSAVER:
-	case GRABBINGMODE_INVALID:
-		_grabber->setFlags(0);
-		start();
-		break;
-	case GRABBINGMODE_OFF:
-		stop();
-		break;
-	}
+	_grabber->setFlags(DISPMANX_SNAPSHOT_NO_RGB|DISPMANX_SNAPSHOT_FILL);
+	GrabberWrapper::kodiStart();
+	
+}
+
+void DispmanxWrapper::kodiPause()
+{
+	_grabber->setFlags(0);
+	GrabberWrapper::kodiStart();
 }
 
 void DispmanxWrapper::setVideoMode(const VideoMode mode)

--- a/libsrc/grabber/framebuffer/FramebufferWrapper.cpp
+++ b/libsrc/grabber/framebuffer/FramebufferWrapper.cpp
@@ -40,25 +40,6 @@ void FramebufferWrapper::action()
 	_hyperion->setColors(_priority, _ledColors, _timeout_ms);
 }
 
-void FramebufferWrapper::setGrabbingMode(const GrabbingMode mode)
-{
-	switch (mode)
-	{
-	case GRABBINGMODE_VIDEO:
-	case GRABBINGMODE_PAUSE:
-	case GRABBINGMODE_AUDIO:
-	case GRABBINGMODE_PHOTO:
-	case GRABBINGMODE_MENU:
-	case GRABBINGMODE_SCREENSAVER:
-	case GRABBINGMODE_INVALID:
-		start();
-		break;
-	case GRABBINGMODE_OFF:
-		stop();
-		break;
-	}
-}
-
 void FramebufferWrapper::setVideoMode(const VideoMode mode)
 {
 	_grabber->setVideoMode(mode);

--- a/libsrc/grabber/osx/OsxWrapper.cpp
+++ b/libsrc/grabber/osx/OsxWrapper.cpp
@@ -40,24 +40,6 @@ void OsxWrapper::action()
 	_hyperion->setColors(_priority, _ledColors, _timeout_ms);
 }
 
-void OsxWrapper::setGrabbingMode(const GrabbingMode mode)
-{
-	switch (mode)
-	{
-	case GRABBINGMODE_VIDEO:
-	case GRABBINGMODE_PAUSE:
-	case GRABBINGMODE_AUDIO:
-	case GRABBINGMODE_PHOTO:
-	case GRABBINGMODE_MENU:
-	case GRABBINGMODE_SCREENSAVER:
-	case GRABBINGMODE_INVALID:
-		start();
-		break;
-	case GRABBINGMODE_OFF:
-		stop();
-		break;
-	}
-}
 
 void OsxWrapper::setVideoMode(const VideoMode mode)
 {

--- a/libsrc/grabber/x11/X11Wrapper.cpp
+++ b/libsrc/grabber/x11/X11Wrapper.cpp
@@ -73,24 +73,6 @@ void X11Wrapper::action()
 	_hyperion->setColors(_priority, _ledColors, _timeout_ms);
 }
 
-void X11Wrapper::setGrabbingMode(const GrabbingMode mode)
-{
-	switch (mode)
-	{
-	case GRABBINGMODE_VIDEO:
-	case GRABBINGMODE_PAUSE:
-	case GRABBINGMODE_AUDIO:
-	case GRABBINGMODE_PHOTO:
-	case GRABBINGMODE_MENU:
-	case GRABBINGMODE_SCREENSAVER:
-	case GRABBINGMODE_INVALID:
-		start();
-		break;
-	case GRABBINGMODE_OFF:
-		stop();
-		break;
-	}
-}
 
 void X11Wrapper::setVideoMode(const VideoMode mode)
 {

--- a/libsrc/hyperion/GrabberWrapper.cpp
+++ b/libsrc/hyperion/GrabberWrapper.cpp
@@ -60,3 +60,41 @@ void GrabberWrapper::componentStateChanged(const hyperion::Components component,
 		Info(_log, "bb detector change state to %s", (_processor->blackBorderDetectorEnabled() ? "enabled" : "disabled") );
 	}
 }
+
+void GrabberWrapper::kodiPlay()
+{
+	start();
+}
+
+void GrabberWrapper::kodiPause()
+{
+	start();
+}
+
+void GrabberWrapper::kodiOff()
+{
+	stop();
+}
+
+
+void GrabberWrapper::setGrabbingMode(const GrabbingMode mode)
+{
+	switch (mode)
+	{
+	case GRABBINGMODE_VIDEO:
+	case GRABBINGMODE_PAUSE:
+		kodiPause();
+		break;
+	case GRABBINGMODE_AUDIO:
+	case GRABBINGMODE_PHOTO:
+	case GRABBINGMODE_MENU:
+	case GRABBINGMODE_SCREENSAVER:
+	case GRABBINGMODE_INVALID:
+		kodiPlay();
+		break;
+	case GRABBINGMODE_OFF:
+		kodiOff();
+		break;
+	}
+}
+

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -400,93 +400,79 @@
 		"grabber-v4l2" :
 		{
 			"type" : "object",
-			"required" : false,
 			"properties" :
 			{
 				"enable" :
 				{
-					"type" : "boolean",
-					"required" : true
+					"type" : "boolean"
 				},
 				"device" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" : "string"
 				},
 				"input" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"standard" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" : "string"
 				},
 				"width" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"height" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"frameDecimation" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"sizeDecimation" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"priority" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"mode" :
 				{
-					"type" : "string",
-					"required" : true
+					"type" : "string"
+				},
+				"useKodiChecker" :
+				{
+					"type" : "boolean"
 				},
 				"cropLeft" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"cropRight" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"cropTop" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"cropBottom" :
 				{
-					"type" : "integer",
-					"required" : true
+					"type" : "integer"
 				},
 				"redSignalThreshold" :
 				{
-					"type" : "number",
-					"required" : true
+					"type" : "number"
 				},
 				"greenSignalThreshold" :
 				{
-					"type" : "number",
-					"required" : true
+					"type" : "number"
 				},
 				"blueSignalThreshold" :
 				{
-					"type" : "number",
-					"required" : true
+					"type" : "number"
 				}
 			},
 			"additionalProperties" : false

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -562,6 +562,10 @@ void HyperionDaemon::createGrabberV4L2()
 	Debug(_log, "V4L2 grabber created");
 
 	QObject::connect(_v4l2Grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)));
+	if (grabberConfig["useKodiChecker"].toBool(false))
+	{
+		QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _v4l2Grabber, SLOT(setGrabbingMode(GrabbingMode)));
+	}
 	InfoIf( enableV4l && _v4l2Grabber->start(), _log, "V4L2 grabber started");
 #endif
 


### PR DESCRIPTION
**1.** Tell us something about your changes.
grabbingMode methode is moved to base class. This save lots of code dups.
V4L gets optional kodichecker via option in config. (default: false)

**2.** If this changes affect the .conf file. Please provide the changed section
yes, optional v4l boolean option: `useKodiChecker` to enable/disable kodichekcer for v4l grabber

**3.** Reference an issue (optional)
#1 

Note: For further discussions use our forum: forum.hyperion-project.org

