### PR TITLE
Update CompileHowto.md to say that Ubuntu instructions apply to Win10 Linux Subsystem

### DIFF
--- a/CompileHowto.md
+++ b/CompileHowto.md
@@ -1,6 +1,6 @@
 # Install the required tools and dependencies
 
-## Debian/Ubuntu
+## Debian/Ubuntu/Win10LinuxSubsystem
 
 ```
 sudo apt-get update


### PR DESCRIPTION
**1.** Tell us something about your changes.
Me and penfold42 compiled it on Windows 10 Bash window and it compiled and ran, so I added it to the compile howto

