### PR TITLE
Example config json is missing a comma

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -364,7 +364,7 @@
 		[
 			"/storage/hyperion/effects",
 			"/usr/share/hyperion/effects"
-		]
+		],
 		"disable" :
 		[
 			"Rainbow swirl",


### PR DESCRIPTION
Example config json is missing a comma making it invalid json