### PR TITLE
Fix throw error in udp, fix default SPI device

### DIFF
--- a/libsrc/leddevice/LedSpiDevice.cpp
+++ b/libsrc/leddevice/LedSpiDevice.cpp
@@ -30,7 +30,7 @@ LedSpiDevice::~LedSpiDevice()
 
 bool LedSpiDevice::setConfig(const Json::Value &deviceConfig)
 {
-	_deviceName    = deviceConfig.get("output","/dev/spidev.0.0").asString();
+	_deviceName    = deviceConfig.get("output","/dev/spidev0.0").asString();
 	_baudRate_Hz   = deviceConfig.get("rate",1000000).asInt();
 	_latchTime_ns  = deviceConfig.get("latchtime",0).asInt();
 	_spiMode       = deviceConfig.get("spimode",SPI_MODE_0).asInt();

--- a/libsrc/leddevice/LedUdpDevice.cpp
+++ b/libsrc/leddevice/LedUdpDevice.cpp
@@ -33,7 +33,7 @@ bool LedUdpDevice::setConfig(const Json::Value &deviceConfig)
 	QHostInfo info = QHostInfo::fromName( QString::fromStdString(deviceConfig["output"].asString()) );
 	if (info.addresses().isEmpty())
 	{
-		throw("invalid target address");
+		throw std::runtime_error("invalid target address");
 	}
 	_address = info.addresses().first();
 	_port    = deviceConfig["port"].asUInt();

--- a/libsrc/leddevice/LedUdpDevice.cpp
+++ b/libsrc/leddevice/LedUdpDevice.cpp
@@ -30,7 +30,7 @@ LedUdpDevice::~LedUdpDevice()
 
 bool LedUdpDevice::setConfig(const Json::Value &deviceConfig)
 {
-	QHostInfo info = QHostInfo::fromName( QString::fromStdString(deviceConfig["output"].asString()) );
+	QHostInfo info = QHostInfo::fromName( QString::fromStdString(deviceConfig["host"].asString()) );
 	if (info.addresses().isEmpty())
 	{
 		throw std::runtime_error("invalid target address");


### PR DESCRIPTION
**1.** Tell us something about your changes.
 	Fix throw error so it correctly fails on invalid output hostnames
 	Fixed broken default /dev/spidev0.0 string
 	UDP devices now use "host" and "port" rather than "output"

**2.** If this changes affect the .conf file. Please provide the changed section
All devices that use the lowlevel UDP driver need a new config:

OLD:
```
"device" :
{
	"output"     : "10.0.0.60:5568",
}
```
NEW:
```
"device" :
{
	"host"     : "10.0.0.60",
	"port"     : 5568,
}
```
**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


