### PR TITLE
Delete custom created effect configurations with JSON RPC

### DIFF
--- a/include/effectengine/EffectDefinition.h
+++ b/include/effectengine/EffectDefinition.h
@@ -6,7 +6,6 @@
 
 struct EffectDefinition
 {
-	QString name;
-	QString script;
+	QString name, script, file;
 	QJsonObject args;
 };

--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -248,6 +248,7 @@ bool EffectEngine::loadEffectDefinition(const QString &path, const QString &effe
 
 	// ---------- setup the definition ----------
 	
+	effectDefinition.file = fileName;
 	QJsonObject config = configEffect.object();
 	QString scriptName = config["script"].toString();
 	effectDefinition.name = config["name"].toString();

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -97,6 +97,13 @@ private:
 	void handleCreateEffectCommand(const QJsonObject & message, const QString &command, const int tan);
 
 	///
+	/// Handle an incoming JSON Effect message (Delete JSON Effect)
+	///
+	/// @param message the incoming message
+	///
+	void handleDeleteEffectCommand(const QJsonObject & message, const QString &command, const int tan);
+
+	///
 	/// Handle an incoming JSON Server info message
 	///
 	/// @param message the incoming message

--- a/libsrc/jsonserver/JsonSchemas.qrc
+++ b/libsrc/jsonserver/JsonSchemas.qrc
@@ -12,6 +12,7 @@
         <file alias="schema-adjustment">schema/schema-adjustment.json</file>
         <file alias="schema-effect">schema/schema-effect.json</file>
         <file alias="schema-create-effect">schema/schema-create-effect.json</file>
+        <file alias="schema-delete-effect">schema/schema-delete-effect.json</file>
         <file alias="schema-sourceselect">schema/schema-sourceselect.json</file>
         <file alias="schema-config">schema/schema-config.json</file>
         <file alias="schema-componentstate">schema/schema-componentstate.json</file>

--- a/libsrc/jsonserver/schema/schema-delete-effect.json
+++ b/libsrc/jsonserver/schema/schema-delete-effect.json
@@ -1,0 +1,21 @@
+
+{
+	"type":"object",
+	"required":true,
+	"properties":{
+		"command": {
+			"type" : "string",
+			"required" : true,
+			"enum" : ["delete-effect"]
+		},
+		"tan" : {
+			"type" : "integer"
+		},
+		"name" :
+		{
+			"type" : "string",
+			"required" : true
+		}
+	},
+	"additionalProperties": false
+}

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -5,7 +5,7 @@
 		"command": {
 			"type" : "string",
 			"required" : true,
-			"enum" : ["color", "image", "effect", "create-effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "config", "componentstate", "ledcolors"]
+			"enum" : ["color", "image", "effect", "create-effect", "delete-effect", "serverinfo", "clear", "clearall", "transform", "correction", "temperature", "adjustment", "sourceselect", "config", "componentstate", "ledcolors"]
 		}
 	}
 }

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -209,6 +209,22 @@ void JsonConnection::createEffect(const QString &effectName, const QString &effe
 	parseReply(reply);
 }
 
+void JsonConnection::deleteEffect(const QString &effectName)
+{
+    qDebug() << "Delete effect configuration" << effectName;
+
+	// create command
+	QJsonObject effect;
+	effect["command"] = QString("delete-effect");
+	effect["name"] = effectName;
+	
+	// send command message
+	QJsonObject reply = sendMessage(effect);
+
+	// parse reply message
+	parseReply(reply);
+}
+
 QString JsonConnection::getServerInfo()
 {
 	qDebug() << "Get server info";

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -64,6 +64,13 @@ public:
 	/// @param effectArgs The arguments of the effect
 	///
 	void createEffect(const QString &effectName, const QString &effectScript, const QString & effectArgs);
+	
+	///
+	/// Delete a effect configuration file (.json)
+	///
+	/// @param effectName The name of the effect
+	///
+	void deleteEffect(const QString &effectName);
 
 	///
 	/// Retrieve a list of all occupied priority channels

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -65,6 +65,7 @@ int main(int argc, char * argv[])
 		Option          & argEffectFile  = parser.add<Option>       (0x0, "effectFile", "Arguments to use in combination with --createEffect");
 		Option          & argEffectArgs  = parser.add<Option>       (0x0, "effectArgs", "Arguments to use in combination with the specified effect. Should be a Json object string.", "");
 		Option          & argCreateEffect= parser.add<Option>       (0x0, "createEffect","Write a new Json Effect configuration file.\nFirst parameter = Effect name.\nSecond parameter = Effect file (--effectFile).\nLast parameter = Effect arguments (--effectArgs.)", "");
+		Option          & argDeleteEffect= parser.add<Option>       (0x0, "deleteEffect","Delete a custom created Json Effect configuration file.");
 		BooleanOption   & argServerInfo  = parser.add<BooleanOption>('l', "list"      , "List server info and active effects with priority and duration");
 		BooleanOption   & argClear       = parser.add<BooleanOption>('x', "clear"     , "Clear data for the priority channel provided by the -p option");
 		BooleanOption   & argClearAll    = parser.add<BooleanOption>(0x0, "clearall"  , "Clear data for all active priority channels");
@@ -108,7 +109,7 @@ int main(int argc, char * argv[])
 		bool colorModding = colorTransform || colorAdjust;
 		
 		// check that exactly one command was given
-		int commandCount = count({parser.isSet(argColor), parser.isSet(argImage), parser.isSet(argEffect), parser.isSet(argCreateEffect), parser.isSet(argServerInfo), parser.isSet(argClear), parser.isSet(argClearAll), parser.isSet(argEnableComponent), parser.isSet(argDisableComponent), colorModding, parser.isSet(argSource), parser.isSet(argSourceAuto), parser.isSet(argSourceOff), parser.isSet(argConfigGet), parser.isSet(argSchemaGet), parser.isSet(argConfigSet)});
+		int commandCount = count({parser.isSet(argColor), parser.isSet(argImage), parser.isSet(argEffect), parser.isSet(argCreateEffect), parser.isSet(argDeleteEffect), parser.isSet(argServerInfo), parser.isSet(argClear), parser.isSet(argClearAll), parser.isSet(argEnableComponent), parser.isSet(argDisableComponent), colorModding, parser.isSet(argSource), parser.isSet(argSourceAuto), parser.isSet(argSourceOff), parser.isSet(argConfigGet), parser.isSet(argSchemaGet), parser.isSet(argConfigSet)});
 		if (commandCount != 1)
 		{
 			qWarning() << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:";
@@ -116,6 +117,7 @@ int main(int argc, char * argv[])
 			showHelp(argImage);
 			showHelp(argEffect);
 			showHelp(argCreateEffect);
+			showHelp(argDeleteEffect);
 			showHelp(argServerInfo);
 			showHelp(argClear);
 			showHelp(argClearAll);
@@ -162,6 +164,10 @@ int main(int argc, char * argv[])
 		else if (parser.isSet(argCreateEffect))
 		{
 			connection.createEffect(argCreateEffect.value(parser), argEffectFile.value(parser), argEffectArgs.value(parser));
+		}
+		else if (parser.isSet(argDeleteEffect))
+		{
+			connection.deleteEffect(argDeleteEffect.value(parser));
 		}
 		else if (parser.isSet(argServerInfo))
 		{


### PR DESCRIPTION
**1.** Tell us something about your changes.
In german.

Wie der Titel schon vermuten lässt, kann man **benutzerdefinierte** Effektkonfigurationen löschen.
Das Wort "benutzerdefinierte" habe ich Fett geschrieben, aus dem Grund, es sind nur die externen und NICHT die internen Effektkonfigurationen gemeint.
Die Verwendung ist einfach. Haben wir z.b. einen neuen Effekt mit dem Namen "dream" erstellt, löschen wir diesen folgendermaßen. 

hyperion-remote:
./hyperion-remote --deleteEffect "dream"

JSON RPC:
{"command":"delete-effect","name":"dream"}

EDIT: Ach ja, fast vergessen. Die "effects" Serverinfo von Hyperion enthält jetzt auch den Dateipfad der Effektkonfigurationen.

**2.** If this changes affect the .conf file. Please provide the changed section
nein