### PR TITLE
Renamed the lowlevel providers from LedXXXDevice to ProviderXXX

### DIFF
--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -15,12 +15,12 @@ include_directories(
 # Group the headers that go through the MOC compiler
 SET(Leddevice_QT_HEADERS
 	${CURRENT_HEADER_DIR}/LedDevice.h
-	${CURRENT_SOURCE_DIR}/LedRs232Device.h
+	${CURRENT_SOURCE_DIR}/ProviderRs232.h
 	${CURRENT_SOURCE_DIR}/LedDeviceAdalight.h
 	${CURRENT_SOURCE_DIR}/LedDeviceAdalightApa102.h
 	${CURRENT_SOURCE_DIR}/LedDeviceAtmoOrb.h
 	${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.h
-	${CURRENT_SOURCE_DIR}/LedHIDDevice.h
+	${CURRENT_SOURCE_DIR}/ProviderHID.h
 	${CURRENT_SOURCE_DIR}/LedDeviceRawHID.h
 	${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.h
 )
@@ -36,7 +36,7 @@ SET(Leddevice_HEADERS
 	${CURRENT_SOURCE_DIR}/LedDeviceFile.h
 	${CURRENT_SOURCE_DIR}/LedDeviceUdpRaw.h
 	${CURRENT_SOURCE_DIR}/LedDeviceUdpE131.h
-	${CURRENT_SOURCE_DIR}/LedUdpDevice.h
+	${CURRENT_SOURCE_DIR}/ProviderUdp.h
 	${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.h
 	${CURRENT_SOURCE_DIR}/LedDeviceTpm2.h
 	${CURRENT_SOURCE_DIR}/LedDeviceTpm2net.h
@@ -47,8 +47,8 @@ SET(Leddevice_SOURCES
 	${CURRENT_SOURCE_DIR}/LedDevice.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceFactory.cpp
 
-	${CURRENT_SOURCE_DIR}/LedRs232Device.cpp
-	${CURRENT_SOURCE_DIR}/LedHIDDevice.cpp
+	${CURRENT_SOURCE_DIR}/ProviderRs232.cpp
+	${CURRENT_SOURCE_DIR}/ProviderHID.cpp
 
 	${CURRENT_SOURCE_DIR}/LedDeviceAdalight.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceAdalightApa102.cpp
@@ -63,7 +63,7 @@ SET(Leddevice_SOURCES
 	${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceUdpRaw.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceUdpE131.cpp
-	${CURRENT_SOURCE_DIR}/LedUdpDevice.cpp
+	${CURRENT_SOURCE_DIR}/ProviderUdp.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.cpp
 	${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.cpp
 	${CURRENT_SOURCE_DIR}/LedDeviceTpm2.cpp
@@ -74,7 +74,7 @@ SET(Leddevice_SOURCES
 if(ENABLE_SPIDEV)
 	SET(Leddevice_HEADERS
 		${Leddevice_HEADERS}
-		${CURRENT_SOURCE_DIR}/LedSpiDevice.h
+		${CURRENT_SOURCE_DIR}/ProviderSpi.h
 		${CURRENT_SOURCE_DIR}/LedDeviceLpd6803.h
 		${CURRENT_SOURCE_DIR}/LedDeviceLpd8806.h
 		${CURRENT_SOURCE_DIR}/LedDeviceP9813.h
@@ -85,7 +85,7 @@ if(ENABLE_SPIDEV)
 	)
 	SET(Leddevice_SOURCES
 		${Leddevice_SOURCES}
-		${CURRENT_SOURCE_DIR}/LedSpiDevice.cpp
+		${CURRENT_SOURCE_DIR}/ProviderSpi.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceLpd6803.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceLpd8806.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceP9813.cpp

--- a/libsrc/leddevice/LedDeviceAPA102.cpp
+++ b/libsrc/leddevice/LedDeviceAPA102.cpp
@@ -13,7 +13,7 @@
 #include "LedDeviceAPA102.h"
 
 LedDeviceAPA102::LedDeviceAPA102(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 {
 	_latchTime_ns = 500000;
 }

--- a/libsrc/leddevice/LedDeviceAPA102.h
+++ b/libsrc/leddevice/LedDeviceAPA102.h
@@ -4,13 +4,13 @@
 #include <string>
 
 // hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 #include <json/json.h>
 
 ///
 /// Implementation of the LedDevice interface for writing to APA102 led device.
 ///
-class LedDeviceAPA102 : public LedSpiDevice
+class LedDeviceAPA102 : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceAdalight.cpp
+++ b/libsrc/leddevice/LedDeviceAdalight.cpp
@@ -13,7 +13,7 @@
 #include <leddevice/LedDevice.h>
 
 LedDeviceAdalight::LedDeviceAdalight(const Json::Value &deviceConfig)
-	: LedRs232Device(deviceConfig)
+	: ProviderRs232(deviceConfig)
 	, _timer()
 {
 	// setup the timer

--- a/libsrc/leddevice/LedDeviceAdalight.h
+++ b/libsrc/leddevice/LedDeviceAdalight.h
@@ -7,12 +7,12 @@
 #include <QTimer>
 
 // hyperion include
-#include "LedRs232Device.h"
+#include "ProviderRs232.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to an Adalight led device.
 ///
-class LedDeviceAdalight : public LedRs232Device
+class LedDeviceAdalight : public ProviderRs232
 {
 	Q_OBJECT
 

--- a/libsrc/leddevice/LedDeviceAtmo.cpp
+++ b/libsrc/leddevice/LedDeviceAtmo.cpp
@@ -2,7 +2,7 @@
 #include "LedDeviceAtmo.h"
 
 LedDeviceAtmo::LedDeviceAtmo(const Json::Value &deviceConfig)
-	: LedRs232Device(deviceConfig)
+	: ProviderRs232(deviceConfig)
 {
 	_ledBuffer.resize(4 + 5*3); // 4-byte header, 5 RGB values
 	_ledBuffer[0] = 0xFF; // Startbyte

--- a/libsrc/leddevice/LedDeviceAtmo.h
+++ b/libsrc/leddevice/LedDeviceAtmo.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedRs232Device.h"
+#include "ProviderRs232.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to serial device using tpm2 protocol.
 ///
-class LedDeviceAtmo : public LedRs232Device
+class LedDeviceAtmo : public ProviderRs232
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceLpd6803.cpp
+++ b/libsrc/leddevice/LedDeviceLpd6803.cpp
@@ -11,7 +11,7 @@
 #include "LedDeviceLpd6803.h"
 
 LedDeviceLpd6803::LedDeviceLpd6803(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 {
 }
 

--- a/libsrc/leddevice/LedDeviceLpd6803.h
+++ b/libsrc/leddevice/LedDeviceLpd6803.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Local hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to LDP6803 led device.
@@ -14,7 +14,7 @@
 /// (R, G and B in the above illustration) making 16 bits per led. Total bytes = 4 + (2 x number of
 /// leds)
 ///
-class LedDeviceLpd6803 : public LedSpiDevice
+class LedDeviceLpd6803 : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceLpd8806.cpp
+++ b/libsrc/leddevice/LedDeviceLpd8806.cpp
@@ -11,7 +11,7 @@
 #include "LedDeviceLpd8806.h"
 
 LedDeviceLpd8806::LedDeviceLpd8806(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 {
 }
 

--- a/libsrc/leddevice/LedDeviceLpd8806.h
+++ b/libsrc/leddevice/LedDeviceLpd8806.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Local hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to LPD8806 led device.
@@ -75,7 +75,7 @@
 ///
 /// The number of zeroes in the 'clear data' is (#led/32 + 1)bytes (or *8 for bits)
 ///
-class LedDeviceLpd8806 : public LedSpiDevice
+class LedDeviceLpd8806 : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceP9813.cpp
+++ b/libsrc/leddevice/LedDeviceP9813.cpp
@@ -12,7 +12,7 @@
 #include "LedDeviceP9813.h"
 
 LedDeviceP9813::LedDeviceP9813(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 {
 }
 

--- a/libsrc/leddevice/LedDeviceP9813.h
+++ b/libsrc/leddevice/LedDeviceP9813.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion include
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to P9813 led device.
 ///
-class LedDeviceP9813 : public LedSpiDevice
+class LedDeviceP9813 : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDevicePaintpack.cpp
+++ b/libsrc/leddevice/LedDevicePaintpack.cpp
@@ -4,7 +4,7 @@
 
 // Use out report HID device
 LedDevicePaintpack::LedDevicePaintpack(const Json::Value &deviceConfig)
-	: LedHIDDevice(deviceConfig)
+	: ProviderHID(deviceConfig)
 {
 	_useFeature = false;
 }

--- a/libsrc/leddevice/LedDevicePaintpack.h
+++ b/libsrc/leddevice/LedDevicePaintpack.h
@@ -4,12 +4,12 @@
 #include <vector>
 
 // Hyperion includes
-#include "LedHIDDevice.h"
+#include "ProviderHID.h"
 
 ///
 /// LedDevice implementation for a paintpack device ()
 ///
-class LedDevicePaintpack : public LedHIDDevice
+class LedDevicePaintpack : public ProviderHID
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceRawHID.cpp
+++ b/libsrc/leddevice/LedDeviceRawHID.cpp
@@ -13,7 +13,7 @@
 
 // Use feature report HID device
 LedDeviceRawHID::LedDeviceRawHID(const Json::Value &deviceConfig)
-	: LedHIDDevice(deviceConfig)
+	: ProviderHID(deviceConfig)
 	, _timer()
 {
 	_useFeature = true;

--- a/libsrc/leddevice/LedDeviceRawHID.h
+++ b/libsrc/leddevice/LedDeviceRawHID.h
@@ -7,12 +7,12 @@
 #include <QTimer>
 
 // hyperion include
-#include "LedHIDDevice.h"
+#include "ProviderHID.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to an RawHID led device.
 ///
-class LedDeviceRawHID : public LedHIDDevice
+class LedDeviceRawHID : public ProviderHID
 {
 	Q_OBJECT
 

--- a/libsrc/leddevice/LedDeviceSedu.cpp
+++ b/libsrc/leddevice/LedDeviceSedu.cpp
@@ -18,7 +18,7 @@ struct FrameSpec
 };
 
 LedDeviceSedu::LedDeviceSedu(const Json::Value &deviceConfig)
-	: LedRs232Device(deviceConfig)
+	: ProviderRs232(deviceConfig)
 {
 	// empty
 }

--- a/libsrc/leddevice/LedDeviceSedu.h
+++ b/libsrc/leddevice/LedDeviceSedu.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedRs232Device.h"
+#include "ProviderRs232.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to SEDU led device.
 ///
-class LedDeviceSedu : public LedRs232Device
+class LedDeviceSedu : public ProviderRs232
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceSk6812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.cpp
@@ -12,7 +12,7 @@
 #include "LedDeviceSk6812SPI.h"
 
 LedDeviceSk6812SPI::LedDeviceSk6812SPI(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 	, bitpair_to_byte {
 		0b10001000,
 		0b10001100,
@@ -32,7 +32,7 @@ LedDevice* LedDeviceSk6812SPI::construct(const Json::Value &deviceConfig)
 
 bool LedDeviceSk6812SPI::setConfig(const Json::Value &deviceConfig)
 {
-	LedSpiDevice::setConfig(deviceConfig);
+	ProviderSpi::setConfig(deviceConfig);
 	_whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
 
 	return true;

--- a/libsrc/leddevice/LedDeviceSk6812SPI.h
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to Sk6801 led device.
 ///
-class LedDeviceSk6812SPI : public LedSpiDevice
+class LedDeviceSk6812SPI : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceTpm2.cpp
+++ b/libsrc/leddevice/LedDeviceTpm2.cpp
@@ -9,7 +9,7 @@
 #include <json/json.h>
 
 LedDeviceTpm2::LedDeviceTpm2(const Json::Value &deviceConfig)
-	: LedRs232Device(deviceConfig)
+	: ProviderRs232(deviceConfig)
 {
 }
 

--- a/libsrc/leddevice/LedDeviceTpm2.h
+++ b/libsrc/leddevice/LedDeviceTpm2.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedRs232Device.h"
+#include "ProviderRs232.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to serial device using tpm2 protocol.
 ///
-class LedDeviceTpm2 : public LedRs232Device
+class LedDeviceTpm2 : public ProviderRs232
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceUdpE131.cpp
+++ b/libsrc/leddevice/LedDeviceUdpE131.cpp
@@ -13,7 +13,7 @@
 #include "LedDeviceUdpE131.h"
 
 LedDeviceUdpE131::LedDeviceUdpE131(const Json::Value &deviceConfig)
-	: LedUdpDevice(deviceConfig)
+	: ProviderUdp(deviceConfig)
 
 {
 	setConfig(deviceConfig);
@@ -21,7 +21,7 @@ LedDeviceUdpE131::LedDeviceUdpE131(const Json::Value &deviceConfig)
 
 bool LedDeviceUdpE131::setConfig(const Json::Value &deviceConfig)
 {
-	LedUdpDevice::setConfig(deviceConfig);
+	ProviderUdp::setConfig(deviceConfig);
 	_LatchTime_ns  = deviceConfig.get("latchtime",104000).asInt();
 	_e131_universe = deviceConfig.get("universe",1).asInt();
 

--- a/libsrc/leddevice/LedDeviceUdpE131.h
+++ b/libsrc/leddevice/LedDeviceUdpE131.h
@@ -4,7 +4,7 @@
 #include <string>
 
 // hyperion includes
-#include "LedUdpDevice.h"
+#include "ProviderUdp.h"
 
 /*
 *
@@ -96,7 +96,7 @@ typedef union {
 ///
 /// Implementation of the LedDevice interface for sending led colors via udp/E1.31 packets
 ///
-class LedDeviceUdpE131 : public LedUdpDevice
+class LedDeviceUdpE131 : public ProviderUdp
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceUdpRaw.cpp
+++ b/libsrc/leddevice/LedDeviceUdpRaw.cpp
@@ -12,14 +12,14 @@
 #include "LedDeviceUdpRaw.h"
 
 LedDeviceUdpRaw::LedDeviceUdpRaw(const Json::Value &deviceConfig)
-	: LedUdpDevice(deviceConfig)
+	: ProviderUdp(deviceConfig)
 {
 	setConfig(deviceConfig);
 }
 
 bool LedDeviceUdpRaw::setConfig(const Json::Value &deviceConfig)
 {
-	LedUdpDevice::setConfig(deviceConfig);
+	ProviderUdp::setConfig(deviceConfig);
 	_LatchTime_ns = deviceConfig.get("latchtime",500000).asInt();
 
 	return true;

--- a/libsrc/leddevice/LedDeviceUdpRaw.h
+++ b/libsrc/leddevice/LedDeviceUdpRaw.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedUdpDevice.h"
+#include "ProviderUdp.h"
 
 ///
 /// Implementation of the LedDevice interface for sending led colors via udp.
 ///
-class LedDeviceUdpRaw : public LedUdpDevice
+class LedDeviceUdpRaw : public ProviderUdp
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceWs2801.cpp
+++ b/libsrc/leddevice/LedDeviceWs2801.cpp
@@ -12,7 +12,7 @@
 #include "LedDeviceWs2801.h"
 
 LedDeviceWs2801::LedDeviceWs2801(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 {
 }
 

--- a/libsrc/leddevice/LedDeviceWs2801.h
+++ b/libsrc/leddevice/LedDeviceWs2801.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to Ws2801 led device.
 ///
-class LedDeviceWs2801 : public LedSpiDevice
+class LedDeviceWs2801 : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/LedDeviceWs2812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.cpp
@@ -12,7 +12,7 @@
 #include "LedDeviceWs2812SPI.h"
 
 LedDeviceWs2812SPI::LedDeviceWs2812SPI(const Json::Value &deviceConfig)
-	: LedSpiDevice(deviceConfig)
+	: ProviderSpi(deviceConfig)
 	, bitpair_to_byte {
 		0b10001000,
 		0b10001100,

--- a/libsrc/leddevice/LedDeviceWs2812SPI.h
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.h
@@ -4,12 +4,12 @@
 #include <string>
 
 // hyperion incluse
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 
 ///
 /// Implementation of the LedDevice interface for writing to Ws2801 led device.
 ///
-class LedDeviceWs2812SPI : public LedSpiDevice
+class LedDeviceWs2812SPI : public ProviderSpi
 {
 public:
 	///

--- a/libsrc/leddevice/ProviderHID.cpp
+++ b/libsrc/leddevice/ProviderHID.cpp
@@ -7,9 +7,9 @@
 #include <QTimer>
 
 // Local Hyperion includes
-#include "LedHIDDevice.h"
+#include "ProviderHID.h"
 
-LedHIDDevice::LedHIDDevice(const Json::Value &deviceConfig)
+ProviderHID::ProviderHID(const Json::Value &deviceConfig)
 	: _useFeature(false)
 	, _deviceHandle(nullptr)
 	, _blockedForDelay(false)
@@ -17,7 +17,7 @@ LedHIDDevice::LedHIDDevice(const Json::Value &deviceConfig)
 	setConfig(deviceConfig);
 }
 
-LedHIDDevice::~LedHIDDevice()
+ProviderHID::~ProviderHID()
 {
 	if (_deviceHandle != nullptr)
 	{
@@ -28,7 +28,7 @@ LedHIDDevice::~LedHIDDevice()
 	hid_exit();
 }
 
-bool LedHIDDevice::setConfig(const Json::Value &deviceConfig)
+bool ProviderHID::setConfig(const Json::Value &deviceConfig)
 {
 	_delayAfterConnect_ms = deviceConfig.get("delayAfterConnect", 0 ).asInt();
 	auto VendorIdString   = deviceConfig.get("VID", "0x2341").asString();
@@ -41,7 +41,7 @@ bool LedHIDDevice::setConfig(const Json::Value &deviceConfig)
 	return true;
 }
 
-int LedHIDDevice::open()
+int ProviderHID::open()
 {
 	// Initialize the usb context
 	int error = hid_init();
@@ -97,7 +97,7 @@ int LedHIDDevice::open()
 }
 
 
-int LedHIDDevice::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderHID::writeBytes(const unsigned size, const uint8_t * data)
 {
 	if (_blockedForDelay) {
 		return 0;
@@ -156,7 +156,7 @@ int LedHIDDevice::writeBytes(const unsigned size, const uint8_t * data)
 	return ret;
 }
 
-void LedHIDDevice::unblockAfterDelay()
+void ProviderHID::unblockAfterDelay()
 {
 	Debug(_log,"Device unblocked");
 	_blockedForDelay = false;

--- a/libsrc/leddevice/ProviderHID.h
+++ b/libsrc/leddevice/ProviderHID.h
@@ -9,9 +9,9 @@
 #include <leddevice/LedDevice.h>
 
 ///
-/// The LedHIDDevice implements an abstract base-class for LedDevices using an HID-device.
+/// The ProviderHID implements an abstract base-class for LedDevices using an HID-device.
 ///
-class LedHIDDevice : public LedDevice
+class ProviderHID : public LedDevice
 {
 	Q_OBJECT
 
@@ -21,12 +21,12 @@ public:
 	///
 	/// @param deviceConfig json device config
 	///
-	LedHIDDevice(const Json::Value &deviceConfig);
+	ProviderHID(const Json::Value &deviceConfig);
 
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
 	///
-	virtual ~LedHIDDevice();
+	virtual ~ProviderHID();
 
 	///
 	/// Sets configuration

--- a/libsrc/leddevice/ProviderRs232.cpp
+++ b/libsrc/leddevice/ProviderRs232.cpp
@@ -7,9 +7,9 @@
 #include <QTimer>
 
 // Local Hyperion includes
-#include "LedRs232Device.h"
+#include "ProviderRs232.h"
 
-LedRs232Device::LedRs232Device(const Json::Value &deviceConfig)
+ProviderRs232::ProviderRs232(const Json::Value &deviceConfig)
 	: _rs232Port(this)
 	, _blockedForDelay(false)
 	, _stateChanged(true)
@@ -18,7 +18,7 @@ LedRs232Device::LedRs232Device(const Json::Value &deviceConfig)
 	connect(&_rs232Port, SIGNAL(error(QSerialPort::SerialPortError)), this, SLOT(error(QSerialPort::SerialPortError)));
 }
 
-bool LedRs232Device::setConfig(const Json::Value &deviceConfig)
+bool ProviderRs232::setConfig(const Json::Value &deviceConfig)
 {
 	closeDevice();
 	_deviceName           = deviceConfig["output"].asString();
@@ -28,7 +28,7 @@ bool LedRs232Device::setConfig(const Json::Value &deviceConfig)
 	return true;
 }
 
-void LedRs232Device::error(QSerialPort::SerialPortError error)
+void ProviderRs232::error(QSerialPort::SerialPortError error)
 {
 	if ( error != QSerialPort::NoError )
 	{
@@ -64,13 +64,13 @@ void LedRs232Device::error(QSerialPort::SerialPortError error)
 	}
 }
 
-LedRs232Device::~LedRs232Device()
+ProviderRs232::~ProviderRs232()
 {
 	disconnect(&_rs232Port, SIGNAL(error(QSerialPort::SerialPortError)), this, SLOT(error(QSerialPort::SerialPortError)));
 	closeDevice();
 }
 
-void LedRs232Device::closeDevice()
+void ProviderRs232::closeDevice()
 {
 	if (_rs232Port.isOpen())
 	{
@@ -79,7 +79,7 @@ void LedRs232Device::closeDevice()
 	}
 }
 
-int LedRs232Device::open()
+int ProviderRs232::open()
 {
 	Info(_log, "Opening UART: %s", _deviceName.c_str());
 	_rs232Port.setPortName(_deviceName.c_str());
@@ -88,7 +88,7 @@ int LedRs232Device::open()
 }
 
 
-bool LedRs232Device::tryOpen()
+bool ProviderRs232::tryOpen()
 {
 	if ( ! _rs232Port.isOpen() )
 	{
@@ -116,7 +116,7 @@ bool LedRs232Device::tryOpen()
 }
 
 
-int LedRs232Device::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderRs232::writeBytes(const unsigned size, const uint8_t * data)
 {
 	if (_blockedForDelay)
 	{
@@ -143,7 +143,7 @@ int LedRs232Device::writeBytes(const unsigned size, const uint8_t * data)
 }
 
 
-void LedRs232Device::unblockAfterDelay()
+void ProviderRs232::unblockAfterDelay()
 {
 	Debug(_log, "Device unblocked");
 	_blockedForDelay = false;

--- a/libsrc/leddevice/ProviderRs232.h
+++ b/libsrc/leddevice/ProviderRs232.h
@@ -7,9 +7,9 @@
 #include <leddevice/LedDevice.h>
 
 ///
-/// The LedRs232Device implements an abstract base-class for LedDevices using a RS232-device.
+/// The ProviderRs232 implements an abstract base-class for LedDevices using a RS232-device.
 ///
-class LedRs232Device : public LedDevice
+class ProviderRs232 : public LedDevice
 {
 	Q_OBJECT
 
@@ -19,7 +19,7 @@ public:
 	///
 	/// @param deviceConfig json device config
 	///
-	LedRs232Device(const Json::Value &deviceConfig);
+	ProviderRs232(const Json::Value &deviceConfig);
 
 	///
 	/// Sets configuration
@@ -31,7 +31,7 @@ public:
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
 	///
-	virtual ~LedRs232Device();
+	virtual ~ProviderRs232();
 
 	///
 	/// Opens and configures the output device

--- a/libsrc/leddevice/ProviderSpi.cpp
+++ b/libsrc/leddevice/ProviderSpi.cpp
@@ -10,11 +10,11 @@
 #include <sys/ioctl.h>
 
 // Local Hyperion includes
-#include "LedSpiDevice.h"
+#include "ProviderSpi.h"
 #include <utils/Logger.h>
 
 
-LedSpiDevice::LedSpiDevice(const Json::Value &deviceConfig)
+ProviderSpi::ProviderSpi(const Json::Value &deviceConfig)
 	: LedDevice()
 	, _fid(-1)
 {
@@ -23,12 +23,12 @@ LedSpiDevice::LedSpiDevice(const Json::Value &deviceConfig)
 	Debug(_log, "_spiDataInvert %d,  _spiMode %d", _spiDataInvert, _spiMode);
 }
 
-LedSpiDevice::~LedSpiDevice()
+ProviderSpi::~ProviderSpi()
 {
 //	close(_fid);
 }
 
-bool LedSpiDevice::setConfig(const Json::Value &deviceConfig)
+bool ProviderSpi::setConfig(const Json::Value &deviceConfig)
 {
 	_deviceName    = deviceConfig.get("output","/dev/spidev0.0").asString();
 	_baudRate_Hz   = deviceConfig.get("rate",1000000).asInt();
@@ -39,7 +39,7 @@ bool LedSpiDevice::setConfig(const Json::Value &deviceConfig)
 	return true;
 }
 
-int LedSpiDevice::open()
+int ProviderSpi::open()
 {
 	const int bitsPerWord = 8;
 
@@ -69,7 +69,7 @@ int LedSpiDevice::open()
 	return 0;
 }
 
-int LedSpiDevice::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderSpi::writeBytes(const unsigned size, const uint8_t * data)
 {
 	if (_fid < 0)
 	{

--- a/libsrc/leddevice/ProviderSpi.h
+++ b/libsrc/leddevice/ProviderSpi.h
@@ -7,9 +7,9 @@
 #include <leddevice/LedDevice.h>
 
 ///
-/// The LedSpiDevice implements an abstract base-class for LedDevices using the SPI-device.
+/// The ProviderSpi implements an abstract base-class for LedDevices using the SPI-device.
 ///
-class LedSpiDevice : public LedDevice
+class ProviderSpi : public LedDevice
 {
 public:
 	///
@@ -17,7 +17,7 @@ public:
 	///
 	/// @param deviceConfig json device config
 	///
-	LedSpiDevice(const Json::Value &deviceConfig);
+	ProviderSpi(const Json::Value &deviceConfig);
 
 	///
 	/// Sets configuration
@@ -29,7 +29,7 @@ public:
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
 	///
-	virtual ~LedSpiDevice();
+	virtual ~ProviderSpi();
 
 	///
 	/// Opens and configures the output device

--- a/libsrc/leddevice/ProviderUdp.cpp
+++ b/libsrc/leddevice/ProviderUdp.cpp
@@ -13,9 +13,9 @@
 #include <QHostInfo>
 
 // Local Hyperion includes
-#include "LedUdpDevice.h"
+#include "ProviderUdp.h"
 
-LedUdpDevice::LedUdpDevice(const Json::Value &deviceConfig)
+ProviderUdp::ProviderUdp(const Json::Value &deviceConfig)
 	: LedDevice()
 	, _LatchTime_ns(-1)
 {
@@ -23,12 +23,12 @@ LedUdpDevice::LedUdpDevice(const Json::Value &deviceConfig)
 	_udpSocket = new QUdpSocket();
 }
 
-LedUdpDevice::~LedUdpDevice()
+ProviderUdp::~ProviderUdp()
 {
 	_udpSocket->close();
 }
 
-bool LedUdpDevice::setConfig(const Json::Value &deviceConfig)
+bool ProviderUdp::setConfig(const Json::Value &deviceConfig)
 {
 	if (_address.setAddress( QString::fromStdString(deviceConfig["host"].asString()) ) )
 	{
@@ -52,7 +52,7 @@ bool LedUdpDevice::setConfig(const Json::Value &deviceConfig)
 	return true;
 }
 
-int LedUdpDevice::open()
+int ProviderUdp::open()
 {
 	QHostAddress localAddress = QHostAddress::Any;
 	quint16      localPort = 0;
@@ -62,7 +62,7 @@ int LedUdpDevice::open()
 	return 0;
 }
 
-int LedUdpDevice::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderUdp::writeBytes(const unsigned size, const uint8_t * data)
 {
 
 	qint64 retVal = _udpSocket->writeDatagram((const char *)data,size,_address,_port);

--- a/libsrc/leddevice/ProviderUdp.h
+++ b/libsrc/leddevice/ProviderUdp.h
@@ -7,9 +7,9 @@
 #include <utils/Logger.h>
 
 ///
-/// The LedUdpDevice implements an abstract base-class for LedDevices using the SPI-device.
+/// The ProviderUdp implements an abstract base-class for LedDevices using the SPI-device.
 ///
-class LedUdpDevice : public LedDevice
+class ProviderUdp : public LedDevice
 {
 public:
 	///
@@ -17,12 +17,12 @@ public:
 	///
 	/// @param deviceConfig json device config
 	///
-	LedUdpDevice(const Json::Value &deviceConfig);
+	ProviderUdp(const Json::Value &deviceConfig);
 
 	///
 	/// Destructor of the LedDevice; closes the output device if it is open
 	///
-	virtual ~LedUdpDevice();
+	virtual ~ProviderUdp();
 
 	///
 	/// Sets configuration


### PR DESCRIPTION
**1.** Tell us something about your changes.
The low level providers are not led devices in their own right 

**2.** If this changes affect the .conf file. Please provide the changed section
Nope 

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

Here's how I did it - nearly automated...
vi `grep -l LedUdp *`
%s/LedUdpDevice/ProviderUdp/g
git mv LedUdpDevice.cpp ProviderUdp.cpp
git mv LedUdpDevice.h ProviderUdp.h

vi `grep -l LedHID *`
%s/LedHIDDevice/ProviderHID/g
git mv LedHIDDevice.cpp ProviderHID.cpp
git mv LedHIDDevice.h ProviderHID.h

vi `grep -l LedRs *`
%s/LedRs232Device/ProviderRs232/g
git mv LedRs232Device.cpp ProviderRs232.cpp
git mv LedRs232Device.h ProviderRs232.h

vi `grep -l LedSpi *`
%s/LedSpiDevice/ProviderSpi/g
git mv LedSpiDevice.cpp ProviderSpi.cpp
git mv LedSpiDevice.h ProviderSpi.h