### PR TITLE
fix input selection wont work when color is set

### DIFF
--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -828,7 +828,7 @@ void Hyperion::setColors(int priority, const std::vector<ColorRgb>& ledColors, c
 		_muxer.setInput(priority, ledColors);
 	}
 
-	if (priority == _muxer.getCurrentPriority())
+	if (! _sourceAutoSelectEnabled || priority == _muxer.getCurrentPriority())
 	{
 		update();
 	}


### PR DESCRIPTION
**1.** Tell us something about your changes.
... fix input selection wont work when color is set

test:
- start hyperion
- open webui -> remote controll
- set a color
- try to set a specific input source
-> current: led color stays always
-> fixed: led colors are set according selected input source

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


