### PR TITLE
make shared libs work again

### DIFF
--- a/libsrc/hyperion/CMakeLists.txt
+++ b/libsrc/hyperion/CMakeLists.txt
@@ -58,10 +58,8 @@ add_library(hyperion
 )
 
 target_link_libraries(hyperion
-	kodivideochecker
 	blackborder
 	hyperion-utils
 	leddevice
-	effectengine
 	${QT_LIBRARIES}
 )

--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-    commandline
+	effectengine
+	commandline
 	blackborder
 	hyperion-utils
 	protoserver

--- a/src/hyperion-dispmanx/CMakeLists.txt
+++ b/src/hyperion-dispmanx/CMakeLists.txt
@@ -31,7 +31,8 @@ add_executable( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-    commandline
+	effectengine
+	commandline
 	blackborder
 	hyperion-utils
 	protoserver

--- a/src/hyperion-framebuffer/CMakeLists.txt
+++ b/src/hyperion-framebuffer/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-    commandline
+	effectengine
+	commandline
 	blackborder
 	hyperion-utils
 	protoserver

--- a/src/hyperion-osx/CMakeLists.txt
+++ b/src/hyperion-osx/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-    commandline
+	effectengine
+	commandline
 	blackborder
 	hyperion-utils
 	protoserver

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -26,7 +26,8 @@ add_executable(${PROJECT_NAME}
 	${hyperion-remote_SOURCES})
 
 target_link_libraries(${PROJECT_NAME}
-    commandline
+	effectengine
+	commandline
 	jsoncpp
 	${QT_LIBRARIES})
 

--- a/src/hyperion-v4l2/CMakeLists.txt
+++ b/src/hyperion-v4l2/CMakeLists.txt
@@ -32,8 +32,9 @@ add_executable(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
+	effectengine
 	v4l2-grabber
-    commandline
+	commandline
 	blackborder
 	hyperion-utils
 	protoserver

--- a/src/hyperion-x11/CMakeLists.txt
+++ b/src/hyperion-x11/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
+	effectengine
 	blackborder
 	commandline
 	hyperion-utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(../libsrc)
 if(ENABLE_SPIDEV)
 	# Add the simple test executable 'TestSpi'
 	add_executable(test_spi TestSpi.cpp)
-	target_link_libraries(test_spi hyperion)
+	target_link_libraries(test_spi hyperion effectengine)
 
 	add_executable(spidev_test spidev_test.c)
 
@@ -14,7 +14,9 @@ endif(ENABLE_SPIDEV)
 add_executable(test_configfile
 		TestConfigFile.cpp)
 target_link_libraries(test_configfile
-		hyperion)
+		hyperion
+		effectengine
+		)
 
 add_executable(test_ImageRgb
 		TestRgbImage.cpp)
@@ -24,24 +26,32 @@ target_link_libraries(test_ImageRgb
 add_executable(test_colortransform
 	TestColorTransform.cpp)
 target_link_libraries(test_colortransform
-	hyperion)
+	hyperion
+	effectengine
+)
 
 add_executable(test_image2ledsmap
 		TestImage2LedsMap.cpp)
 target_link_libraries(test_image2ledsmap
-		hyperion)
+		hyperion
+		effectengine
+		)
 
 if (ENABLE_DISPMANX)
 	add_subdirectory(dispmanx2png)
 endif (ENABLE_DISPMANX)
 
 add_executable(test_blackborderdetector TestBlackBorderDetector.cpp)
-target_link_libraries(test_blackborderdetector hyperion)
+target_link_libraries(test_blackborderdetector
+		effectengine
+ hyperion)
 
 add_executable(test_blackborderprocessor
 		TestBlackBorderProcessor.cpp)
 target_link_libraries(test_blackborderprocessor
-		hyperion)
+		hyperion
+		effectengine
+)
 
 add_executable(test_qregexp TestQRegExp.cpp)
 target_link_libraries(test_qregexp


### PR DESCRIPTION
**1.** Tell us something about your changes.
resolve cyclic dependencies between hyperion modules. Now we can compile as shared libs (again).
This is needed preparation for dynamicly load (dlopen) grabbers or other components.

```
cd build
cmake -DBUILD_SHARED_LIBS=ON ..
make -j$(nproc)
export LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH"
bin/hyperiond --debug path_to_my_config.json
```

generated libs (for platform x86-dev):
```
libamlogic-grabber.so
libblackborder.so
libboblightserver.so
libbonjour.so
libcommandline.so
libeffectengine.so
libframebuffer-grabber.so
libhidapi-libusb.so
libhyperion.so
libhyperion-utils.so
libjsoncpp.so
libjsonserver.so
libkodivideochecker.so
libleddevice.so
libprotobuf-lite.so
libprotobuf.so
libprotoc_lib.so
libprotoserver.so
libtinkerforge.so
libudplistener.so
libv4l2-grabber.so
libwebconfig.so
libws281x.so
libx11-grabber.so
```



**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)
somehow related to #122 

Note: For further discussions use our forum: forum.hyperion-project.org


