### PR TITLE
Update and fix JSON writer

### DIFF
--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -931,8 +931,9 @@ void JsonClientConnection::handleConfigSetCommand(const Json::Value &message, co
 				return;
 			}
 			
-			bool createKey = message.isMember("create");
-			Json::Value hyperionConfig = _hyperion->getJsonConfig();
+			bool createKey = message["create"].asBool();
+			Json::Value hyperionConfig;
+			message["overwrite"].asBool() ? createKey = true : hyperionConfig = _hyperion->getJsonConfig();
 			nested::configSetCommand(message["config"], hyperionConfig, createKey);
 			
 			JsonFactory::writeJson(_hyperion->getConfigFileName(), hyperionConfig);

--- a/libsrc/jsonserver/schema/schema-config.json
+++ b/libsrc/jsonserver/schema/schema-config.json
@@ -20,6 +20,9 @@
 		},
 		"create": {
 			"type" : "boolean"
+		},
+		"overwrite": {
+			"type" : "boolean"
 		}
 	},
 	"additionalProperties": false

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -268,7 +268,7 @@ QString JsonConnection::getConfig(std::string type)
 	return QString();
 }
 
-void JsonConnection::setConfig(const std::string &jsonString, bool create)
+void JsonConnection::setConfig(const std::string &jsonString, bool create, bool overwrite)
 {
 	// create command
 	Json::Value command;
@@ -276,6 +276,7 @@ void JsonConnection::setConfig(const std::string &jsonString, bool create)
 	command["subcommand"] = "setconfig";
 	
 	command["create"] = create;
+	command["overwrite"] = overwrite;
 	Json::Value & config = command["config"];
 	if (jsonString.size() > 0)
 	{

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -114,7 +114,7 @@ public:
 	/// @param jsonString The JSON String(s) to write
 	/// @param create Specifies whether the nonexistent json string to be created
 	///
-	void setConfig(const std::string & jsonString, bool create);
+	void setConfig(const std::string & jsonString, bool create, bool overwrite);
 
 	///
 	/// Set the color transform of the leds

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -91,6 +91,7 @@ int main(int argc, char * argv[])
 		SwitchParameter<>  & argSchemaGet   = parameters.add<SwitchParameter<> >(0x0, "schemaGet"  , "Print the json schema for Hyperion configuration");
 		StringParameter & argConfigSet      = parameters.add<StringParameter>('W', "configSet", "Write to the actual loaded configuration file. Should be a Json object string.");
 		SwitchParameter<> & argCreate       = parameters.add<SwitchParameter<> >(0x0, "createkeys", "Create non exist Json Entry(s) in the actual loaded configuration file. Argument to use in combination with configSet.");
+		SwitchParameter<> & argOverwriteConfig       = parameters.add<SwitchParameter<> >(0x0, "overwrite", "Overwrite the actual loaded configuration file with the Json object string from configSet. Argument to use in combination with configSet.");
 
 		// set the default values
 		argAddress.setDefault(defaultServerAddress.toStdString());
@@ -219,7 +220,7 @@ int main(int argc, char * argv[])
 		}
 		else if (argConfigSet.isSet())
 		{
-			connection.setConfig(argConfigSet.getValue(), argCreate.isSet());
+			connection.setConfig(argConfigSet.getValue(), argCreate.isSet(), argOverwriteConfig.isSet());
 		}
 		else if (colorModding)
 		{	


### PR DESCRIPTION
**1.** Tell us something about your changes.
Update:
Die "overwrite" Option im Zusammenhang mit setConfig ermöglicht jetzt das komplette überschreiben der Hyperion config Datei. Bis jetzt war es nur möglich, die config zu aktualisieren oder mit der Zusatzoption  "create" neue Schlüssel hinzu zu fügen, wenn sich diese noch nicht in der config befunden haben.

Kleines Beispiel ausgehen von der Standard Konfigurationsdatei:
Senden wir den unten stehenden JSON String an den Hyperionserver, versetzen wir den logger in den Debug modus. Dies funktioniert nur, wenn sich der logger schon in der config befindet. Sollte er nicht vorhanden sein, müssten wir die option "create" auf true setzen. Dadurch wird der Schlüssel in die aktuelle config hinzugefügt.

{"command":"config","subcommand":"setconfig","config":{"logger":{"level":"debug"}},"create":false, "overwrite":false}

Um eine komplett NEUE config zu erstellen, kann man jetzt die option "overwrite" auf true setzen. Dadurch wird die aktuelle config NICHT eingelesen und es wird nur noch der übertragene JSON String in der config geschrieben.

Fix:
Es hat sich mal wieder ein Denkfehler eingeschlichen. Die Abfrage ob der Schlüssel "create" auf true gestellt ist war falsch. Es wurde nur abgefragt ob der Schlüssel vorhanden ist. Dies wurde korrigiert. 

**2.** If this changes affect the .conf file. Please provide the changed section
nein
