### PR TITLE
Fixed QHostAddress address binding for AtmoOrb

### DIFF
--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -24,7 +24,7 @@ LedDeviceAtmoOrb::LedDeviceAtmoOrb(const QJsonObject &deviceConfig)
 	_groupAddress = QHostAddress(_multicastGroup);
 
 	_udpSocket = new QUdpSocket(this);
-	_udpSocket->bind(QHostAddress::Any, _multiCastGroupPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+	_udpSocket->bind(QHostAddress::AnyIPv4, _multiCastGroupPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
 
 	joinedMulticastgroup = _udpSocket->joinMulticastGroup(_groupAddress);
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.

QHostAddress::Any no longer works with used Qt version, this resolves it by changing it so that it binds to Any IPv4 address.


