### PR TITLE
extend effect engine with qt image effectsx

### DIFF
--- a/assets/webconfig/js/content_remote.js
+++ b/assets/webconfig/js/content_remote.js
@@ -96,6 +96,7 @@ $(document).ready(function() {
 
 			$('#cp2').colorpicker().on('changeColor', function(e) {
 				color = e.color.toRGB();
+				$("#effect_select").val("__none__");
 				requestSetColor(color.r, color.g, color.b);
 			});
 		});
@@ -106,7 +107,10 @@ $(document).ready(function() {
 			efx = $(this).val();
 			if(efx != "__none__")
 			{
-				requestPlayEffect(efx);
+				requestPriorityClear();
+				$(hyperion).one("cmd-clear", function(event) {
+					setTimeout(function() {requestPlayEffect(efx)}, 100);
+				});
 			}
 		});
 

--- a/effects/rainbow-swirl-fast.json
+++ b/effects/rainbow-swirl-fast.json
@@ -4,7 +4,8 @@
 	"args" :
 	{
 		"rotation-time" : 3.0,
-		"brightness" : 1.0,
+		"center_x" : 0.5,
+		"center_y" : 0.5,
 		"reverse" : false
 	}
 }

--- a/effects/rainbow-swirl-fast.json
+++ b/effects/rainbow-swirl-fast.json
@@ -3,7 +3,7 @@
 	"script" : "rainbow-swirl.py",
 	"args" :
 	{
-		"rotation-time" : 3.0,
+		"rotation-time" : 4.0,
 		"center_x" : 0.5,
 		"center_y" : 0.5,
 		"reverse" : false

--- a/effects/rainbow-swirl.json
+++ b/effects/rainbow-swirl.json
@@ -4,7 +4,8 @@
 	"args" :
 	{
 		"rotation-time" : 20.0,
-		"brightness" : 1.0,
+		"center_x" : 0.5,
+		"center_y" : 0.5,
 		"reverse" : false
 	}
 }

--- a/effects/rainbow-swirl.py
+++ b/effects/rainbow-swirl.py
@@ -1,39 +1,49 @@
-import hyperion
-import time
-import colorsys
+import hyperion, time
 
 # Get the parameters
 rotationTime = float(hyperion.args.get('rotation-time', 3.0))
-brightness = float(hyperion.args.get('brightness', 1.0))
-saturation = float(hyperion.args.get('saturation', 1.0))
-reverse = bool(hyperion.args.get('reverse', False))
+reverse      = bool(hyperion.args.get('reverse', False))
+centerX      = float(hyperion.args.get('center_x', 0.5))
+centerY      = float(hyperion.args.get('center_y', 0.5))
 
 # Check parameters
 rotationTime = max(0.1, rotationTime)
-brightness = max(0.0, min(brightness, 1.0))
-saturation = max(0.0, min(saturation, 1.0))
-
-# Initialize the led data
-ledData = bytearray()
-for i in range(hyperion.ledCount):
-	hue = float(i)/hyperion.ledCount
-	rgb = colorsys.hsv_to_rgb(hue, saturation, brightness)
-	ledData += bytearray((int(255*rgb[0]), int(255*rgb[1]), int(255*rgb[2])))
+angle = 0
 
 # Calculate the sleep time and rotation increment
 increment = 3
-sleepTime = rotationTime / hyperion.ledCount
+sleepTime = rotationTime / 360
 while sleepTime < 0.05:
 	increment *= 2
 	sleepTime *= 2
-increment %= hyperion.ledCount
+increment %= 360
 
-# Switch direction if needed
+# table of stop colors for rainbow gradient
+rainbowColors = bytearray([
+	0  ,255,0  ,0,
+	25 ,255,230,0,
+	63 ,255,255,0,
+	100,0  ,255,0,
+	127,0  ,255,200,
+	159,0  ,255,255,
+	191,0  ,0  ,255,
+	224,255,0  ,255,
+	255,255,0  ,127,
+])
+
 if reverse:
 	increment = -increment
-	
-# Start the write data loop
+
 while not hyperion.abort():
-	hyperion.setColor(ledData)
-	ledData = ledData[-increment:] + ledData[:-increment]
+	angle += increment
+	if angle > 360: angle=0
+	if angle <   0: angle=360
+
+	hyperion.imageCanonicalGradient(0,0,
+		hyperion.imageWidth,hyperion.imageHeight,
+		int(round(hyperion.imageWidth)*centerX),int(round(float(hyperion.imageHeight)*centerY)),
+		angle,rainbowColors
+	);
+
+	hyperion.imageShow()
 	time.sleep(sleepTime)

--- a/effects/rainbow-swirl.py
+++ b/effects/rainbow-swirl.py
@@ -8,15 +8,9 @@ centerY      = float(hyperion.args.get('center_y', 0.5))
 
 # Check parameters
 rotationTime = max(0.1, rotationTime)
-angle = 0
-
-# Calculate the sleep time and rotation increment
-increment = 3
 sleepTime = rotationTime / 360
-while sleepTime < 0.05:
-	increment *= 2
-	sleepTime *= 2
-increment %= 360
+angle = 0
+increment = 1
 
 # table of stop colors for rainbow gradient
 rainbowColors = bytearray([
@@ -32,7 +26,7 @@ rainbowColors = bytearray([
 ])
 
 if reverse:
-	increment = -increment
+	increment *= -1
 
 while not hyperion.abort():
 	angle += increment
@@ -43,7 +37,7 @@ while not hyperion.abort():
 		hyperion.imageWidth,hyperion.imageHeight,
 		int(round(hyperion.imageWidth)*centerX),int(round(float(hyperion.imageHeight)*centerY)),
 		angle,rainbowColors
-	);
+	)
 
 	hyperion.imageShow()
 	time.sleep(sleepTime)

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -7,6 +7,7 @@
 // QT includes
 #include <QObject>
 #include <QTimer>
+#include <QSize>
 
 // hyperion-utils includes
 #include <utils/Image.h>
@@ -85,7 +86,9 @@ public:
 	/// Returns the number of attached leds
 	///
 	unsigned getLedCount() const;
-	
+
+	QSize getLedGridSize() const { return _ledGridSize; }
+
 	///
 	/// Returns the current priority
 	///
@@ -292,7 +295,8 @@ public:
 
 	static LinearColorSmoothing * createColorSmoothing(const Json::Value & smoothingConfig, LedDevice* leddevice);
 	static MessageForwarder * createMessageForwarder(const Json::Value & forwarderConfig);
-	
+	static QSize getLedLayoutGridSize(const Json::Value& ledsConfig);
+
 signals:
 	/// Signal which is emitted when a priority channel is actively cleared
 	/// This signal will not be emitted when a priority channel time out
@@ -390,4 +394,6 @@ private:
 	int _currentSourcePriority;
 
 	QByteArray _configHash;
+
+	QSize _ledGridSize;
 };

--- a/libsrc/effectengine/CMakeLists.txt
+++ b/libsrc/effectengine/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(effectengine
 	${EffectEngineSOURCES}
 )
 
+qt5_use_modules(effectengine Core Gui)
+
 target_link_libraries(effectengine
 	hyperion
 	jsoncpp

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -8,16 +8,25 @@
 // Qt includes
 #include <QDateTime>
 #include <QFile>
+#include <Qt>
+#include <QLinearGradient>
+#include <QConicalGradient>
+#include <QRect>
 
 // effect engin eincludes
 #include "Effect.h"
 #include <utils/Logger.h>
+#include <hyperion/Hyperion.h>
 
 // Python method table
 PyMethodDef Effect::effectMethods[] = {
-	{"setColor",    Effect::wrapSetColor,    METH_VARARGS, "Set a new color for the leds."},
-	{"setImage",    Effect::wrapSetImage,    METH_VARARGS, "Set a new image to process and determine new led colors."},
-	{"abort",       Effect::wrapAbort,       METH_NOARGS,  "Check if the effect should abort execution."},
+	{"setColor",     Effect::wrapSetColor,    METH_VARARGS, "Set a new color for the leds."},
+	{"setImage",     Effect::wrapSetImage,    METH_VARARGS, "Set a new image to process and determine new led colors."},
+	{"abort",        Effect::wrapAbort,       METH_NOARGS,  "Check if the effect should abort execution."},
+	{"imageShow",    Effect::wrapImageShow,   METH_NOARGS,  "set current effect image to hyperion core."},
+	{"imageCanonicalGradient",    Effect::wrapImageCanonicalGradient,   METH_VARARGS,  "set current effect image to hyperion core."},
+// 	{"imageSetPixel",Effect::wrapImageShow,   METH_VARARGS, "set pixel color of image"},
+// 	{"imageGetPixel",Effect::wrapImageShow,   METH_VARARGS, "get pixel color of image"},
 	{NULL, NULL, 0, NULL}
 };
 
@@ -69,6 +78,12 @@ Effect::Effect(PyThreadState * mainThreadState, int priority, int timeout, const
 
 	// disable the black border detector for effects
 	_imageProcessor->enableBlackBorderDetector(false);
+	
+	// init effect image for image based effects, size is based on led layout
+	_imageSize = Hyperion::getInstance()->getLedGridSize();
+	_image = new QImage(_imageSize, QImage::Format_ARGB32_Premultiplied);
+	_image->fill(Qt::black);
+	_painter = new QPainter(_image);
 
 	// connect the finished signal
 	connect(this, SIGNAL(finished()), this, SLOT(effectFinished()));
@@ -77,6 +92,8 @@ Effect::Effect(PyThreadState * mainThreadState, int priority, int timeout, const
 
 Effect::~Effect()
 {
+	delete _painter;
+	delete _image;
 }
 
 void Effect::run()
@@ -95,6 +112,12 @@ void Effect::run()
 
 	// add ledCount variable to the interpreter
 	PyObject_SetAttrString(module, "ledCount", Py_BuildValue("i", _imageProcessor->getLedCount()));
+
+	// add imageWidth variable to the interpreter
+	PyObject_SetAttrString(module, "imageWidth", Py_BuildValue("i", _imageSize.width()));
+
+	// add imageHeight variable to the interpreter
+	PyObject_SetAttrString(module, "imageHeight", Py_BuildValue("i", _imageSize.height()));
 
 	// add a args variable to the interpreter
 	PyObject_SetAttrString(module, "args", json2python(_args));
@@ -356,6 +379,106 @@ PyObject* Effect::wrapAbort(PyObject *self, PyObject *)
 
 	return Py_BuildValue("i", effect->_abortRequested ? 1 : 0);
 }
+
+
+PyObject* Effect::wrapImageShow(PyObject *self, PyObject *args)
+{
+	Effect * effect = getEffect();
+
+	// determine the timeout
+	int timeout = effect->_timeout;
+	if (timeout > 0)
+	{
+		timeout = effect->_endTime - QDateTime::currentMSecsSinceEpoch();
+
+		// we are done if the time has passed
+		if (timeout <= 0)
+		{
+			return Py_BuildValue("");
+		}
+	}
+
+	int width = effect->_imageSize.width();
+	int height = effect->_imageSize.height();
+	QImage * qimage = effect->_image;
+	
+	Image<ColorRgb> image(width, height);
+	QByteArray binaryImage;
+
+	for (int i = 0; i <qimage->height(); ++i)
+	{
+		const QRgb * scanline = reinterpret_cast<const QRgb *>(qimage->scanLine(i));
+		for (int j = 0; j < qimage->width(); ++j)
+		{
+			binaryImage.append((char) qRed(scanline[j]));
+			binaryImage.append((char) qGreen(scanline[j]));
+			binaryImage.append((char) qBlue(scanline[j]));
+		}
+	}
+	
+	memcpy(image.memptr(), binaryImage.data(), binaryImage.size());
+	effect->_imageProcessor->process(image, effect->_colors);
+	effect->setColors(effect->_priority, effect->_colors, timeout, false);
+
+	return Py_BuildValue("");
+}
+
+
+PyObject* Effect::wrapImageCanonicalGradient(PyObject *self, PyObject *args)
+{
+	Effect * effect = getEffect();
+ // = effect->_imageSize.width();
+	 // = effect->_imageSize.height();
+	
+	int width, height, startX, startY, centerX, centerY, angle;
+	PyObject * bytearray = nullptr;
+	if (PyArg_ParseTuple(args, "iiiiiiiO", &startX, &startY, &width, &height, &centerX, &centerY, &angle, &bytearray))
+	{
+		if (PyByteArray_Check(bytearray))
+		{
+			int length = PyByteArray_Size(bytearray);
+			if (length % 4 == 0)
+			{
+
+				QPainter * painter = effect->_painter;
+				QRect myQRect(startX,startY,width,height);
+				QConicalGradient gradient(QPoint(centerX,centerY), std::max(std::min(angle,360),0) );
+				char * data = PyByteArray_AS_STRING(bytearray);
+
+				for (int idx=0; idx<length; idx+=4)
+				{
+					gradient.setColorAt(
+						((uint8_t)data[idx])/255.0,
+						QColor(
+							(uint8_t)(data[idx+1]),
+							(uint8_t)(data[idx+2]),
+							(uint8_t)(data[idx+3])
+					));
+				}
+
+				gradient.setSpread(QGradient::RepeatSpread);
+				painter->fillRect(myQRect, gradient);
+				
+				return Py_BuildValue("");
+			}
+			else
+			{
+				PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 4");
+				return nullptr;
+			}
+		}
+		else
+		{
+			PyErr_SetString(PyExc_RuntimeError, "Argument 8 is not a bytearray");
+			return nullptr;
+		}
+	}
+	else
+	{
+		return nullptr;
+	}
+}
+
 
 Effect * Effect::getEffect()
 {

--- a/libsrc/effectengine/Effect.h
+++ b/libsrc/effectengine/Effect.h
@@ -5,6 +5,9 @@
 
 // Qt includes
 #include <QThread>
+#include <QSize>
+#include <QImage>
+#include <QPainter>
 
 // Hyperion includes
 #include <hyperion/ImageProcessor.h>
@@ -48,21 +51,24 @@ private:
 	PyObject * json2python(const Json::Value & json) const;
 
 	// Wrapper methods for Python interpreter extra buildin methods
-    static PyMethodDef effectMethods[];
-    static PyObject* wrapSetColor(PyObject *self, PyObject *args);
+	static PyMethodDef effectMethods[];
+	static PyObject* wrapSetColor(PyObject *self, PyObject *args);
 	static PyObject* wrapSetImage(PyObject *self, PyObject *args);
 	static PyObject* wrapAbort(PyObject *self, PyObject *args);
-    static Effect * getEffect();
+	static PyObject* wrapImageShow(PyObject *self, PyObject *args);
+	static PyObject* wrapImageCanonicalGradient(PyObject *self, PyObject *args);
+	
+	static Effect * getEffect();
 
 #if PY_MAJOR_VERSION >= 3
-    static struct PyModuleDef moduleDef;
-    static PyObject* PyInit_hyperion();
+	static struct PyModuleDef moduleDef;
+	static PyObject* PyInit_hyperion();
 #else
-    static void PyInit_hyperion();
+	static void PyInit_hyperion();
 #endif
 
 private:
-    PyThreadState * _mainThreadState;
+	PyThreadState * _mainThreadState;
 
 	const int _priority;
 
@@ -84,5 +90,10 @@ private:
 
 	/// Buffer for colorData
 	std::vector<ColorRgb> _colors;
+	
+	QSize _imageSize;
+	
+	QImage * _image;
+	QPainter * _painter;
 };
 	

--- a/libsrc/effectengine/Effect.h
+++ b/libsrc/effectengine/Effect.h
@@ -57,6 +57,7 @@ private:
 	static PyObject* wrapAbort(PyObject *self, PyObject *args);
 	static PyObject* wrapImageShow(PyObject *self, PyObject *args);
 	static PyObject* wrapImageCanonicalGradient(PyObject *self, PyObject *args);
+	static PyObject* wrapImageRadialGradient(PyObject *self, PyObject *args);
 	
 	static Effect * getEffect();
 


### PR DESCRIPTION
**1.** Tell us something about your changes.
extend effect engine for better image drawing effects:
- hyperion calculates led layout grid size from led configuration
-> this is needed to create optimzed image dimensions for image effects
- now every effect creates a image (qimage) buffer with optimized size (for optional use of course)
- this image buffer can be modified with qpainter commands and when drawing is done, image buffer can be send to the leds
- currently QCanonicalGradient and QRadialGradient are implemented, but all other commands are possible now, just some monkey work (qpainter functions are e.g. drawing lines, circles, rects, text, gradients, ...)

The rainbow effect is now image based. The advantage is, that it also look good on other matrix or more strange layouts. 

here main code from rainbow-swirl.py
```
	hyperion.imageCanonicalGradient(0,0,
		hyperion.imageWidth,hyperion.imageHeight,
		int(round(hyperion.imageWidth)*centerX),int(round(float(hyperion.imageHeight)*centerY)),
		angle,rainbowColors
	)

	hyperion.imageShow()
```
the **imageCanonicalGradient** func takes several arguments: 
"rect of drawing area - startX, startY, width, height" "center point - cx, cy" "gradient angle" "list with gradient colors"*

*
needs 4 values per color: position (0-255), r,g,b
more info here:
http://doc.qt.io/qt-5/qconicalgradient.html  (stop color)
http://doc.qt.io/qt-5/qradialgradient.html

also other gradients are possible, but not yet implemented:
http://doc.qt.io/qt-5/qlineargradient.html

after drawing on image buffer, the image buffer must be send to the leds with
**imageShow**

hint: play with the center point in rainbow-swirl json file. 0.5 means center, values are valid from 0 to 1

![bildschirmfoto5](https://cloud.githubusercontent.com/assets/6893049/18684779/c3d95d6e-7f75-11e6-8995-c1519a654155.png)

additional:
fix some js errors

**2.** If this changes affect the .conf file. Please provide the changed section
yes - for better js compatibility "grabber-v4l2" is renamed to "grabberV4L2"

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

