### PR TITLE
Added source-name and cid to e1.31 driver.

### DIFF
--- a/libsrc/leddevice/LedDeviceUdpE131.h
+++ b/libsrc/leddevice/LedDeviceUdpE131.h
@@ -6,6 +6,8 @@
 // hyperion includes
 #include "ProviderUdp.h"
 
+#include <QUuid>
+
 /*
 *
 * https://raw.githubusercontent.com/forkineye/ESPixelStick/master/_E131.h
@@ -55,12 +57,12 @@ typedef union {
         uint8_t  acn_id[12];
         uint16_t root_flength;
         uint32_t root_vector;
-        uint8_t  cid[16];
+        char     cid[16];
 
         /* Frame Layer */
         uint16_t frame_flength;
         uint32_t frame_vector;
-        uint8_t  source_name[64];
+        char     source_name[64];
         uint8_t  priority;
         uint16_t reserved;
         uint8_t  sequence_number;
@@ -135,4 +137,6 @@ private:
 	uint8_t	_e131_seq = 0;
 	uint8_t	_e131_universe = 1;
         uint8_t _acn_id[12] = {0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00 };
+	std::string _e131_source_name;
+	QUuid _e131_cid;
 };


### PR DESCRIPTION
**1.** Tell us something about your changes.
- source-name defaults to "hyperion on <hostname>"
- cid defautls to randomly generated on each startup
- if cid is unparsable, falls back to  {00000000-0000-0000-0000-000000000000}

**2.** If this changes affect the .conf file. Please provide the changed section
```
        "device" :
        {
                "name"       : "DMX_e131",
                "type"       : "e131",
                "universe"   : 1,
                "cid" : "{7204b83c-efb5-4b23-b2d0-35939d561061}",
                "source-name": "This is my custom e1.31 source",
                "host"       : "239.255.0.1",
                "port"       : 5568,
                "colorOrder" : "rgb"
        },
```
**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


