### PR TITLE
JSON RPC Writer (configSet)

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -604,7 +604,5 @@
 			"hscan" : { "minimum" : 0.5625, "maximum" : 0.6250 },
 			"vscan" : { "minimum" : 0.9200, "maximum" : 1.0000 }
 		}
-	],
-
-	"endOfJson" : "endOfJson"
+	]
 }

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -437,7 +437,5 @@
 			"hscan" : { "minimum" : 0.5625, "maximum" : 0.6250 },
 			"vscan" : { "minimum" : 0.9200, "maximum" : 1.0000 }
 		}
-	],
-
-	"endOfJson" : "endOfJson"
+	]
 }

--- a/include/utils/jsonschema/JsonFactory.h
+++ b/include/utils/jsonschema/JsonFactory.h
@@ -63,4 +63,12 @@ public:
 		}
 		return jsonTree;
 	}
+
+	static void writeJson(const std::string& filename, Json::Value& jsonTree)
+	{
+		Json::StyledStreamWriter writer;
+		
+		std::ofstream ofs(filename.c_str());
+		writer.write(ofs, jsonTree);
+	}
 };

--- a/include/utils/jsonschema/JsonSchemaChecker.h
+++ b/include/utils/jsonschema/JsonSchemaChecker.h
@@ -43,7 +43,7 @@ public:
 	/// @param value The JSON value to check
 	/// @return true when the arguments is valid according to the schema
 	///
-	bool validate(const Json::Value & value);
+	bool validate(const Json::Value & value, bool ignoreRequired = false);
 
 	///
 	/// @return A list of error messages
@@ -179,6 +179,8 @@ private:
 private:
 	/// The schema of the entire json-configuration
 	Json::Value _schema;
+	/// ignore the required value in json schema
+	bool _ignoreRequired;
 
 	/// The current location into a json-configuration structure being checked
 	std::list<std::string> _currentPath;

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -896,10 +896,6 @@
 				},
 				"additionalProperties" : false
 			}
-		},
-		"endOfJson" :
-		{
-			"type" : "string"
 		}
 	},
 	"additionalProperties" : false

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -144,6 +144,11 @@ private:
 	/// @param message the incoming message
 	///
 	void handleConfigGetCommand(const Json::Value & message);
+
+	///
+	/// Handle an incoming JSON SetConfig message
+	///
+	void handleConfigSetCommand(const Json::Value & message);
 	
 	///
 	/// Handle an incoming JSON Component State message
@@ -197,12 +202,13 @@ private:
 	/// Check if a JSON messag is valid according to a given JSON schema
 	///
 	/// @param message JSON message which need to be checked
-	/// @param schemaResource Qt esource identifier with the JSON schema
+	/// @param schemaResource Qt Resource identifier with the JSON schema
 	/// @param errors Output error message
+	/// @param ignoreRequired ignore the required value in JSON schema
 	///
 	/// @return true if message conforms the given JSON schema
 	///
-	bool checkJson(const Json::Value & message, const QString &schemaResource, std::string & errors);
+	bool checkJson(const Json::Value & message, const QString &schemaResource, std::string & errors, bool ignoreRequired = false);
 
 private:
 	/// The TCP-Socket that is connected tot the Json-client

--- a/libsrc/jsonserver/JsonSchemas.qrc
+++ b/libsrc/jsonserver/JsonSchemas.qrc
@@ -13,6 +13,7 @@
         <file alias="schema-effect">schema/schema-effect.json</file>
         <file alias="schema-sourceselect">schema/schema-sourceselect.json</file>
         <file alias="schema-configget">schema/schema-configget.json</file>
+        <file alias="schema-configset">schema/schema-configset.json</file>
         <file alias="schema-componentstate">schema/schema-componentstate.json</file>
     </qresource>
 </RCC>

--- a/libsrc/jsonserver/schema/schema-configset.json
+++ b/libsrc/jsonserver/schema/schema-configset.json
@@ -1,0 +1,20 @@
+{
+	"type" : "object",
+	"required" : true,
+	"properties" : {
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["configset"]
+		},
+		"configset": {
+			"type" : "object",
+			"required" : true
+		},
+		"create": {
+			"type" : "boolean",
+			"required" : false
+		}
+	},
+	"additionalProperties": false
+}

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -5,7 +5,7 @@
         "command": {
             "type" : "string",
             "required" : true,
-            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "configget", "componentstate"]
+            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "configget", "configset", "componentstate"]
         }
     }
 }

--- a/libsrc/utils/jsonschema/JsonSchemaChecker.cpp
+++ b/libsrc/utils/jsonschema/JsonSchemaChecker.cpp
@@ -26,9 +26,10 @@ bool JsonSchemaChecker::setSchema(const Json::Value & schema)
 	return true;
 }
 
-bool JsonSchemaChecker::validate(const Json::Value & value)
+bool JsonSchemaChecker::validate(const Json::Value & value, bool ignoreRequired)
 {
 	// initialize state
+	_ignoreRequired = ignoreRequired;
 	_error = false;
 	_messages.clear();
 	_currentPath.clear();
@@ -201,7 +202,7 @@ void JsonSchemaChecker::checkProperties(const Json::Value & value, const Json::V
 		{
 			validate(value[property], propertyValue);
 		}
-		else if (propertyValue.get("required", false).asBool())
+		else if (propertyValue.get("required", false).asBool() && !_ignoreRequired)
 		{
 			_error = true;
 			setMessage("missing member");

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -265,6 +265,29 @@ QString JsonConnection::getConfigFile()
 	return QString();
 }
 
+void JsonConnection::setConfigFile(const std::string &jsonString, bool create)
+{
+	// create command
+	Json::Value command;
+	command["command"] = "configset";
+	command["create"] = create;
+	Json::Value & config = command["configset"];
+	if (jsonString.size() > 0)
+	{
+		Json::Reader reader;
+		if (!reader.parse(jsonString, config, false))
+		{
+			throw std::runtime_error("Error in configset arguments: " + reader.getFormattedErrorMessages());
+		}
+	}
+
+	// send command message
+	Json::Value reply = sendMessage(command);
+
+	// parse reply message
+	parseReply(reply);
+}
+
 void JsonConnection::setTransform(std::string * transformId, double * saturation, double * value, double * saturationL, double * luminance, double * luminanceMin, ColorTransformValues *threshold, ColorTransformValues *gamma, ColorTransformValues *blacklevel, ColorTransformValues *whitelevel)
 {
 	std::cout << "Set color transforms" << std::endl;

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -109,6 +109,14 @@ public:
 	QString getConfigFile();
 
 	///
+	/// Write JSON Value(s) to the actual loaded configuration file
+	///
+	/// @param jsonString The JSON String(s) to write
+	/// @param create Specifies whether the nonexistent json string to be created
+	///
+	void setConfigFile(const std::string & jsonString, bool create);
+
+	///
 	/// Set the color transform of the leds
 	///
 	/// @note Note that providing a NULL will leave the settings on the server unchanged

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -87,7 +87,9 @@ int main(int argc, char * argv[])
 		IntParameter       & argSource   = parameters.add<IntParameter>      (0x0, "sourceSelect"  , "Set current active priority channel and deactivate auto source switching");
 		SwitchParameter<>  & argSourceAuto = parameters.add<SwitchParameter<> >(0x0, "sourceAutoSelect", "Enables auto source, if disabled prio by manual selecting input source");
 		SwitchParameter<>  & argSourceOff = parameters.add<SwitchParameter<> >(0x0, "sourceOff", "select no source, this results in leds activly set to black (=off)");
-		SwitchParameter<>  & argConfigGet   = parameters.add<SwitchParameter<> >(0x0, "configget"  , "Print the current loaded Hyperion configuration file");
+		SwitchParameter<>  & argConfigGet   = parameters.add<SwitchParameter<> >(0x0, "configGet"  , "Print the current loaded Hyperion configuration file");
+		StringParameter & argConfigSet = parameters.add<StringParameter>('W', "configSet", "Write to the actual loaded configuration file. Should be a Json object string.");
+		SwitchParameter<> & argCreate = parameters.add<SwitchParameter<> >(0x0, "createkeys", "Create non exist Json Entry(s) in the actual loaded configuration file. Argument to use in combination with configSet.");
 
 		// set the default values
 		argAddress.setDefault(defaultServerAddress.toStdString());
@@ -111,7 +113,7 @@ int main(int argc, char * argv[])
 		bool colorModding = colorTransform || colorAdjust || argCorrection.isSet() || argTemperature.isSet();
 		
 		// check that exactly one command was given
-        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), argEnableComponent.isSet(), argDisableComponent.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet(), argSourceOff.isSet(), argConfigGet.isSet()});
+        int commandCount = count({argColor.isSet(), argImage.isSet(), argEffect.isSet(), argServerInfo.isSet(), argClear.isSet(), argClearAll.isSet(), argEnableComponent.isSet(), argDisableComponent.isSet(), colorModding, argSource.isSet(), argSourceAuto.isSet(), argSourceOff.isSet(), argConfigGet.isSet(), argConfigSet.isSet()});
 		if (commandCount != 1)
 		{
 			std::cerr << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:" << std::endl;
@@ -126,6 +128,7 @@ int main(int argc, char * argv[])
 			std::cerr << "  " << argSource.usageLine() << std::endl;
 			std::cerr << "  " << argSourceAuto.usageLine() << std::endl;
 			std::cerr << "  " << argConfigGet.usageLine() << std::endl;
+			std::cerr << "  " << argConfigSet.usageLine() << std::endl;
 			std::cerr << "or one or more of the available color modding operations:" << std::endl;
 			std::cerr << "  " << argId.usageLine() << std::endl;
 			std::cerr << "  " << argSaturation.usageLine() << std::endl;
@@ -201,6 +204,10 @@ int main(int argc, char * argv[])
 		{
 			QString info = connection.getConfigFile();
 			std::cout << "Configuration File:\n" << info.toStdString() << std::endl;
+		}
+		else if (argConfigSet.isSet())
+		{
+			connection.setConfigFile(argConfigSet.getValue(), argCreate.isSet());
 		}
 		else if (colorModding)
 		{	


### PR DESCRIPTION
**1.** Tell us something about your changes.
Wie der Titel schon vermuten lässt, lassen sich mit dieser Funktion, einzelne, mehrere, oder gleich alle Werte in die hyperion config schreiben. 

Der JSON Befehl ist wie folgt aufgebaut:
{"command" : "configset", "configset" : { "logger" : {"level" : "debug"} } , "create" : false}

Der Schlüssel command enthält den eigentlichen Befehl "configset".
Der Schlüssel configset beinhaltet den zu schreibenden JSON String.
Und der Schlüssel create gibt an, ob die nicht vorhandenen Werte in der zu beschreibenden config erstellt werden sollen oder nicht. Der Standard ist false.

Im obigen Beispiel werden nur die vorhanden Werte aktualisiert ,wenn der logger schon in der config vorhanden ist.

Hyperion-remote unterstützt natürlich auch diesen Befehl. Dieser sollte wie folgt aussehen:
hyperion-remote --configSet '{"logger":{"level":"debug"}}'

Sollen die nicht vorhandenen Schlüssel und Werte erstellt werden muss der Befehl --configSet mit der option --createkeys erweitert werden. Dieser sollte wie folgt aussehen:
hyperion-remote --configSet '{"logger":{"level":"debug"}}'  --createkeys