### PR TITLE
Added latchtime web configuration for ws2801 device.

### DIFF
--- a/libsrc/leddevice/LedDeviceWs2801.cpp
+++ b/libsrc/leddevice/LedDeviceWs2801.cpp
@@ -3,11 +3,8 @@
 LedDeviceWs2801::LedDeviceWs2801(const QJsonObject &deviceConfig)
 	: ProviderSpi()
 {
+	_latchTime_ns = 500000;
 	_deviceReady = 	ProviderSpi::init(deviceConfig);
-	if (deviceConfig["latchtime"] == QJsonValue::Undefined )
-	{
-		_latchTime_ns = 500000;
-	}
 }
 
 LedDevice* LedDeviceWs2801::construct(const QJsonObject &deviceConfig)

--- a/libsrc/leddevice/LedDeviceWs2801.cpp
+++ b/libsrc/leddevice/LedDeviceWs2801.cpp
@@ -4,6 +4,10 @@ LedDeviceWs2801::LedDeviceWs2801(const QJsonObject &deviceConfig)
 	: ProviderSpi()
 {
 	_deviceReady = 	ProviderSpi::init(deviceConfig);
+	if (deviceConfig["latchtime"] == QJsonValue::Undefined )
+	{
+		_latchTime_ns = 500000;
+	}
 }
 
 LedDevice* LedDeviceWs2801::construct(const QJsonObject &deviceConfig)

--- a/libsrc/leddevice/schemas/schema-ws2801.json
+++ b/libsrc/leddevice/schemas/schema-ws2801.json
@@ -18,6 +18,7 @@
                         "type": "integer",
                         "title":"Latchtime",
                         "default": 500000,
+                        "append" : "ms",
                         "propertyOrder" : 3
                 },
 		"invert": {

--- a/libsrc/leddevice/schemas/schema-ws2801.json
+++ b/libsrc/leddevice/schemas/schema-ws2801.json
@@ -18,7 +18,7 @@
                         "type": "integer",
                         "title":"Latchtime",
                         "default": 500000,
-                        "append" : "ms",
+                        "append" : "ns",
                         "propertyOrder" : 3
                 },
 		"invert": {

--- a/libsrc/leddevice/schemas/schema-ws2801.json
+++ b/libsrc/leddevice/schemas/schema-ws2801.json
@@ -14,12 +14,18 @@
 			"default": 1000000,
 			"propertyOrder" : 2
 		},
+                "latchtime": {
+                        "type": "integer",
+                        "title":"Latchtime",
+                        "default": 500000,
+                        "propertyOrder" : 3
+                },
 		"invert": {
 			"type": "boolean",
 			"format": "checkbox",
 			"title":"Invert signal",
 			"default": false,
-			"propertyOrder" : 3
+			"propertyOrder" : 4
 		}
 	},
 	"additionalProperties": true


### PR DESCRIPTION
**1.** Tell us something about your changes.
Added latchtime web configuration for ws2801 device.
Fixed default to be 500000ns

**2.** If this changes affect the .conf file. Please provide the changed section
not directly - if omitted the defatul is now 500,000ns rather than zero

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org
