### PR TITLE
global logbuffer

### DIFF
--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <map>
+#include <QString>
 
 // standard log messages
 //#define _FUNCNAME_ __PRETTY_FUNCTION__
@@ -22,16 +23,31 @@
 
 // ================================================================
 
+
 class Logger
 {
 public:
 	enum LogLevel { UNSET=0,DEBUG=1, INFO=2,WARNING=3,ERROR=4,OFF=5 };
 
+	typedef struct
+	{
+		QString      appName;
+		QString      loggerName;
+		QString      function;
+		unsigned int line;
+		QString      fileName;
+		time_t       utime;
+		QString      message;
+		LogLevel     level;
+		QString      levelString;
+	} T_LOG_MESSAGE;
+
 	static Logger*  getInstance(std::string name="", LogLevel minLevel=Logger::INFO);
 	static void     deleteInstance(std::string name="");
 	static void     setLogLevel(LogLevel level,std::string name="");
 	static LogLevel getLogLevel(std::string name="");
-
+	static std::vector<Logger::T_LOG_MESSAGE>* getGlobalLogMessageBuffer() { return GlobalLogMessageBuffer; };
+	
 	void     Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...);
 	void     setMinLevel(LogLevel level) { _minLevel = level; };
 	LogLevel getMinLevel() { return _minLevel; };
@@ -43,6 +59,7 @@ protected:
 private:
 	static std::map<std::string,Logger*> *LoggerMap;
 	static LogLevel GLOBAL_MIN_LOG_LEVEL;
+	static std::vector<T_LOG_MESSAGE> *GlobalLogMessageBuffer;
 
 	std::string _name;
 	std::string _appname;

--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -1,10 +1,17 @@
 #pragma once
 
+// QT includes
+#include <QObject>
+#include <QString>
+
+// stl includes
 #include <string>
 #include <stdio.h>
 #include <stdarg.h>
 #include <map>
-#include <QString>
+#include <QVector>
+
+
 
 // standard log messages
 //#define _FUNCNAME_ __PRETTY_FUNCTION__
@@ -24,8 +31,10 @@
 // ================================================================
 
 
-class Logger
+class Logger : public QObject
 {
+	Q_OBJECT
+
 public:
 	enum LogLevel { UNSET=0,DEBUG=1, INFO=2,WARNING=3,ERROR=4,OFF=5 };
 
@@ -46,11 +55,14 @@ public:
 	static void     deleteInstance(std::string name="");
 	static void     setLogLevel(LogLevel level,std::string name="");
 	static LogLevel getLogLevel(std::string name="");
-	static std::vector<Logger::T_LOG_MESSAGE>* getGlobalLogMessageBuffer() { return GlobalLogMessageBuffer; };
+	static QVector<Logger::T_LOG_MESSAGE>* getGlobalLogMessageBuffer() { return GlobalLogMessageBuffer; };
 	
 	void     Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...);
 	void     setMinLevel(LogLevel level) { _minLevel = level; };
 	LogLevel getMinLevel() { return _minLevel; };
+
+signals:
+	void newLogMessage(Logger::T_LOG_MESSAGE);
 
 protected:
 	Logger( std::string name="", LogLevel minLevel=INFO);
@@ -59,7 +71,7 @@ protected:
 private:
 	static std::map<std::string,Logger*> *LoggerMap;
 	static LogLevel GLOBAL_MIN_LOG_LEVEL;
-	static std::vector<T_LOG_MESSAGE> *GlobalLogMessageBuffer;
+	static QVector<T_LOG_MESSAGE> *GlobalLogMessageBuffer;
 
 	std::string _name;
 	std::string _appname;

--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -30,7 +30,6 @@
 
 // ================================================================
 
-
 class Logger : public QObject
 {
 	Q_OBJECT
@@ -56,7 +55,7 @@ public:
 	static void     setLogLevel(LogLevel level,std::string name="");
 	static LogLevel getLogLevel(std::string name="");
 	static QVector<Logger::T_LOG_MESSAGE>* getGlobalLogMessageBuffer() { return GlobalLogMessageBuffer; };
-	
+
 	void     Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...);
 	void     setMinLevel(LogLevel level) { _minLevel = level; };
 	LogLevel getMinLevel() { return _minLevel; };
@@ -72,6 +71,7 @@ private:
 	static std::map<std::string,Logger*> *LoggerMap;
 	static LogLevel GLOBAL_MIN_LOG_LEVEL;
 	static QVector<T_LOG_MESSAGE> *GlobalLogMessageBuffer;
+	static QVector<T_LOG_MESSAGE> *LogCallacks;
 
 	std::string _name;
 	std::string _appname;
@@ -80,3 +80,21 @@ private:
 	unsigned int _loggerId;
 };
 
+class LoggerNotifier : public QObject
+{
+	Q_OBJECT
+
+public:
+	static LoggerNotifier* getInstance();
+
+protected:
+	LoggerNotifier();
+	~LoggerNotifier();
+
+	static LoggerNotifier* instance;
+public slots:
+	void handleNewLogMessage(Logger::T_LOG_MESSAGE);
+
+signals:
+	void newLogMessage(Logger::T_LOG_MESSAGE);
+};

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -40,6 +40,7 @@ public:
 public slots:
 	void componentStateChanged(const hyperion::Components component, bool enable);
 	void streamLedcolorsUpdate();
+	void incommingLogMessage(Logger::T_LOG_MESSAGE);
 
 signals:
 	///
@@ -181,6 +182,12 @@ private:
 	///
 	void handleLedColorsCommand(const QJsonObject & message, const QString &command, const int tan);
 
+	/// Handle an incoming JSON Logging message
+	///
+	/// @param message the incoming message
+	///
+	void handleLoggingCommand(const QJsonObject & message, const QString &command, const int tan);
+
 	///
 	/// Handle an incoming JSON message of unknown type
 	///
@@ -255,9 +262,12 @@ private:
 	/// Flag if forwarder is enabled
 	bool _forwarder_enabled;
 	
-	/// 
+	/// timer for ledcolors streaming
 	QTimer _timer_ledcolors;
 	
+	// streaming buffers
 	QJsonObject _streaming_leds_reply;
+	QJsonObject _streaming_logging_reply;
+	bool _streaming_logging_activated;
 
 };

--- a/libsrc/leddevice/ProviderRs232.cpp
+++ b/libsrc/leddevice/ProviderRs232.cpp
@@ -166,7 +166,7 @@ int ProviderRs232::writeBytes(const qint64 size, const uint8_t * data)
 			return tryOpen(5000) ? 0 : -1;
 		}
 
-		if (_frameDropCounter > 0)
+		if (_frameDropCounter > 5)
 		{
 			Debug(_log, "%d frames dropped", _frameDropCounter);
 		}

--- a/libsrc/utils/CMakeLists.txt
+++ b/libsrc/utils/CMakeLists.txt
@@ -1,54 +1,64 @@
 # Define the current source locations
+
 SET(CURRENT_HEADER_DIR ${CMAKE_SOURCE_DIR}/include/utils)
 SET(CURRENT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/libsrc/utils)
+
+SET(Utils_QT_HEADERS
+	${CURRENT_HEADER_DIR}/Logger.h
+)
+
+SET(Utils_HEADERS
+	${CURRENT_HEADER_DIR}/ColorBgr.h
+	${CURRENT_HEADER_DIR}/ColorRgb.h
+	${CURRENT_HEADER_DIR}/ColorRgba.h
+	${CURRENT_HEADER_DIR}/ColorRgbw.h
+	${CURRENT_HEADER_DIR}/Image.h
+	${CURRENT_HEADER_DIR}/Sleep.h
+	${CURRENT_HEADER_DIR}/FileUtils.h
+	${CURRENT_HEADER_DIR}/Process.h
+	${CURRENT_HEADER_DIR}/PixelFormat.h
+	${CURRENT_HEADER_DIR}/VideoMode.h
+	${CURRENT_HEADER_DIR}/ImageResampler.h
+	${CURRENT_HEADER_DIR}/HsvTransform.h
+	${CURRENT_HEADER_DIR}/HslTransform.h
+	${CURRENT_HEADER_DIR}/RgbChannelTransform.h
+	${CURRENT_HEADER_DIR}/RgbChannelAdjustment.h
+	${CURRENT_HEADER_DIR}/RgbToRgbw.h
+	${CURRENT_HEADER_DIR}/jsonschema/QJsonFactory.h
+	${CURRENT_HEADER_DIR}/jsonschema/QJsonSchemaChecker.h
+)
+
+SET(Utils_SOURCES
+	${CURRENT_SOURCE_DIR}/ColorArgb.cpp
+	${CURRENT_SOURCE_DIR}/ColorBgr.cpp
+	${CURRENT_SOURCE_DIR}/ColorRgb.cpp
+	${CURRENT_SOURCE_DIR}/ColorRgba.cpp
+	${CURRENT_SOURCE_DIR}/ColorRgbw.cpp
+	${CURRENT_SOURCE_DIR}/FileUtils.cpp
+	${CURRENT_SOURCE_DIR}/Process.cpp
+	${CURRENT_SOURCE_DIR}/Logger.cpp
+	${CURRENT_SOURCE_DIR}/ImageResampler.cpp
+	${CURRENT_SOURCE_DIR}/HsvTransform.cpp
+	${CURRENT_SOURCE_DIR}/HslTransform.cpp
+	${CURRENT_SOURCE_DIR}/RgbChannelTransform.cpp
+	${CURRENT_SOURCE_DIR}/RgbChannelAdjustment.cpp
+	${CURRENT_SOURCE_DIR}/RgbToRgbw.cpp
+	${CURRENT_SOURCE_DIR}/jsonschema/QJsonSchemaChecker.cpp
+)
 
 if ( ENABLE_PROFILER )
 	SET ( PROFILER_SOURCE ${CURRENT_HEADER_DIR}/Profiler.h ${CURRENT_SOURCE_DIR}/Profiler.cpp )
 endif()
 
+qt5_wrap_cpp(Utils_HEADERS_MOC ${Utils_QT_HEADERS})
+
+
 add_library(hyperion-utils
-	${CURRENT_HEADER_DIR}/ColorArgb.h
-	${CURRENT_SOURCE_DIR}/ColorArgb.cpp
-	${CURRENT_HEADER_DIR}/ColorBgr.h
-	${CURRENT_SOURCE_DIR}/ColorBgr.cpp
-	${CURRENT_HEADER_DIR}/ColorRgb.h
-	${CURRENT_SOURCE_DIR}/ColorRgb.cpp
-	${CURRENT_HEADER_DIR}/ColorRgba.h
-	${CURRENT_SOURCE_DIR}/ColorRgba.cpp
-	${CURRENT_HEADER_DIR}/ColorRgbw.h
-	${CURRENT_SOURCE_DIR}/ColorRgbw.cpp
-	${CURRENT_HEADER_DIR}/Image.h
-	${CURRENT_HEADER_DIR}/Sleep.h
-	${CURRENT_HEADER_DIR}/FileUtils.h
-	${CURRENT_SOURCE_DIR}/FileUtils.cpp
-	${CURRENT_HEADER_DIR}/Process.h
-	${CURRENT_SOURCE_DIR}/Process.cpp
-
-	${CURRENT_HEADER_DIR}/Logger.h
-	${CURRENT_SOURCE_DIR}/Logger.cpp
+	${Utils_QT_HEADERS}
+	${Utils_HEADERS_MOC}
+	${Utils_HEADERS}
+	${Utils_SOURCES}
 	${PROFILER_SOURCE}
-
-	${CURRENT_HEADER_DIR}/PixelFormat.h
-	${CURRENT_HEADER_DIR}/VideoMode.h
-
-	${CURRENT_HEADER_DIR}/ImageResampler.h
-	${CURRENT_SOURCE_DIR}/ImageResampler.cpp
-
-	${CURRENT_HEADER_DIR}/HsvTransform.h
-	${CURRENT_SOURCE_DIR}/HsvTransform.cpp
-	${CURRENT_HEADER_DIR}/HslTransform.h
-	${CURRENT_SOURCE_DIR}/HslTransform.cpp
-	${CURRENT_HEADER_DIR}/RgbChannelTransform.h
-	${CURRENT_SOURCE_DIR}/RgbChannelTransform.cpp
-	${CURRENT_HEADER_DIR}/RgbChannelAdjustment.h
-	${CURRENT_SOURCE_DIR}/RgbChannelAdjustment.cpp
-
-	${CURRENT_HEADER_DIR}/RgbToRgbw.h
-	${CURRENT_SOURCE_DIR}/RgbToRgbw.cpp
-
-	${CURRENT_HEADER_DIR}/jsonschema/QJsonFactory.h
-	${CURRENT_HEADER_DIR}/jsonschema/QJsonSchemaChecker.h
-	${CURRENT_SOURCE_DIR}/jsonschema/QJsonSchemaChecker.cpp
 )
 
 qt5_use_modules(hyperion-utils Core)

--- a/libsrc/utils/Logger.cpp
+++ b/libsrc/utils/Logger.cpp
@@ -7,18 +7,22 @@
 #include <QFileInfo>
 #include <time.h>
 
-static const char * LogLevelStrings[] = { "", "DEBUG", "INFO", "WARNING", "ERROR" };
-static const int    LogLevelSysLog[]  = { LOG_DEBUG, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR };
-static unsigned int loggerCount = 0;
-static unsigned int loggerId = 0;
+static const char * LogLevelStrings[]   = { "", "DEBUG", "INFO", "WARNING", "ERROR" };
+static const int    LogLevelSysLog[]    = { LOG_DEBUG, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR };
+static unsigned int loggerCount         = 0;
+static unsigned int loggerId            = 0;
 static const int loggerMaxMsgBufferSize = 50;
 
 std::map<std::string,Logger*> *Logger::LoggerMap = nullptr;
 Logger::LogLevel Logger::GLOBAL_MIN_LOG_LEVEL = Logger::UNSET;
 QVector<Logger::T_LOG_MESSAGE> *Logger::GlobalLogMessageBuffer  = nullptr;
 
+LoggerNotifier* LoggerNotifier::instance = nullptr;
+
+
 Logger* Logger::getInstance(std::string name, Logger::LogLevel minLevel)
 {
+	Logger* log = nullptr;
 	if (LoggerMap == nullptr)
 	{
 		LoggerMap = new std::map<std::string,Logger*>;
@@ -26,18 +30,22 @@ Logger* Logger::getInstance(std::string name, Logger::LogLevel minLevel)
 	
 	if ( LoggerMap->find(name) == LoggerMap->end() )
 	{
-		Logger* log = new Logger(name,minLevel);
+		log = new Logger(name,minLevel);
 		LoggerMap->insert(std::pair<std::string,Logger*>(name,log)); // compat version, replace it with following line if we have 100% c++11
 		//LoggerMap->emplace(name,log);  // not compat with older linux distro's e.g. wheezy
-		return log;
-	} 
+		connect(log, SIGNAL(newLogMessage(Logger::T_LOG_MESSAGE)), LoggerNotifier::getInstance(), SLOT(handleNewLogMessage(Logger::T_LOG_MESSAGE)));
+	}
+	else
+	{
+		log = LoggerMap->at(name);
+	}
 
 	if (GlobalLogMessageBuffer == nullptr)
 	{
 		GlobalLogMessageBuffer = new QVector<Logger::T_LOG_MESSAGE>;
 	}
 
-	return LoggerMap->at(name);
+	return log;
 }
 
 void Logger::deleteInstance(std::string name)
@@ -86,11 +94,12 @@ Logger::LogLevel Logger::getLogLevel(std::string name)
 	return log->getMinLevel();
 }
 
-Logger::Logger ( std::string name, LogLevel minLevel ):
-	_name(name),
-	_minLevel(minLevel),
-	_syslogEnabled(true),
-	_loggerId(loggerId++)
+Logger::Logger ( std::string name, LogLevel minLevel )
+	: QObject()
+	, _name(name)
+	, _minLevel(minLevel)
+	, _syslogEnabled(true)
+	, _loggerId(loggerId++)
 {
 #ifdef __GLIBC__
     const char* _appname_char = program_invocation_short_name;
@@ -143,6 +152,7 @@ void Logger::Message(LogLevel level, const char* sourceFile, const char* func, u
 	logMsg.levelString = QString::fromStdString(LogLevelStrings[level]);
 
 	emit newLogMessage(logMsg);
+
 	QString location;
 	if ( level == Logger::DEBUG )
 	{
@@ -165,3 +175,25 @@ void Logger::Message(LogLevel level, const char* sourceFile, const char* func, u
 }
 
 
+LoggerNotifier::LoggerNotifier()
+	: QObject()
+{
+}
+
+LoggerNotifier::~LoggerNotifier()
+{
+}
+
+
+void LoggerNotifier::handleNewLogMessage(Logger::T_LOG_MESSAGE msg)
+{
+	//std::cout << "<" << msg.loggerName.toStdString() << "> " << msg.message.toStdString() << std::endl;
+	emit newLogMessage(msg);
+}
+
+LoggerNotifier* LoggerNotifier::getInstance()
+{
+	if ( instance == nullptr )
+		instance = new LoggerNotifier();
+	return instance;
+}

--- a/libsrc/utils/Profiler.cpp
+++ b/libsrc/utils/Profiler.cpp
@@ -21,12 +21,12 @@ double getClockDelta(clock_t start)
 	return ((double)(clock() - start) / CLOCKS_PER_SEC)	;
 }
 
-Profiler::Profiler(const char* sourceFile, const char* func, unsigned int line) :
-	_file(sourceFile),
-	_func(func),
-	_line(line),
-	_blockId(blockCounter++),
-	_startTime(clock())
+Profiler::Profiler(const char* sourceFile, const char* func, unsigned int line)
+	: _file(sourceFile)
+	, _func(func)
+	, _line(line)
+	, _blockId(blockCounter++)
+	, _startTime(clock())
 {
 	Profiler::initLogger();
 	_logger->Message(Logger::DEBUG,_file,_func,_line,">>> enter block %d", _blockId);


### PR DESCRIPTION
**1.** Tell us something about your changes.
implement a in memory global log buffer. this can be used for e.g. webinterface to retrieve last log messages

call:
`QVector<Logger::T_LOG_MESSAGE>* logMessages = Logger::getGlobalLogMessageBuffer();`
to retrieve the messages. (logger.h should provide needed info about the message struct)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org
