### PR TITLE
Ws2812spi and sk6812rgbw have wrong default rate

### DIFF
--- a/libsrc/leddevice/LedDeviceSk6812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.cpp
@@ -33,7 +33,13 @@ LedDevice* LedDeviceSk6812SPI::construct(const Json::Value &deviceConfig)
 bool LedDeviceSk6812SPI::setConfig(const Json::Value &deviceConfig)
 {
 	ProviderSpi::setConfig(deviceConfig);
-        _baudRate_Hz   = deviceConfig.get("rate",2800000).asInt();
+
+        _baudRate_Hz   = deviceConfig.get("rate",3000000).asInt();
+	if ( (_baudRate_Hz < 2050000) || (_baudRate_Hz > 4000000) )
+	{
+		Warning(_log, "SPI rate %d outside recommended range (2050000 -> 4000000)", _baudRate_Hz);
+	}
+
 	_whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
 
 	return true;

--- a/libsrc/leddevice/LedDeviceSk6812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceSk6812SPI.cpp
@@ -33,6 +33,7 @@ LedDevice* LedDeviceSk6812SPI::construct(const Json::Value &deviceConfig)
 bool LedDeviceSk6812SPI::setConfig(const Json::Value &deviceConfig)
 {
 	ProviderSpi::setConfig(deviceConfig);
+        _baudRate_Hz   = deviceConfig.get("rate",2800000).asInt();
 	_whiteAlgorithm = deviceConfig.get("white_algorithm","").asString();
 
 	return true;

--- a/libsrc/leddevice/LedDeviceWs2812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.cpp
@@ -33,8 +33,12 @@ LedDevice* LedDeviceWs2812SPI::construct(const Json::Value &deviceConfig)
 bool LedDeviceWs2812SPI::setConfig(const Json::Value &deviceConfig)
 {
         ProviderSpi::setConfig(deviceConfig);
-        _baudRate_Hz   = deviceConfig.get("rate",2800000).asInt();
 
+        _baudRate_Hz   = deviceConfig.get("rate",3000000).asInt();
+	if ( (_baudRate_Hz < 2050000) || (_baudRate_Hz > 4000000) )
+	{
+		Warning(_log, "SPI rate %d outside recommended range (2050000 -> 4000000)", _baudRate_Hz);
+	}
         return true;
 }
 

--- a/libsrc/leddevice/LedDeviceWs2812SPI.cpp
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.cpp
@@ -19,12 +19,23 @@ LedDeviceWs2812SPI::LedDeviceWs2812SPI(const Json::Value &deviceConfig)
 		0b11001000,
 		0b11001100,
 	}
+
 {
+	setConfig(deviceConfig);
+
 }
 
 LedDevice* LedDeviceWs2812SPI::construct(const Json::Value &deviceConfig)
 {
 	return new LedDeviceWs2812SPI(deviceConfig);
+}
+
+bool LedDeviceWs2812SPI::setConfig(const Json::Value &deviceConfig)
+{
+        ProviderSpi::setConfig(deviceConfig);
+        _baudRate_Hz   = deviceConfig.get("rate",2800000).asInt();
+
+        return true;
 }
 
 int LedDeviceWs2812SPI::write(const std::vector<ColorRgb> &ledValues)

--- a/libsrc/leddevice/LedDeviceWs2812SPI.h
+++ b/libsrc/leddevice/LedDeviceWs2812SPI.h
@@ -22,6 +22,13 @@ public:
 	/// constructs leddevice
 	static LedDevice* construct(const Json::Value &deviceConfig);
 
+        ///
+        /// Sets configuration
+        ///
+        /// @param deviceConfig the json device config
+        /// @return true if success
+        bool setConfig(const Json::Value &deviceConfig);
+
 	///
 	/// Writes the led color values to the led-device
 	///

--- a/libsrc/leddevice/ProviderSpi.cpp
+++ b/libsrc/leddevice/ProviderSpi.cpp
@@ -20,7 +20,6 @@ ProviderSpi::ProviderSpi(const Json::Value &deviceConfig)
 {
 	setConfig(deviceConfig);
 	memset(&_spi, 0, sizeof(_spi));
-	Debug(_log, "_spiDataInvert %d,  _spiMode %d", _spiDataInvert, _spiMode);
 }
 
 ProviderSpi::~ProviderSpi()
@@ -41,6 +40,9 @@ bool ProviderSpi::setConfig(const Json::Value &deviceConfig)
 
 int ProviderSpi::open()
 {
+	Debug(_log, "_baudRate_Hz %d,  _latchTime_ns %d", _baudRate_Hz, _latchTime_ns);
+	Debug(_log, "_spiDataInvert %d,  _spiMode %d", _spiDataInvert, _spiMode);
+
 	const int bitsPerWord = 8;
 
 	_fid = ::open(_deviceName.c_str(), O_RDWR);

--- a/libsrc/leddevice/schemas/schema-sk6812rgbw-spi.json
+++ b/libsrc/leddevice/schemas/schema-sk6812rgbw-spi.json
@@ -10,7 +10,7 @@
 		"rate": {
 			"type": "integer",
 			"title":"Baudrate",
-			"default": 1000000
+			"default": 2666666
 		},
 		"invert": {
 			"type": "boolean",

--- a/libsrc/leddevice/schemas/schema-ws2812spi.json
+++ b/libsrc/leddevice/schemas/schema-ws2812spi.json
@@ -10,7 +10,7 @@
 		"rate": {
 			"type": "integer",
 			"title":"Baudrate",
-			"default": 1000000
+			"default": 2666666
 		},
 		"invert": {
 			"type": "boolean",


### PR DESCRIPTION
**1.** Tell us something about your changes.
now sets the default baud_rate speed to 3000000 if omitted.
Previously it used the ProviderSPI default which was 1000000 and guaranteed not to work
Added warnings if the SPI baud rate is likely out of range
Added some debug statements to ProviderSpi

**2.** If this changes affect the .conf file. Please provide the changed section
nope

**3.** Reference an issue (optional)
#216

Note: For further discussions use our forum: forum.hyperion-project.org

