### PR TITLE
fix restart of hyperion. 

### DIFF
--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -78,6 +78,10 @@ public:
 	///
 	~Hyperion();
 
+	///
+	/// free all alocated objects, should be called only from constructor or before restarting hyperion
+	///
+	void freeObjects();
 
 	static Hyperion* initInstance(const Json::Value& jsonConfig, const QJsonObject& qjsonConfig, const std::string configFile);
 	static Hyperion* getInstance();

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -594,7 +594,7 @@ Hyperion::Hyperion(const Json::Value &jsonConfig, const QJsonObject &qjsonConfig
 }
 
 
-Hyperion::~Hyperion()
+void Hyperion::freeObjects()
 {
 	// switch off all leds
 	clearall();
@@ -606,6 +606,11 @@ Hyperion::~Hyperion()
 	delete _raw2ledTransform;
 	delete _raw2ledAdjustment;
 	delete _messageForwarder;
+}
+
+Hyperion::~Hyperion()
+{
+	freeObjects();
 }
 
 unsigned Hyperion::getLedCount() const

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -903,6 +903,7 @@ void JsonClientConnection::handleConfigCommand(const QJsonObject& message, const
 	} 
 	else if (subcommand == "reload")
 	{
+		_hyperion->freeObjects();
 		Process::restartHyperion();
 		sendErrorReply("failed to restart hyperion", full_command, tan);
 	} 


### PR DESCRIPTION
**1.** Tell us something about your changes.
..  now devices closed before restart.
Before that it wasn't possible to restart hyperion via json/webui with serial device (adalight), because serialport was left open after exit the prior hyperion instance.

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


