### PR TITLE
extend json api to better track request-reply relations

### DIFF
--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -42,10 +42,8 @@
 				},
 				"colorOrder" :
 				{
-					"type":
-					{
-						"enum" : ["bgr", "rbg", "brg", "gbr", "grb"]
-					}
+					"type" : "string",
+					"enum" : ["rgb", "bgr", "rbg", "brg", "gbr", "grb"]
 				}
 			},
 			"additionalProperties" : true
@@ -888,10 +886,8 @@
 					},
 					"colorOrder":
 					{
-						"type":
-						{
-							"enum" : ["bgr", "rbg", "brg", "gbr", "grb"]
-						}
+						"type": "string",
+						"enum" : ["bgr", "rbg", "brg", "gbr", "grb"]
 					}
 				},
 				"additionalProperties" : false

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -246,31 +246,32 @@ void JsonClientConnection::handleMessage(const std::string &messageString)
 			return;
 		}
 
+		int tan = message.get("tan",0).asInt();
 		// switch over all possible commands and handle them
 		if (command == "color")
-			handleColorCommand(message);
+			handleColorCommand(message, command, tan);
 		else if (command == "image")
-			handleImageCommand(message);
+			handleImageCommand(message, command, tan);
 		else if (command == "effect")
-			handleEffectCommand(message);
+			handleEffectCommand(message, command, tan);
 		else if (command == "serverinfo")
-			handleServerInfoCommand(message);
+			handleServerInfoCommand(message, command, tan);
 		else if (command == "clear")
-			handleClearCommand(message);
+			handleClearCommand(message, command, tan);
 		else if (command == "clearall")
-			handleClearallCommand(message);
+			handleClearallCommand(message, command, tan);
 		else if (command == "transform")
-			handleTransformCommand(message);
+			handleTransformCommand(message, command, tan);
 		else if (command == "temperature")
-			handleTemperatureCommand(message);
+			handleTemperatureCommand(message, command, tan);
 		else if (command == "adjustment")
-			handleAdjustmentCommand(message);
+			handleAdjustmentCommand(message, command, tan);
 		else if (command == "sourceselect")
-			handleSourceSelectCommand(message);
+			handleSourceSelectCommand(message, command, tan);
 		else if (command == "config")
-			handleConfigCommand(message);
+			handleConfigCommand(message, command, tan);
 		else if (command == "componentstate")
-			handleComponentStateCommand(message);
+			handleComponentStateCommand(message, command, tan);
 		else
 			handleNotImplemented();
  	}
@@ -310,7 +311,7 @@ void JsonClientConnection::forwardJsonMessage(const Json::Value & message)
 	}
 }
 
-void JsonClientConnection::handleColorCommand(const Json::Value &message)
+void JsonClientConnection::handleColorCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	forwardJsonMessage(message);
 
@@ -346,10 +347,10 @@ void JsonClientConnection::handleColorCommand(const Json::Value &message)
 	_hyperion->setColors(priority, colorData, duration);
 
 	// send reply
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleImageCommand(const Json::Value &message)
+void JsonClientConnection::handleImageCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	forwardJsonMessage(message);
 
@@ -363,7 +364,7 @@ void JsonClientConnection::handleImageCommand(const Json::Value &message)
 	// check consistency of the size of the received data
 	if (data.size() != width*height*3)
 	{
-		sendErrorReply("Size of image data does not match with the width and height");
+		sendErrorReply("Size of image data does not match with the width and height", command, tan);
 		return;
 	}
 
@@ -379,10 +380,10 @@ void JsonClientConnection::handleImageCommand(const Json::Value &message)
 	_hyperion->setColors(priority, ledColors, duration);
 
 	// send reply
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleEffectCommand(const Json::Value &message)
+void JsonClientConnection::handleEffectCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	forwardJsonMessage(message);
 
@@ -403,14 +404,16 @@ void JsonClientConnection::handleEffectCommand(const Json::Value &message)
 	}
 
 	// send reply
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleServerInfoCommand(const Json::Value &)
+void JsonClientConnection::handleServerInfoCommand(const Json::Value &, const std::string &command, const int tan)
 {
 	// create result
 	Json::Value result;
 	result["success"] = true;
+	result["command"] = command;
+	result["tan"] = tan;
 	Json::Value & info = result["info"];
 	
 	// add host name for remote clients
@@ -641,7 +644,7 @@ void JsonClientConnection::handleServerInfoCommand(const Json::Value &)
 	sendMessage(result);
 }
 
-void JsonClientConnection::handleClearCommand(const Json::Value &message)
+void JsonClientConnection::handleClearCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	forwardJsonMessage(message);
 
@@ -652,10 +655,10 @@ void JsonClientConnection::handleClearCommand(const Json::Value &message)
 	_hyperion->clear(priority);
 
 	// send reply
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleClearallCommand(const Json::Value & message)
+void JsonClientConnection::handleClearallCommand(const Json::Value & message, const std::string &command, const int tan)
 {
 	forwardJsonMessage(message);
 
@@ -663,10 +666,10 @@ void JsonClientConnection::handleClearallCommand(const Json::Value & message)
 	_hyperion->clearall();
 
 	// send reply
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleTransformCommand(const Json::Value &message)
+void JsonClientConnection::handleTransformCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	const Json::Value & transform = message["transform"];
 
@@ -738,11 +741,11 @@ void JsonClientConnection::handleTransformCommand(const Json::Value &message)
 	// commit the changes
 	_hyperion->transformsUpdated();
 
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
 
-void JsonClientConnection::handleTemperatureCommand(const Json::Value &message)
+void JsonClientConnection::handleTemperatureCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	const Json::Value & temperature = message["temperature"];
 
@@ -765,10 +768,10 @@ void JsonClientConnection::handleTemperatureCommand(const Json::Value &message)
 	// commit the changes
 	_hyperion->temperaturesUpdated();
 
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleAdjustmentCommand(const Json::Value &message)
+void JsonClientConnection::handleAdjustmentCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	const Json::Value & adjustment = message["adjustment"];
 
@@ -806,10 +809,10 @@ void JsonClientConnection::handleAdjustmentCommand(const Json::Value &message)
 	// commit the changes
 	_hyperion->adjustmentsUpdated();
 
-	sendSuccessReply();
+	sendSuccessReply(command, tan);
 }
 
-void JsonClientConnection::handleSourceSelectCommand(const Json::Value & message)
+void JsonClientConnection::handleSourceSelectCommand(const Json::Value & message, const std::string &command, const int tan)
 {
 	bool success = false;
 	if (message.get("auto",false).asBool())
@@ -819,45 +822,47 @@ void JsonClientConnection::handleSourceSelectCommand(const Json::Value & message
 	}
 	else if (message.isMember("priority"))
 	{
-		success =  _hyperion->setCurrentSourcePriority(message["priority"].asInt());
+		success = _hyperion->setCurrentSourcePriority(message["priority"].asInt());
 	}
 
 	if (success)
 	{
-		sendSuccessReply();
+		sendSuccessReply(command, tan);
 	}
 	else
 	{
-		sendErrorReply("setting current priority failed");
+		sendErrorReply("setting current priority failed", command, tan);
 	}
 }
 
-void JsonClientConnection::handleConfigCommand(const Json::Value & message)
+void JsonClientConnection::handleConfigCommand(const Json::Value & message, const std::string &command, const int tan)
 {
 	std::string subcommand = message.get("subcommand","").asString();
 	if (subcommand == "getschema")
 	{
-		handleSchemaGetCommand(message);
+		handleSchemaGetCommand(message, command, tan);
 	}
 	else if (subcommand == "getconfig")
 	{
-		handleConfigGetCommand(message);
+		handleConfigGetCommand(message, command, tan);
 	}
 	else if (subcommand == "setconfig")
 	{
-		handleConfigSetCommand(message);
+		handleConfigSetCommand(message, command, tan);
 	} 
 	else
 	{
-		sendErrorReply("unknown or missing subcommand");
+		sendErrorReply("unknown or missing subcommand", command, tan);
 	}
 }
 
-void JsonClientConnection::handleConfigGetCommand(const Json::Value & message)
+void JsonClientConnection::handleConfigGetCommand(const Json::Value & message, const std::string &command, const int tan)
 {
 	// create result
 	Json::Value result;
 	result["success"] = true;
+	result["command"] = command;
+	result["tan"] = tan;
 	Json::Value & config = result["result"];
 	config = _hyperion->getJsonConfig();
 	
@@ -865,11 +870,13 @@ void JsonClientConnection::handleConfigGetCommand(const Json::Value & message)
 	sendMessage(result);
 }
 
-void JsonClientConnection::handleSchemaGetCommand(const Json::Value & message)
+void JsonClientConnection::handleSchemaGetCommand(const Json::Value & message, const std::string &command, const int tan)
 {
 	// create result
 	Json::Value result;
 	result["success"] = true;
+	result["command"] = command;
+	result["tan"] = tan;
 	Json::Value & schemaJson = result["result"];
 	
 	// make sure the resources are loaded (they may be left out after static linking)
@@ -889,7 +896,7 @@ void JsonClientConnection::handleSchemaGetCommand(const Json::Value & message)
 	sendMessage(result);
 }
 
-void JsonClientConnection::handleConfigSetCommand(const Json::Value &message)
+void JsonClientConnection::handleConfigSetCommand(const Json::Value &message, const std::string &command, const int tan)
 {
 	struct nested
 	{
@@ -920,7 +927,7 @@ void JsonClientConnection::handleConfigSetCommand(const Json::Value &message)
 			std::string errors;
 			if (!checkJson(message["config"], ":/hyperion-schema", errors, true))
 			{
-				sendErrorReply("Error while validating json: " + errors);
+				sendErrorReply("Error while validating json: " + errors, command, tan);
 				return;
 			}
 			
@@ -930,13 +937,13 @@ void JsonClientConnection::handleConfigSetCommand(const Json::Value &message)
 			
 			JsonFactory::writeJson(_hyperion->getConfigFileName(), hyperionConfig);
 			
-			sendSuccessReply();
+			sendSuccessReply(command, tan);
 		}
 	} else
-		sendErrorReply("Error while parsing json: Message size " + message.size());
+		sendErrorReply("Error while parsing json: Message size " + message.size(), command, tan);
 }
 
-void JsonClientConnection::handleComponentStateCommand(const Json::Value& message)
+void JsonClientConnection::handleComponentStateCommand(const Json::Value& message, const std::string &command, const int tan)
 {
 	const Json::Value & componentState = message["componentstate"];
 	Components component = stringToComponent(QString::fromStdString(componentState.get("component", "invalid").asString()));
@@ -944,11 +951,11 @@ void JsonClientConnection::handleComponentStateCommand(const Json::Value& messag
 	if (component != COMP_INVALID)
 	{
 		_hyperion->setComponentState(component, componentState.get("state", true).asBool());
-		sendSuccessReply();
+		sendSuccessReply(command, tan);
 	}
 	else
 	{
-		sendErrorReply("invalid component name");
+		sendErrorReply("invalid component name", command, tan);
 	}
 }
 
@@ -1029,22 +1036,26 @@ void JsonClientConnection::sendMessage(const Json::Value & message, QTcpSocket *
 
 }
 
-void JsonClientConnection::sendSuccessReply()
+void JsonClientConnection::sendSuccessReply(const std::string &command, const int tan)
 {
 	// create reply
 	Json::Value reply;
 	reply["success"] = true;
+	reply["command"] = command;
+	reply["tan"] = tan;
 
 	// send reply
 	sendMessage(reply);
 }
 
-void JsonClientConnection::sendErrorReply(const std::string &error)
+void JsonClientConnection::sendErrorReply(const std::string &error, const std::string &command, const int tan)
 {
 	// create reply
 	Json::Value reply;
 	reply["success"] = false;
 	reply["error"] = error;
+	reply["command"] = command;
+	reply["tan"] = tan;
 
 	// send reply
 	sendMessage(reply);

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -74,100 +74,100 @@ private:
 	///
 	/// @param message the incoming message
 	///
-	void handleColorCommand(const Json::Value & message);
+	void handleColorCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Image message
 	///
 	/// @param message the incoming message
 	///
-	void handleImageCommand(const Json::Value & message);
+	void handleImageCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Effect message
 	///
 	/// @param message the incoming message
 	///
-	void handleEffectCommand(const Json::Value & message);
+	void handleEffectCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Server info message
 	///
 	/// @param message the incoming message
 	///
-	void handleServerInfoCommand(const Json::Value & message);
+	void handleServerInfoCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Clear message
 	///
 	/// @param message the incoming message
 	///
-	void handleClearCommand(const Json::Value & message);
+	void handleClearCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Clearall message
 	///
 	/// @param message the incoming message
 	///
-	void handleClearallCommand(const Json::Value & message);
+	void handleClearallCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON Transform message
 	///
 	/// @param message the incoming message
 	///
-	void handleTransformCommand(const Json::Value & message);
+	void handleTransformCommand(const Json::Value & message, const std::string &command, const int tan);
 	
 	///
 	/// Handle an incoming JSON Temperature message
 	///
 	/// @param message the incoming message
 	///
-	void handleTemperatureCommand(const Json::Value & message);
+	void handleTemperatureCommand(const Json::Value & message, const std::string &command, const int tan);
 	
 	///
 	/// Handle an incoming JSON Adjustment message
 	///
 	/// @param message the incoming message
 	///
-	void handleAdjustmentCommand(const Json::Value & message);
+	void handleAdjustmentCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON SourceSelect message
 	///
 	/// @param message the incoming message
 	///
-	void handleSourceSelectCommand(const Json::Value & message);
+	void handleSourceSelectCommand(const Json::Value & message, const std::string &command, const int tan);
 	
 	/// Handle an incoming JSON GetConfig message
 	///
 	/// @param message the incoming message
 	///
-	void handleConfigCommand(const Json::Value & message);
+	void handleConfigCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	/// Handle an incoming JSON GetConfig message
 	///
 	/// @param message the incoming message
 	///
-	void handleSchemaGetCommand(const Json::Value & message);
+	void handleSchemaGetCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	/// Handle an incoming JSON GetConfig message
 	///
 	/// @param message the incoming message
 	///
-	void handleConfigGetCommand(const Json::Value & message);
+	void handleConfigGetCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON SetConfig message
 	///
-	void handleConfigSetCommand(const Json::Value & message);
+	void handleConfigSetCommand(const Json::Value & message, const std::string &command, const int tan);
 	
 	///
 	/// Handle an incoming JSON Component State message
 	///
 	/// @param message the incoming message
 	///
-	void handleComponentStateCommand(const Json::Value & message);
+	void handleComponentStateCommand(const Json::Value & message, const std::string &command, const int tan);
 
 	///
 	/// Handle an incoming JSON message of unknown type
@@ -185,14 +185,14 @@ private:
 	///
 	/// Send a standard reply indicating success
 	///
-	void sendSuccessReply();
+	void sendSuccessReply(const std::string &command="", const int tan=0);
 
 	///
 	/// Send an error message back to the client
 	///
 	/// @param error String describing the error
 	///
-	void sendErrorReply(const std::string & error);
+	void sendErrorReply(const std::string & error, const std::string &command="", const int tan=0);
 	
 	///
 	/// Do handshake for a websocket connection

--- a/libsrc/jsonserver/schema/schema-adjustment.json
+++ b/libsrc/jsonserver/schema/schema-adjustment.json
@@ -7,6 +7,9 @@
 			"required" : true,
 			"enum" : ["adjustment"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"adjustment": {
 			"type": "object",
 			"required": true,

--- a/libsrc/jsonserver/schema/schema-clear.json
+++ b/libsrc/jsonserver/schema/schema-clear.json
@@ -1,16 +1,19 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["clear"]
-        },
-        "priority": {
-            "type": "integer",
-            "required": true
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["clear"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"priority": {
+			"type": "integer",
+			"required": true
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-clearall.json
+++ b/libsrc/jsonserver/schema/schema-clearall.json
@@ -1,12 +1,15 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["clearall"]
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["clearall"]
+		},
+		"tan" : {
+			"type" : "integer"
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-color.json
+++ b/libsrc/jsonserver/schema/schema-color.json
@@ -1,28 +1,31 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["color"]
-        },
-        "priority": {
-            "type": "integer",
-            "required": true
-        },
-        "duration": {
-            "type": "integer",
-            "required": false
-        },
-        "color": {
-            "type": "array",
-            "required": true,
-            "items" :{
-                "type" : "integer"
-            },
-            "minItems": 3
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["color"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"priority": {
+			"type": "integer",
+			"required": true
+		},
+		"duration": {
+			"type": "integer",
+			"required": false
+		},
+		"color": {
+			"type": "array",
+			"required": true,
+			"items" :{
+				"type" : "integer"
+			},
+			"minItems": 3
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-componentstate.json
+++ b/libsrc/jsonserver/schema/schema-componentstate.json
@@ -9,6 +9,9 @@
 			"required" : true,
 			"enum" : ["componentstate"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"componentstate":
 		{
 			"type": "object",
@@ -17,6 +20,7 @@
 			{
 				"component":
 				{
+					"type" : "string",
 					"enum" : ["SMOOTHING", "BLACKBORDER", "KODICHECKER", "FORWARDER", "UDPLISTENER", "BOBLIGHTSERVER", "GRABBER"],
 					"required": true
 				},

--- a/libsrc/jsonserver/schema/schema-config.json
+++ b/libsrc/jsonserver/schema/schema-config.json
@@ -12,6 +12,9 @@
 			"required" : true,
 			"enum" : ["getconfig","setconfig","getschema"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"config": {
 			"type" : "object"
 		},

--- a/libsrc/jsonserver/schema/schema-correction.json
+++ b/libsrc/jsonserver/schema/schema-correction.json
@@ -7,6 +7,9 @@
 			"required" : true,
 			"enum" : ["correction"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"correction": {
 			"type": "object",
 			"required": true,

--- a/libsrc/jsonserver/schema/schema-effect.json
+++ b/libsrc/jsonserver/schema/schema-effect.json
@@ -1,35 +1,38 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["effect"]
-        },
-        "priority": {
-            "type": "integer",
-            "required": true
-        },
-        "duration": {
-            "type": "integer",
-            "required": false
-        },
-        "effect": {
-            "type": "object",
-            "required": true,
-            "properties" :{
-                "name" : {
-                    "type" : "string",
-                    "required" : true
-                },
-                "args" : {
-                    "type" : "object",
-                    "required" : false
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["effect"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"priority": {
+			"type": "integer",
+			"required": true
+		},
+		"duration": {
+			"type": "integer",
+			"required": false
+		},
+		"effect": {
+			"type": "object",
+			"required": true,
+			"properties" :{
+				"name" : {
+					"type" : "string",
+					"required" : true
+				},
+				"args" : {
+					"type" : "object",
+					"required" : false
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-image.json
+++ b/libsrc/jsonserver/schema/schema-image.json
@@ -1,34 +1,37 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["image"]
-        },
-        "priority": {
-            "type": "integer",
-            "required": true
-        },
-        "duration": {
-            "type": "integer",
-            "required": false
-        },
-        "imagewidth": {
-            "type" : "integer",
-            "required": true,
-            "minimum": 0
-        },
-        "imageheight": {
-            "type" : "integer",
-            "required": true,
-            "minimum": 0
-        },
-        "imagedata": {
-            "type": "string",
-            "required": true
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["image"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"priority": {
+			"type": "integer",
+			"required": true
+		},
+		"duration": {
+			"type": "integer",
+			"required": false
+		},
+		"imagewidth": {
+			"type" : "integer",
+			"required": true,
+			"minimum": 0
+		},
+		"imageheight": {
+			"type" : "integer",
+			"required": true,
+			"minimum": 0
+		},
+		"imagedata": {
+			"type": "string",
+			"required": true
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-serverinfo.json
+++ b/libsrc/jsonserver/schema/schema-serverinfo.json
@@ -1,12 +1,15 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["serverinfo"]
-        }
-    },
-    "additionalProperties": false
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["serverinfo"]
+		},
+		"tan" : {
+			"type" : "integer"
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-sourceselect.json
+++ b/libsrc/jsonserver/schema/schema-sourceselect.json
@@ -1,18 +1,21 @@
 {
-    "type":"object",
-    "required":false,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["sourceselect"]
-        },
-        "priority": {
-            "type": "integer"
-        },
-        "auto": {
-            "type": "boolean"
-        }
-     },
-    "additionalProperties": false
+	"type":"object",
+	"required":false,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["sourceselect"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"priority": {
+			"type": "integer"
+		},
+		"auto": {
+			"type": "boolean"
+		}
+	},
+	"additionalProperties": false
 }

--- a/libsrc/jsonserver/schema/schema-temperature.json
+++ b/libsrc/jsonserver/schema/schema-temperature.json
@@ -7,6 +7,9 @@
 			"required" : true,
 			"enum" : ["temperature"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"temperature": {
 			"type": "object",
 			"required": true,

--- a/libsrc/jsonserver/schema/schema-transform.json
+++ b/libsrc/jsonserver/schema/schema-transform.json
@@ -7,6 +7,9 @@
 			"required" : true,
 			"enum" : ["transform"]
 		},
+		"tan" : {
+			"type" : "integer"
+		},
 		"transform": {
 			"type": "object",
 			"required": true,

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -1,11 +1,11 @@
 {
-    "type":"object",
-    "required":true,
-    "properties":{
-        "command": {
-            "type" : "string",
-            "required" : true,
-            "enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "config", "componentstate"]
-        }
-    }
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["color", "image", "effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "config", "componentstate"]
+		}
+	}
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.
- in json reply the command is written again, to better identify it.
- also added a transaction number (tan). This is a user defined number to track exactly every request-reply relation (default is 0 if not used)

examples:
```
Command: {"command":"clearall"}
Reply: {"command":"clearall","success":true,"tan":0}

Command: {"command":"clearall","tan",111}
Reply: {"command":"clearall","success":true,"tan":111}
```
additional:
- fix hyperion.schema.json (wrong format and missing "rgb" in colorOrder enum)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


