### PR TITLE
Added "invert" and "spimode" options to ws2801, ws2812spi and sk6812spi devices

### DIFF
--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -116,14 +116,18 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 			device = new LedDeviceWs2801(
 				deviceConfig["output"].asString(),
 				deviceConfig["rate"].asInt(),
-				deviceConfig.get("latchtime",500000).asInt()
+				deviceConfig.get("latchtime",500000).asInt(),
+				deviceConfig.get("spimode",0).asInt(),
+				deviceConfig.get("invert",false).asBool()
 			);
 		}
 		else if (type == "ws2812spi")
 		{
 			device = new LedDeviceWs2812SPI(
 				deviceConfig["output"].asString(),
-				deviceConfig.get("rate",2857143).asInt()
+				deviceConfig.get("rate",2857143).asInt(),
+				deviceConfig.get("spimode",0).asInt(),
+				deviceConfig.get("invert",false).asBool()
 			);
 		}
 		else if (type == "sk6812rgbw-spi")
@@ -131,7 +135,9 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 			device = new LedDeviceSk6812SPI(
 				deviceConfig["output"].asString(),
 				deviceConfig.get("rate",2857143).asInt(),
-				deviceConfig.get("white_algorithm","").asString()
+				deviceConfig.get("white_algorithm","").asString(),
+				deviceConfig.get("spimode",0).asInt(),
+				deviceConfig.get("invert",false).asBool()
 			);
 		}
 	#endif

--- a/libsrc/leddevice/LedDeviceSk6812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.cpp
@@ -12,12 +12,11 @@
 #include "LedDeviceSk6812SPI.h"
 
 LedDeviceSk6812SPI::LedDeviceSk6812SPI(const std::string& outputDevice, const unsigned baudrate, const std::string& whiteAlgorithm,
-                                                const int spiMode, const bool spiDataInvert) :
-
-	LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert),
-	mLedCount(0),
-	_whiteAlgorithm(whiteAlgorithm),
-	bitpair_to_byte {
+                                                const int spiMode, const bool spiDataInvert)
+	: LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert)
+	, mLedCount(0)
+	, _whiteAlgorithm(whiteAlgorithm)
+	, bitpair_to_byte {
 		0b10001000,
 		0b10001100,
 		0b11001000,

--- a/libsrc/leddevice/LedDeviceSk6812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.cpp
@@ -11,8 +11,10 @@
 // hyperion local includes
 #include "LedDeviceSk6812SPI.h"
 
-LedDeviceSk6812SPI::LedDeviceSk6812SPI(const std::string& outputDevice, const unsigned baudrate, const std::string& whiteAlgorithm) :
-	LedSpiDevice(outputDevice, baudrate, 0),
+LedDeviceSk6812SPI::LedDeviceSk6812SPI(const std::string& outputDevice, const unsigned baudrate, const std::string& whiteAlgorithm,
+                                                const int spiMode, const bool spiDataInvert) :
+
+	LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert),
 	mLedCount(0),
 	_whiteAlgorithm(whiteAlgorithm),
 	bitpair_to_byte {

--- a/libsrc/leddevice/LedDeviceSk6812SPI.h
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.h
@@ -20,7 +20,8 @@ public:
 	///
 
 	LedDeviceSk6812SPI(const std::string& outputDevice, const unsigned baudrate,
-				const std::string& whiteAlgorithm);
+				const std::string& whiteAlgorithm,
+				const int spiMode, const bool spiDataInvert);
 
 	///
 	/// Writes the led color values to the led-device

--- a/libsrc/leddevice/LedDeviceWs2801.cpp
+++ b/libsrc/leddevice/LedDeviceWs2801.cpp
@@ -11,8 +11,9 @@
 // hyperion local includes
 #include "LedDeviceWs2801.h"
 
-LedDeviceWs2801::LedDeviceWs2801(const std::string& outputDevice, const unsigned baudrate, const unsigned latchTime) :
-	LedSpiDevice(outputDevice, baudrate, latchTime),
+LedDeviceWs2801::LedDeviceWs2801(const std::string& outputDevice, const unsigned baudrate, const unsigned latchTime,
+						const int spiMode, const bool spiDataInvert) :
+	LedSpiDevice(outputDevice, baudrate, latchTime, spiMode, spiDataInvert),
 	mLedCount(0)
 {
 	// empty

--- a/libsrc/leddevice/LedDeviceWs2801.cpp
+++ b/libsrc/leddevice/LedDeviceWs2801.cpp
@@ -12,9 +12,9 @@
 #include "LedDeviceWs2801.h"
 
 LedDeviceWs2801::LedDeviceWs2801(const std::string& outputDevice, const unsigned baudrate, const unsigned latchTime,
-						const int spiMode, const bool spiDataInvert) :
-	LedSpiDevice(outputDevice, baudrate, latchTime, spiMode, spiDataInvert),
-	mLedCount(0)
+						const int spiMode, const bool spiDataInvert)
+	: LedSpiDevice(outputDevice, baudrate, latchTime, spiMode, spiDataInvert)
+	, mLedCount(0)
 {
 	// empty
 }

--- a/libsrc/leddevice/LedDeviceWs2801.h
+++ b/libsrc/leddevice/LedDeviceWs2801.h
@@ -21,7 +21,9 @@ public:
 
 	LedDeviceWs2801(const std::string& outputDevice,
 					const unsigned baudrate,
-					const unsigned latchTime);
+					const unsigned latchTime,
+					const int spiMode,
+					const bool spiDataInvert);
 
 	///
 	/// Writes the led color values to the led-device

--- a/libsrc/leddevice/LedDeviceWs2812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.cpp
@@ -12,10 +12,10 @@
 #include "LedDeviceWs2812SPI.h"
 
 LedDeviceWs2812SPI::LedDeviceWs2812SPI(const std::string& outputDevice, const unsigned baudrate,
-                                                const int spiMode, const bool spiDataInvert) :
-        LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert),
-	mLedCount(0),
-	bitpair_to_byte {
+                                                const int spiMode, const bool spiDataInvert)
+        : LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert)
+	, mLedCount(0)
+	, bitpair_to_byte {
 		0b10001000,
 		0b10001100,
 		0b11001000,

--- a/libsrc/leddevice/LedDeviceWs2812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.cpp
@@ -11,8 +11,9 @@
 // hyperion local includes
 #include "LedDeviceWs2812SPI.h"
 
-LedDeviceWs2812SPI::LedDeviceWs2812SPI(const std::string& outputDevice, const unsigned baudrate) :
-	LedSpiDevice(outputDevice, baudrate, 0),
+LedDeviceWs2812SPI::LedDeviceWs2812SPI(const std::string& outputDevice, const unsigned baudrate,
+                                                const int spiMode, const bool spiDataInvert) :
+        LedSpiDevice(outputDevice, baudrate, 0, spiMode, spiDataInvert),
 	mLedCount(0),
 	bitpair_to_byte {
 		0b10001000,

--- a/libsrc/leddevice/LedDeviceWs2812SPI.h
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.h
@@ -18,8 +18,8 @@ public:
 	/// @param outputDevice The name of the output device (eg '/etc/SpiDev.0.0')
 	/// @param baudrate The used baudrate for writing to the output device
 	///
-	LedDeviceWs2812SPI(const std::string& outputDevice,
-					const unsigned baudrate);
+	LedDeviceWs2812SPI(const std::string& outputDevice, const unsigned baudrate,
+					const int spiMode, const bool spiDataInvert);
 
 	///
 	/// Writes the led color values to the led-device

--- a/libsrc/leddevice/LedSpiDevice.cpp
+++ b/libsrc/leddevice/LedSpiDevice.cpp
@@ -15,13 +15,13 @@
 
 
 LedSpiDevice::LedSpiDevice(const std::string& outputDevice, const unsigned baudrate, const int latchTime_ns,
-				const int spiMode, const bool spiDataInvert) :
-	mDeviceName(outputDevice),
-	mBaudRate_Hz(baudrate),
-	mLatchTime_ns(latchTime_ns),
-	mFid(-1),
-	mSpiMode(spiMode),
-	mSpiDataInvert(spiDataInvert)
+				const int spiMode, const bool spiDataInvert)
+	: mDeviceName(outputDevice)
+	, mBaudRate_Hz(baudrate)
+	, mLatchTime_ns(latchTime_ns)
+	, mFid(-1)
+	, mSpiMode(spiMode)
+	, mSpiDataInvert(spiDataInvert)
 {
 	memset(&spi, 0, sizeof(spi));
 }

--- a/libsrc/leddevice/LedSpiDevice.cpp
+++ b/libsrc/leddevice/LedSpiDevice.cpp
@@ -14,11 +14,14 @@
 #include <utils/Logger.h>
 
 
-LedSpiDevice::LedSpiDevice(const std::string& outputDevice, const unsigned baudrate, const int latchTime_ns) :
+LedSpiDevice::LedSpiDevice(const std::string& outputDevice, const unsigned baudrate, const int latchTime_ns,
+				const int spiMode, const bool spiDataInvert) :
 	mDeviceName(outputDevice),
 	mBaudRate_Hz(baudrate),
 	mLatchTime_ns(latchTime_ns),
-	mFid(-1)
+	mFid(-1),
+	mSpiMode(spiMode),
+	mSpiDataInvert(spiDataInvert)
 {
 	memset(&spi, 0, sizeof(spi));
 }
@@ -30,6 +33,7 @@ LedSpiDevice::~LedSpiDevice()
 
 int LedSpiDevice::open()
 {
+//printf ("mSpiDataInvert %d  mSpiMode %d\n",mSpiDataInvert,  mSpiMode);
 	const int bitsPerWord = 8;
 
 	mFid = ::open(mDeviceName.c_str(), O_RDWR);
@@ -40,8 +44,7 @@ int LedSpiDevice::open()
 		return -1;
 	}
 
-	int mode = SPI_MODE_0;
-	if (ioctl(mFid, SPI_IOC_WR_MODE, &mode) == -1 || ioctl(mFid, SPI_IOC_RD_MODE, &mode) == -1)
+	if (ioctl(mFid, SPI_IOC_WR_MODE, &mSpiMode) == -1 || ioctl(mFid, SPI_IOC_RD_MODE, &mSpiMode) == -1)
 	{
 		return -2;
 	}
@@ -68,6 +71,14 @@ int LedSpiDevice::writeBytes(const unsigned size, const uint8_t * data)
 
 	spi.tx_buf = __u64(data);
 	spi.len    = __u32(size);
+
+	if (mSpiDataInvert) {
+		uint8_t * newdata = (uint8_t *)malloc(size);
+		for (unsigned i = 0; i<size; i++) {
+			newdata[i] = data[i] ^ 0xff;
+		}
+		spi.tx_buf = __u64(newdata);
+	}
 
 	int retVal = ioctl(mFid, SPI_IOC_MESSAGE(1), &spi);
 

--- a/libsrc/leddevice/LedSpiDevice.h
+++ b/libsrc/leddevice/LedSpiDevice.h
@@ -20,7 +20,9 @@ public:
 	/// @param[in] latchTime_ns The latch-time to latch in the values across the SPI-device (negative
 	/// means no latch required) [ns]
 	///
-	LedSpiDevice(const std::string& outputDevice, const unsigned baudrate, const int latchTime_ns = -1);
+	LedSpiDevice(const std::string& outputDevice, const unsigned baudrate, const int latchTime_ns = -1,
+                                const int spiMode = SPI_MODE_0, const bool spiDataInvert = false);
+
 
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
@@ -56,6 +58,13 @@ private:
 
 	/// The File Identifier of the opened output device (or -1 if not opened)
 	int mFid;
+
+	/// which spi clock mode do we use? (0..3)
+	int mSpiMode;
+
+	/// 1=>invert the data pattern
+	bool mSpiDataInvert;
+
 	/// The transfer structure for writing to the spi-device
 	spi_ioc_transfer spi;
 };

--- a/test/TestSpi.cpp
+++ b/test/TestSpi.cpp
@@ -54,7 +54,7 @@ void setColor(char* colorStr)
 	unsigned ledCnt = 50;
 	std::vector<ColorRgb> buff(ledCnt, color);
 
-	LedDeviceWs2801 ledDevice("/dev/spidev0.0", 40000, 500000);
+	LedDeviceWs2801 ledDevice("/dev/spidev0.0", 40000, 500000, 0, 0);
 	ledDevice.open();
 	ledDevice.write(buff);
 }
@@ -68,7 +68,7 @@ void doCircle()
 	unsigned ledCnt = 50;
 	std::vector<ColorRgb> data(ledCnt, ColorRgb::BLACK);
 
-	LedDeviceWs2801 ledDevice("/dev/spidev0.0", 40000, 500000);
+	LedDeviceWs2801 ledDevice("/dev/spidev0.0", 40000, 500000, 0, 0);
 	ledDevice.open();
 
 	timespec loopTime;


### PR DESCRIPTION
**1.** Tell us something about your changes.
Added "invert" and "spimode" options to ws2801, ws2812spi and sk6812spi devices
This adds the option to invert the SPI data line and the SPI clock line.
This is nice if you want to use a level shifter that inverts the signal(s)

**2.** If this changes affect the .conf file. Please provide the changed section
                "rate"       : 1000000,
                "spimode"    : 0,
                "invert"     : true,
                "colorOrder" : "grb"

**3.** Reference an issue (optional)
#101 
