### PR TITLE
multiple v4l devices.

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -168,25 +168,27 @@
 	///  * greenSignalThreshold : Signal threshold for the green channel between 0.0 and 1.0 [default=0.0]
 	///  * blueSignalThreshold  : Signal threshold for the blue channel between 0.0 and 1.0 [default=0.0]
 	"grabber-v4l2" :
-	{
-		"enable"               : false,
-		"device"               : "/dev/video0",
-		"input"                : 0,
-		"standard"             : "no-change",
-		"width"                : -1,
-		"height"               : -1,
-		"frameDecimation"      : 2,
-		"sizeDecimation"       : 8,
-		"priority"             : 890,
-		"mode"                 : "2D",
-		"cropLeft"             : 0,
-		"cropRight"            : 0,
-		"cropTop"              : 0,
-		"cropBottom"           : 0,
-		"redSignalThreshold"   : 0.0,
-		"greenSignalThreshold" : 0.0,
-		"blueSignalThreshold"  : 0.0
-	},
+	[
+		{
+			"enable"   : false,
+			"device"   : "auto",
+			"input"    : 0,
+			"standard" : "PAL",
+			"width"    : -1,
+			"height"   : -1,
+			"frameDecimation" : 2,
+			"sizeDecimation"  : 8,
+			"priority"    : 890,
+			"mode"        : "2D",
+			"cropLeft"    : 0,
+			"cropRight"   : 0,
+			"cropTop"     : 0,
+			"cropBottom"  : 0,
+			"redSignalThreshold"   : 0.0,
+			"greenSignalThreshold" : 0.0,
+			"blueSignalThreshold"  : 0.0
+		}
+	]
 
 	///  The configuration for the frame-grabber, contains the following items: 
 	///   * enable       : true if the framegrabber (platform grabber) should be activated

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -188,7 +188,7 @@
 			"greenSignalThreshold" : 0.0,
 			"blueSignalThreshold"  : 0.0
 		}
-	]
+	],
 
 	///  The configuration for the frame-grabber, contains the following items: 
 	///   * enable       : true if the framegrabber (platform grabber) should be activated

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -117,7 +117,7 @@
 			"greenSignalThreshold" : 0.0,
 			"blueSignalThreshold"  : 0.0
 		}
-	]
+	],
 
 	"framegrabber" :
 	{

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -97,25 +97,27 @@
 	},
 
 	"grabber-v4l2" :
-	{
-		"enable"   : false,
-		"device"   : "auto",
-		"input"    : 0,
-		"standard" : "PAL",
-		"width"    : -1,
-		"height"   : -1,
-		"frameDecimation" : 2,
-		"sizeDecimation"  : 8,
-		"priority"    : 890,
-		"mode"        : "2D",
-		"cropLeft"    : 0,
-		"cropRight"   : 0,
-		"cropTop"     : 0,
-		"cropBottom"  : 0,
-		"redSignalThreshold"   : 0.0,
-		"greenSignalThreshold" : 0.0,
-		"blueSignalThreshold"  : 0.0
-	},
+	[
+		{
+			"enable"   : false,
+			"device"   : "auto",
+			"input"    : 0,
+			"standard" : "PAL",
+			"width"    : -1,
+			"height"   : -1,
+			"frameDecimation" : 2,
+			"sizeDecimation"  : 8,
+			"priority"    : 890,
+			"mode"        : "2D",
+			"cropLeft"    : 0,
+			"cropRight"   : 0,
+			"cropTop"     : 0,
+			"cropBottom"  : 0,
+			"redSignalThreshold"   : 0.0,
+			"greenSignalThreshold" : 0.0,
+			"blueSignalThreshold"  : 0.0
+		}
+	]
 
 	"framegrabber" :
 	{

--- a/include/hyperion/GrabberWrapper.h
+++ b/include/hyperion/GrabberWrapper.h
@@ -15,7 +15,7 @@ class GrabberWrapper : public QObject
 {
 	Q_OBJECT
 public: 
-	GrabberWrapper(std::string grabberName, const int priority);
+	GrabberWrapper(std::string grabberName, const int priority, hyperion::Components grabberComponentId=hyperion::COMP_GRABBER);
 	
 	virtual ~GrabberWrapper();
 	
@@ -72,4 +72,5 @@ protected:
 	/// The processor for transforming images to led colors
 	ImageProcessor * _processor;
 
+	hyperion::Components _grabberComponentId;
 };

--- a/include/utils/Components.h
+++ b/include/utils/Components.h
@@ -15,7 +15,8 @@ enum Components
 	COMP_FORWARDER,
 	COMP_UDPLISTENER,
 	COMP_BOBLIGHTSERVER,
-	COMP_GRABBER
+	COMP_GRABBER,
+	COMP_V4L
 };
 
 inline const char* componentToString(Components c)
@@ -29,6 +30,7 @@ inline const char* componentToString(Components c)
 		case COMP_UDPLISTENER:   return "UDP listener";
 		case COMP_BOBLIGHTSERVER:return "Boblight server";
 		case COMP_GRABBER:       return "Framegrabber";
+		case COMP_V4L:           return "V4l Capture device";
 		default:                 return "";
 	}
 }
@@ -43,6 +45,7 @@ inline  Components stringToComponent(QString component)
 	if (component == "UDPLISTENER")   return COMP_UDPLISTENER;
 	if (component == "BOBLIGHTSERVER")return COMP_BOBLIGHTSERVER;
 	if (component == "GRABBER")       return COMP_GRABBER;
+	if (component == "V4L")           return COMP_V4L;
 
 	return COMP_INVALID;
 }

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -50,7 +50,7 @@ V4L2Grabber::V4L2Grabber(const std::string & device,
 	, _noSignalCounter(0)
 	, _streamNotifier(nullptr)
 	, _imageResampler()
-	, _log(Logger::getInstance("V4L2"))
+	, _log(Logger::getInstance("V4L2:"+device))
 	, _initialized(false)
 	, _deviceAutoDiscoverEnabled(false)
 {

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -16,7 +16,7 @@ V4L2Wrapper::V4L2Wrapper(const std::string &device,
 		double greenSignalThreshold,
 		double blueSignalThreshold,
 		const int priority)
-	: GrabberWrapper("V4L2", priority)
+	: GrabberWrapper("V4L2:"+device, priority)
 	, _timeout_ms(1000)
 	, _grabber(device,
 			input,

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -16,7 +16,7 @@ V4L2Wrapper::V4L2Wrapper(const std::string &device,
 		double greenSignalThreshold,
 		double blueSignalThreshold,
 		const int priority)
-	: GrabberWrapper("V4L2:"+device, priority)
+	: GrabberWrapper("V4L2:"+device, priority, hyperion::COMP_V4L)
 	, _timeout_ms(1000)
 	, _grabber(device,
 			input,

--- a/libsrc/hyperion/GrabberWrapper.cpp
+++ b/libsrc/hyperion/GrabberWrapper.cpp
@@ -4,7 +4,7 @@
 #include <hyperion/GrabberWrapper.h>
 
 
-GrabberWrapper::GrabberWrapper(std::string grabberName, const int priority)
+GrabberWrapper::GrabberWrapper(std::string grabberName, const int priority, hyperion::Components grabberComponentId)
 	: _grabberName(grabberName)
 	, _hyperion(Hyperion::getInstance())
 	, _priority(priority)
@@ -12,6 +12,7 @@ GrabberWrapper::GrabberWrapper(std::string grabberName, const int priority)
 	, _log(Logger::getInstance(grabberName.c_str()))
 	, _forward(true)
 	, _processor(ImageProcessorFactory::getInstance().newImageProcessor())
+	, _grabberComponentId(grabberComponentId)
 {
 	_timer.setSingleShot(false);
 
@@ -44,7 +45,7 @@ void GrabberWrapper::stop()
 
 void GrabberWrapper::componentStateChanged(const hyperion::Components component, bool enable)
 {
-	if (component == hyperion::COMP_GRABBER && _timer.isActive() != enable)
+	if (component == _grabberComponentId && _timer.isActive() != enable)
 	{
 		if (enable) start();
 		else        stop();

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -399,83 +399,87 @@
 		},
 		"grabber-v4l2" :
 		{
-			"type" : "object",
-			"properties" :
+			"type":"array",
+			"items":
 			{
-				"enable" :
+				"type" : "object",
+				"properties" :
 				{
-					"type" : "boolean"
+					"enable" :
+					{
+						"type" : "boolean"
+					},
+					"device" :
+					{
+						"type" : "string"
+					},
+					"input" :
+					{
+						"type" : "integer"
+					},
+					"standard" :
+					{
+						"type" : "string"
+					},
+					"width" :
+					{
+						"type" : "integer"
+					},
+					"height" :
+					{
+						"type" : "integer"
+					},
+					"frameDecimation" :
+					{
+						"type" : "integer"
+					},
+					"sizeDecimation" :
+					{
+						"type" : "integer"
+					},
+					"priority" :
+					{
+						"type" : "integer"
+					},
+					"mode" :
+					{
+						"type" : "string"
+					},
+					"useKodiChecker" :
+					{
+						"type" : "boolean"
+					},
+					"cropLeft" :
+					{
+						"type" : "integer"
+					},
+					"cropRight" :
+					{
+						"type" : "integer"
+					},
+					"cropTop" :
+					{
+						"type" : "integer"
+					},
+					"cropBottom" :
+					{
+						"type" : "integer"
+					},
+					"redSignalThreshold" :
+					{
+						"type" : "number"
+					},
+					"greenSignalThreshold" :
+					{
+						"type" : "number"
+					},
+					"blueSignalThreshold" :
+					{
+						"type" : "number"
+					}
 				},
-				"device" :
-				{
-					"type" : "string"
-				},
-				"input" :
-				{
-					"type" : "integer"
-				},
-				"standard" :
-				{
-					"type" : "string"
-				},
-				"width" :
-				{
-					"type" : "integer"
-				},
-				"height" :
-				{
-					"type" : "integer"
-				},
-				"frameDecimation" :
-				{
-					"type" : "integer"
-				},
-				"sizeDecimation" :
-				{
-					"type" : "integer"
-				},
-				"priority" :
-				{
-					"type" : "integer"
-				},
-				"mode" :
-				{
-					"type" : "string"
-				},
-				"useKodiChecker" :
-				{
-					"type" : "boolean"
-				},
-				"cropLeft" :
-				{
-					"type" : "integer"
-				},
-				"cropRight" :
-				{
-					"type" : "integer"
-				},
-				"cropTop" :
-				{
-					"type" : "integer"
-				},
-				"cropBottom" :
-				{
-					"type" : "integer"
-				},
-				"redSignalThreshold" :
-				{
-					"type" : "number"
-				},
-				"greenSignalThreshold" :
-				{
-					"type" : "number"
-				},
-				"blueSignalThreshold" :
-				{
-					"type" : "number"
-				}
-			},
 			"additionalProperties" : false
+			}
 		},
 		"framegrabber" :
 		{

--- a/libsrc/jsonserver/schema/schema-componentstate.json
+++ b/libsrc/jsonserver/schema/schema-componentstate.json
@@ -21,7 +21,7 @@
 				"component":
 				{
 					"type" : "string",
-					"enum" : ["SMOOTHING", "BLACKBORDER", "KODICHECKER", "FORWARDER", "UDPLISTENER", "BOBLIGHTSERVER", "GRABBER"],
+					"enum" : ["SMOOTHING", "BLACKBORDER", "KODICHECKER", "FORWARDER", "UDPLISTENER", "BOBLIGHTSERVER", "GRABBER", "V4L"],
 					"required": true
 				},
 				"state":

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -65,8 +65,8 @@ int main(int argc, char * argv[])
 		BooleanOption  	& argServerInfo  = parser.add<BooleanOption> ('l', "list"      , "List server info and active effects with priority and duration");
 		BooleanOption  	& argClear       = parser.add<BooleanOption> ('x', "clear"     , "Clear data for the priority channel provided by the -p option");
 		BooleanOption  	& argClearAll    = parser.add<BooleanOption> (0x0, "clearall"  , "Clear data for all active priority channels");
-		Option          & argEnableComponent  = parser.add<Option>   ('E', "enable"    , "Enable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]");
-		Option          & argDisableComponent = parser.add<Option>   ('D', "disable"    , "Disable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER]");
+		Option          & argEnableComponent  = parser.add<Option>   ('E', "enable"    , "Enable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER, V4L]");
+		Option          & argDisableComponent = parser.add<Option>   ('D', "disable"    , "Disable the Component with the given name. Available Components are [SMOOTHING, BLACKBORDER, KODICHECKER, FORWARDER, UDPLISTENER, BOBLIGHT_SERVER, GRABBER, V4L]");
 		Option          & argId          = parser.add<Option>   ('q', "qualifier" , "Identifier(qualifier) of the transform to set");
 		DoubleOption    & argSaturation  = parser.add<DoubleOption>   ('s', "saturation", "!DEPRECATED! Will be removed soon! Set the HSV saturation gain of the leds");
 		DoubleOption    & argValue       = parser.add<DoubleOption>   ('v', "getColors"     , "!DEPRECATED! Will be removed soon! Set the HSV getColors gain of the leds");

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -41,7 +41,7 @@ HyperionDaemon::HyperionDaemon(QString configFile, QObject *parent)
 	, _protoServer(nullptr)
 	, _boblightServer(nullptr)
 	, _udpListener(nullptr)
-	, _v4l2Grabber(nullptr)
+	, _v4l2Grabbers()
 	, _dispmanx(nullptr)
 #ifdef ENABLE_X11
 	, _x11Grabber(nullptr)
@@ -83,7 +83,10 @@ HyperionDaemon::~HyperionDaemon()
 	delete _dispmanx;
 	delete _fbGrabber;
 	delete _osxGrabber;
-	delete _v4l2Grabber;
+	for(V4L2Wrapper* grabber : _v4l2Grabbers)
+	{
+		delete grabber;
+	}
 	delete _kodiVideoChecker;
 	delete _jsonServer;
 	delete _protoServer;
@@ -538,39 +541,52 @@ void HyperionDaemon::createGrabberV4L2()
 {
 	// construct and start the v4l2 grabber if the configuration is present
 	bool v4lConfigured = _qconfig.contains("grabber-v4l2");
-	const QJsonObject & grabberConfig = _qconfig["grabber-v4l2"].toObject();
-	bool enableV4l = v4lConfigured && grabberConfig["enable"].toBool(true);
-
-#ifdef ENABLE_V4L2
-	_v4l2Grabber = new V4L2Wrapper(
-		grabberConfig["device"].toString("auto").toStdString(),
-		grabberConfig["input"].toInt(0),
-		parseVideoStandard(grabberConfig["standard"].toString("no-change").toStdString()),
-		parsePixelFormat(grabberConfig["pixelFormat"].toString("no-change").toStdString()),
-		grabberConfig["width"].toInt(-1),
-		grabberConfig["height"].toInt(-1),
-		grabberConfig["frameDecimation"].toInt(2),
-		grabberConfig["sizeDecimation"].toInt(8),
-		grabberConfig["redSignalThreshold"].toDouble(0.0),
-		grabberConfig["greenSignalThreshold"].toDouble(0.0),
-		grabberConfig["blueSignalThreshold"].toDouble(0.0),
-		grabberConfig["priority"].toInt(890));
-	_v4l2Grabber->set3D(parse3DMode(grabberConfig["mode"].toString("2D").toStdString()));
-	_v4l2Grabber->setCropping(
-		grabberConfig["cropLeft"].toInt(0),
-		grabberConfig["cropRight"].toInt(0),
-		grabberConfig["cropTop"].toInt(0),
-		grabberConfig["cropBottom"].toInt(0));
-	Debug(_log, "V4L2 grabber created");
-
-	QObject::connect(_v4l2Grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)));
-	if (grabberConfig["useKodiChecker"].toBool(false))
+	unsigned v4lEnableCount = 0;
+	
+	if (_qconfig["grabber-v4l2"].isArray())
 	{
-		QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), _v4l2Grabber, SLOT(setGrabbingMode(GrabbingMode)));
-	}
-	InfoIf( enableV4l && _v4l2Grabber->start(), _log, "V4L2 grabber started");
-#endif
+		const QJsonArray & v4lArray = _qconfig["grabber-v4l2"].toArray();
+		for ( signed idx=0; idx<v4lArray.size(); idx++)
+		{
+			const QJsonObject & grabberConfig = v4lArray.at(idx).toObject();
+			bool enableV4l = v4lConfigured && grabberConfig["enable"].toBool(true);
+			if (enableV4l)
+			{
+				v4lEnableCount++;
+			}
+			#ifdef ENABLE_V4L2
+			V4L2Wrapper* grabber = new V4L2Wrapper(
+				grabberConfig["device"].toString("auto").toStdString(),
+				grabberConfig["input"].toInt(0),
+				parseVideoStandard(grabberConfig["standard"].toString("no-change").toStdString()),
+				parsePixelFormat(grabberConfig["pixelFormat"].toString("no-change").toStdString()),
+				grabberConfig["width"].toInt(-1),
+				grabberConfig["height"].toInt(-1),
+				grabberConfig["frameDecimation"].toInt(2),
+				grabberConfig["sizeDecimation"].toInt(8),
+				grabberConfig["redSignalThreshold"].toDouble(0.0),
+				grabberConfig["greenSignalThreshold"].toDouble(0.0),
+				grabberConfig["blueSignalThreshold"].toDouble(0.0),
+				grabberConfig["priority"].toInt(890));
+			grabber->set3D(parse3DMode(grabberConfig["mode"].toString("2D").toStdString()));
+			grabber->setCropping(
+				grabberConfig["cropLeft"].toInt(0),
+				grabberConfig["cropRight"].toInt(0),
+				grabberConfig["cropTop"].toInt(0),
+				grabberConfig["cropBottom"].toInt(0));
+			Debug(_log, "V4L2 grabber created");
 
-	ErrorIf(enableV4l && _v4l2Grabber==nullptr, _log, "The v4l2 grabber can not be instantiated, because it has been left out from the build");
+			QObject::connect(grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)));
+			if (grabberConfig["useKodiChecker"].toBool(false))
+			{
+				QObject::connect(_kodiVideoChecker, SIGNAL(grabbingMode(GrabbingMode)), grabber, SLOT(setGrabbingMode(GrabbingMode)));
+			}
+			InfoIf( enableV4l && grabber->start(), _log, "V4L2 grabber started");
+			_v4l2Grabbers.push_back(grabber);
+			#endif
+		}
+	}
+
+	ErrorIf( (v4lEnableCount>0 && _v4l2Grabbers.size()==0), _log, "The v4l2 grabber can not be instantiated, because it has been left out from the build");
 
 }

--- a/src/hyperiond/hyperiond.h
+++ b/src/hyperiond/hyperiond.h
@@ -79,7 +79,7 @@ private:
 	ProtoServer*        _protoServer;
 	BoblightServer*     _boblightServer;
 	UDPListener*        _udpListener;
-	V4L2Wrapper*        _v4l2Grabber;
+	std::vector<V4L2Wrapper*>  _v4l2Grabbers;
 	DispmanxWrapper*    _dispmanx;
 #ifdef ENABLE_X11
 	X11Wrapper*         _x11Grabber;


### PR DESCRIPTION
**1.** Tell us something about your changes.
now it is possible to use multiple v4l devices.
Attention:
Not all v4l devices are compat with that or must be attaches to different usb controller.
see: http://superuser.com/questions/431759/using-multiple-usb-webcams-in-linux#433237

additional:
split component GRABBER and V4L (#204)

**2.** If this changes affect the .conf file. Please provide the changed section
yes, v4l-grabber is now an array. You can add multiple device blocks ... see default config

my config:
```
	"grabber-v4l2" : 
	[
		{
			"enable" : true,
			"device" : "usbtv",
			"input" : 0,
			"standard" : "PAL",
			"width" : -1,
			"height" : -1,
			"frameDecimation" : 2,
			"sizeDecimation" : 8,
			"priority" : 890,
			"mode" : "2D",
			"cropLeft" : 15,
			"cropRight" : 12,
			"cropTop" : 10,
			"cropBottom" : 10,
			"redSignalThreshold" : 0.1,
			"greenSignalThreshold" : 0.1,
			"blueSignalThreshold" : 1.0
		},
		{
			"enable" : true,
			"device" : "USB2.0 Camera",
			"input" : 0,
//			"standard" : "PAL",
			"width" : -1,
			"height" : -1,
			"frameDecimation" : 2,
			"sizeDecimation" : 8,
			"priority" : 889,
			"mode" : "2D",
			"cropLeft" : 15,
			"cropRight" : 12,
			"cropTop" : 10,
			"cropBottom" : 10,
			"redSignalThreshold" : 0.1,
			"greenSignalThreshold" : 0.1,
			"blueSignalThreshold" : 0.1
		}
	],
```
Keep attention on prio, this must be set carefully. It is also wise to set thresholds. 

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

