### PR TITLE
Added debug logging to ProviderSpi.cpp on writes.

### DIFF
--- a/libsrc/leddevice/ProviderSpi.cpp
+++ b/libsrc/leddevice/ProviderSpi.cpp
@@ -89,6 +89,7 @@ int ProviderSpi::writeBytes(const unsigned size, const uint8_t * data)
 	}
 
 	int retVal = ioctl(_fid, SPI_IOC_MESSAGE(1), &_spi);
+	DebugIf((retVal < 0), _log, "SPI failed to write. errno: %d, %s", errno,  strerror(errno) );
 
 	if (retVal == 0 && _latchTime_ns > 0)
 	{

--- a/libsrc/leddevice/ProviderSpi.cpp
+++ b/libsrc/leddevice/ProviderSpi.cpp
@@ -89,7 +89,7 @@ int ProviderSpi::writeBytes(const unsigned size, const uint8_t * data)
 	}
 
 	int retVal = ioctl(_fid, SPI_IOC_MESSAGE(1), &_spi);
-	DebugIf((retVal < 0), _log, "SPI failed to write. errno: %d, %s", errno,  strerror(errno) );
+	ErrorIf((retVal < 0), _log, "SPI failed to write. errno: %d, %s", errno,  strerror(errno) );
 
 	if (retVal == 0 && _latchTime_ns > 0)
 	{


### PR DESCRIPTION
**1.** Tell us something about your changes.
If you have more leds configured than the SPI buffer can support you now get this:
[HYPERIOND LedDevice] <DEBUG> <ProviderSpi.cpp:92:writeBytes()> SPI failed to write. errno: 90, Message too long

**2.** If this changes affect the .conf file. Please provide the changed section
nope

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

