### PR TITLE
embedded webui + config modification detection

### DIFF
--- a/assets/webconfig/css/hyperion.css
+++ b/assets/webconfig/css/hyperion.css
@@ -14,7 +14,7 @@ table.borderless td,table.borderless th{border: none !important;}
 
 /*Header*/
 .navbar-brand{padding: 5px;padding-left:20px;height:60px;}
-.sidebar{margin-top:91px;}
+.sidebar{margin-top:61px;padding-top:20px;}
 .dropdown{font-size:18px;}
 @media (max-width: 767px) {.sidebar{margin-top:0px;}}
 

--- a/assets/webconfig/index.html
+++ b/assets/webconfig/index.html
@@ -80,7 +80,6 @@
 
 <body>
 	<div id="loading_overlay"></div>
-
 	<div id="wrapper">
 
 		<!-- Navigation -->
@@ -225,7 +224,16 @@
 		</nav>
 
 		<!-- Page Content -->
-		<div id="page-wrapper" />
+		<div id="page-wrapper" style="padding-top:10px">
+			<div id="hyperion_restart_notify" class="alert alert-warning" style="display:none;padding:10px;margin:0">
+			<div class="panel-danger" style="text-align:right">
+				<div style="float:left">Hyperion Configuration is modified. To make it active, restart Hyperion.</div>
+				<button id="btn_hyperion_restart" class="btn btn-danger">Restart Hyperion</button>
+			</div>
+		</div>
+
+		<div id="page-content" />
+		</div>
 
 	</div>
 	<!-- /#wrapper -->

--- a/assets/webconfig/js/content_index.js
+++ b/assets/webconfig/js/content_index.js
@@ -20,6 +20,12 @@ $(document).ready( function() {
 		parsedServerInfoJSON = event.response;
 		currentVersion = parsedServerInfoJSON.info.hyperion[0].version;
 		cleanCurrentVersion = currentVersion.replace(/\./g, '');
+
+		if (parsedServerInfoJSON.info.hyperion[0].config_modified)
+			$("#hyperion_restart_notify").fadeIn("fast");
+		else
+			$("#hyperion_restart_notify").fadeOut("fast");
+
 		// get active led device
 		var leddevice = parsedServerInfoJSON.info.ledDevices.active;
 		$('#dash_leddevice').html(leddevice);

--- a/assets/webconfig/js/content_leds.js
+++ b/assets/webconfig/js/content_leds.js
@@ -149,7 +149,7 @@ $(document).ready(function() {
 		isCurrentDevice = (server.info.ledDevices.active == $(this).val());
 
 		for(var key in parsedConfJSON.device){
-			if (key in generalOptions.properties)
+			if (key != "type" && key in generalOptions.properties)
 				values_general[key] = parsedConfJSON.device[key];
 		};
 		grabber_conf_editor.getEditor("root.generalOptions").setValue( values_general );

--- a/assets/webconfig/js/ui_utils.js
+++ b/assets/webconfig/js/ui_utils.js
@@ -1,13 +1,13 @@
 
 function bindNavToContent(containerId, fileName, loadNow)
 {
-	$("#page-wrapper").off();
+	$("#page-content").off();
 	$(containerId).on("click", function() {
-		$("#page-wrapper").load("/content/"+fileName+".html");
+		$("#page-content").load("/content/"+fileName+".html");
 	});
 	if (loadNow)
 	{
-		$("#page-wrapper").load("/content/"+fileName+".html");
+		$("#page-content").load("/content/"+fileName+".html");
 	}
 }
 

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -195,8 +195,6 @@
 	"webConfig" :
 	{
 		"enable"        : true,
-		"document_root" : "/usr/share/hyperion/webconfig",
-		"port"          : 8099
 	},
 
 	"effects" :

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -163,6 +163,8 @@ public:
 
 	ComponentRegister& getComponentRegister() { return _componentRegister; };
 
+	bool configModified();
+
 public slots:
 	///
 	/// Writes a single color to all the leds for the given time and priority
@@ -386,5 +388,6 @@ private:
 	
 	/// holds the current priority channel that is manualy selected
 	int _currentSourcePriority;
-	
+
+	QByteArray _configHash;
 };

--- a/include/webconfig/WebConfig.h
+++ b/include/webconfig/WebConfig.h
@@ -26,7 +26,7 @@ private:
 	quint16              _port;
 	StaticFileServing*   _server;
 
-	const std::string    WEBCONFIG_DEFAULT_PATH = "/usr/share/hyperion/webconfig";
+	const QString        WEBCONFIG_DEFAULT_PATH = ":/webconfig";
 	const quint16        WEBCONFIG_DEFAULT_PORT = 8099;
 };
 

--- a/libsrc/effectengine/CMakeLists.txt
+++ b/libsrc/effectengine/CMakeLists.txt
@@ -38,7 +38,7 @@ CONFIGURE_FILE(${CURRENT_SOURCE_DIR}/EffectEngine.qrc.in ${CMAKE_BINARY_DIR}/Eff
 SET(EffectEngine_RESOURCES ${CMAKE_BINARY_DIR}/EffectEngine.qrc)
 
 QT5_WRAP_CPP(EffectEngineHEADERS_MOC ${EffectEngineQT_HEADERS})
-qt5_add_resources(EffectEngine_RESOURCES_RCC ${EffectEngine_RESOURCES} OPTIONS "-no-compress")
+qt5_add_resources(EffectEngine_RESOURCES_RCC ${EffectEngine_RESOURCES} ) # OPTIONS "-no-compress"
 
 add_library(effectengine
 	${EffectEngineHEADERS}

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -10,6 +10,8 @@
 #include <QRegExp>
 #include <QString>
 #include <QStringList>
+#include <QCryptographicHash>
+#include <QFile>
 
 // JsonSchema include
 #include <utils/jsonschema/JsonFactory.h>
@@ -575,6 +577,7 @@ Hyperion::Hyperion(const Json::Value &jsonConfig, const std::string configFile)
 	, _log(Logger::getInstance("Core"))
 	, _hwLedCount(_ledString.leds().size())
 	, _sourceAutoSelectEnabled(true)
+	, _configHash()
 {
 	registerPriority("Off", PriorityMuxer::LOWEST_PRIORITY);
 	
@@ -623,6 +626,9 @@ Hyperion::Hyperion(const Json::Value &jsonConfig, const std::string configFile)
 	Debug(_log,"configured leds: %d hw leds: %d", getLedCount(), _hwLedCount);
 	WarningIf(hwLedCount < getLedCount(), _log, "more leds configured than available. check 'ledCount' in 'device' section");
 
+	// initialize hash of current config
+	configModified();
+
 	// initialize the leds
 	update();
 }
@@ -646,6 +652,29 @@ Hyperion::~Hyperion()
 unsigned Hyperion::getLedCount() const
 {
 	return _ledString.leds().size();
+}
+
+
+bool Hyperion::configModified()
+{
+	QFile f(_configFile.c_str());
+	if (f.open(QFile::ReadOnly))
+	{
+		QCryptographicHash hash(QCryptographicHash::Sha1);
+			if (hash.addData(&f))
+			{
+				if (_configHash.size() == 0)
+				{
+					_configHash = hash.result();
+					qDebug(_configHash.toHex());
+					return false;
+				}
+				return _configHash != hash.result();
+			}
+	}
+	f.close();
+
+	return false;
 }
 
 void Hyperion::registerPriority(const std::string name, const int priority)

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -1000,7 +1000,6 @@
 		{
 			"type" : "object",
 			"title" : "WebUI - DANGER CHANGES CAN MAKE THE WEBUI UNREACHABLE!",
-			"required" : true,
 			"properties" :
 			{
 				"enable" :
@@ -1009,21 +1008,18 @@
 					"format": "checkbox",
 					"title" : "Activate",
 					"default" : true,
-					"required" : true,
 					"propertyOrder" : 1
 				},
 				"document_root" :
 				{
 					"type" : "string",
-					"title" : "Document Root",
-					"required" : true
+					"title" : "Document Root"
 				},
 				"port" :
 				{
 					"type" : "integer",
 					"title" : "Port",
-					"default" : 8099,
-					"required" : true
+					"default" : 8099
 				}
 			},
 			"additionalProperties" : false

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -669,9 +669,9 @@ void JsonClientConnection::handleServerInfoCommand(const Json::Value &, const st
 	ver["version"] = HYPERION_VERSION;
 	ver["build"]   = HYPERION_BUILD_ID;
 	ver["time"]    = __DATE__ " " __TIME__;
+	ver["config_modified"] = _hyperion->configModified();
 
 	info["hyperion"].append(ver);
-
 	// send the result
 	sendMessage(result);
 }

--- a/libsrc/webconfig/CMakeLists.txt
+++ b/libsrc/webconfig/CMakeLists.txt
@@ -27,14 +27,23 @@ set(WebConfig_SOURCES
 	${CURRENT_SOURCE_DIR}/StaticFileServing.cpp
 	${CURRENT_SOURCE_DIR}/WebConfig.cpp
 )
+FILE ( GLOB_RECURSE webFiles RELATIVE ${CMAKE_BINARY_DIR}  ${CMAKE_SOURCE_DIR}/assets/webconfig/* )
+FOREACH( f ${webFiles} )
+    STRING ( REPLACE "../assets/webconfig/" "" fname ${f})
+    SET(HYPERION_WEBCONFIG_RES "${HYPERION_WEBCONFIG_RES}\n\t\t<file alias=\"/webconfig/${fname}\">${f}</file>")
+ENDFOREACH()
+CONFIGURE_FILE(${CURRENT_SOURCE_DIR}/WebConfig.qrc.in ${CMAKE_BINARY_DIR}/WebConfig.qrc )
+SET(WebConfig_RESOURCES ${CMAKE_BINARY_DIR}/WebConfig.qrc)
 
 qt5_wrap_cpp(WebConfig_HEADERS_MOC ${WebConfig_QT_HEADERS})
+qt5_add_resources(WebConfig_RESOURCES_RCC ${WebConfig_RESOURCES} ) #OPTIONS "-no-compress"
 
 add_library(webconfig
 	${WebConfig_HEADERS}
 	${WebConfig_QT_HEADERS}
 	${WebConfig_SOURCES}
 	${WebConfig_HEADERS_MOC}
+	${WebConfig_RESOURCES_RCC}
 )
 
 qt5_use_modules(webconfig Network)

--- a/libsrc/webconfig/StaticFileServing.cpp
+++ b/libsrc/webconfig/StaticFileServing.cpp
@@ -7,14 +7,17 @@
 #include <QPair>
 #include <QFile>
 #include <QFileInfo>
+#include <QResource>
 
 StaticFileServing::StaticFileServing (Hyperion *hyperion, QString baseUrl, quint16 port, QObject * parent)
-		:  QObject   (parent)
-		, _hyperion(hyperion)
-		, _baseUrl (baseUrl)
-		, _cgi(hyperion, baseUrl, this)
-		, _log(Logger::getInstance("WEBSERVER"))
+	:  QObject   (parent)
+	, _hyperion(hyperion)
+	, _baseUrl (baseUrl)
+	, _cgi(hyperion, baseUrl, this)
+	, _log(Logger::getInstance("WEBSERVER"))
 {
+	Q_INIT_RESOURCE(WebConfig);
+
 	_mimeDb = new QMimeDatabase;
 
 	_server = new QtHttpServer (this);
@@ -26,6 +29,7 @@ StaticFileServing::StaticFileServing (Hyperion *hyperion, QString baseUrl, quint
 	connect (_server, &QtHttpServer::requestNeedsReply, this, &StaticFileServing::onRequestNeedsReply);
 
 	_server->start (port);
+
 }
 
 StaticFileServing::~StaticFileServing ()
@@ -75,6 +79,7 @@ void StaticFileServing::onRequestNeedsReply (QtHttpRequest * request, QtHttpRepl
 			}
 			return;
 		}
+		Q_INIT_RESOURCE(WebConfig);
 
 		QFileInfo info(_baseUrl % "/" % path);
 		if ( path == "/" || path.isEmpty() || ! info.exists() )

--- a/libsrc/webconfig/WebConfig.qrc.in
+++ b/libsrc/webconfig/WebConfig.qrc.in
@@ -1,0 +1,5 @@
+<RCC>
+	<qresource prefix="/">
+		${HYPERION_WEBCONFIG_RES}
+	</qresource>
+</RCC>


### PR DESCRIPTION
**1.** Tell us something about your changes.
optional embedded webui. If document_root in config is set and valid, files taken from there, otherwise compiled in files are taken.
For customer release it is great, because we always have a webui (as long as hyperiond is started).

Webfiles are included in libwebconfig.so separated from hyperiond.
Currently we compile a static binary and of course for now files are embedded in hyperiond directly.
Currently filesize is increase about 2MB -> mean 3.6MB total for a striped binary

Hyperion and webui now have a detection if config file was altered during runtime of hyperiond. We need this detection for reloading new config

![screenshot_20160914_121146](https://cloud.githubusercontent.com/assets/6893049/18507591/4a6f13fa-7a71-11e6-9df7-104fb113d8f1.png)


**Attention webui developers:** set document_root in config (as before), otherwise you won't have fun ;-)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


