### PR TITLE
Fix wrong command in CompileHowto

### DIFF
--- a/CompileHowto.md
+++ b/CompileHowto.md
@@ -39,7 +39,7 @@ brew install doxygen
 ### The general quick way (without big comments)
 assume your home is /home/pi
 ```bash
-cd git clone --recursive https://github.com/hyperion-project/hyperion.ng.git hyperion
+git clone --recursive https://github.com/hyperion-project/hyperion.ng.git hyperion
 cd hyperion
 mkdir build
 cd build


### PR DESCRIPTION
**1.** Tell us something about your changes.

The commant 
`cd git clone --recursive https://github.com/hyperion-project/hyperion.ng.git hyperion`
should be
`git clone --recursive https://github.com/hyperion-project/hyperion.ng.git hyperion`

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org


