### PR TITLE
Kill "Rainbow lights" when v4l grabber has no signal

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -153,6 +153,10 @@
 	///  * redSignalThreshold   : Signal threshold for the red channel between 0.0 and 1.0 [default=0.0]
 	///  * greenSignalThreshold : Signal threshold for the green channel between 0.0 and 1.0 [default=0.0]
 	///  * blueSignalThreshold  : Signal threshold for the blue channel between 0.0 and 1.0 [default=0.0]
+	///  * signalDetectionVerticalOffsetMin   : area for signal detection - horizontal minimum offset value. Values between 0.0 and 1.0
+	///  * signalDetectionHorizontalOffsetMin : area for signal detection - vertical minimum offset value. Values between 0.0 and 1.0
+	///  * signalDetectionVerticalOffsetMax   : area for signal detection - horizontal maximum offset value. Values between 0.0 and 1.0
+	///  * signalDetectionHorizontalOffsetMax : area for signal detection - vertical maximum offset value. Values between 0.0 and 1.0
 	"grabberV4L2" :
 	[
 		{
@@ -173,7 +177,11 @@
 			"cropBottom"  : 0,
 			"redSignalThreshold"   : 0.0,
 			"greenSignalThreshold" : 0.0,
-			"blueSignalThreshold"  : 0.0
+			"blueSignalThreshold"  : 0.0,
+			"signalDetectionVerticalOffsetMin"   : 0.25,
+			"signalDetectionHorizontalOffsetMin" : 0.25,
+			"signalDetectionVerticalOffsetMax"   : 0.75,
+			"signalDetectionHorizontalOffsetMax" : 0.75
 		}
 	],
 

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -105,7 +105,11 @@
 			"cropBottom"  : 0,
 			"redSignalThreshold"   : 0.0,
 			"greenSignalThreshold" : 0.0,
-			"blueSignalThreshold"  : 0.0
+			"blueSignalThreshold"  : 0.0,
+			"signalDetectionVerticalOffsetMin"   : 0.25,
+			"signalDetectionHorizontalOffsetMin" : 0.25,
+			"signalDetectionVerticalOffsetMax"   : 0.75,
+			"signalDetectionHorizontalOffsetMax" : 0.75
 		}
 	],
 

--- a/include/grabber/V4L2Grabber.h
+++ b/include/grabber/V4L2Grabber.h
@@ -8,6 +8,7 @@
 // Qt includes
 #include <QObject>
 #include <QSocketNotifier>
+#include <QRectF>
 
 // util includes
 #include <utils/Image.h>
@@ -35,8 +36,11 @@ public:
 			int height,
 			int frameDecimation,
 			int horizontalPixelDecimation,
-			int verticalPixelDecimation);
+			int verticalPixelDecimation
+	);
 	virtual ~V4L2Grabber();
+
+	QRectF getSignalDetectionOffset();
 
 public slots:
 	void setCropping(int cropLeft,
@@ -46,10 +50,17 @@ public slots:
 
 	void set3D(VideoMode mode);
 
-	void setSignalThreshold(double redSignalThreshold,
+	void setSignalThreshold(
+					double redSignalThreshold,
 					double greenSignalThreshold,
 					double blueSignalThreshold,
 					int noSignalCounterThreshold);
+
+	void setSignalDetectionOffset(
+					double verticalMin,
+					double horizontalMin,
+					double verticalMax,
+					double horizontalMax);
 
 	bool start();
 
@@ -137,4 +148,11 @@ private:
 	Logger * _log;
 	bool _initialized;
 	bool _deviceAutoDiscoverEnabled;
+	
+	bool  _noSignalDetected;
+	double _x_frac_min;
+	double _y_frac_min;
+	double _x_frac_max;
+	double _y_frac_max;
+
 };

--- a/include/grabber/V4L2Wrapper.h
+++ b/include/grabber/V4L2Wrapper.h
@@ -29,11 +29,10 @@ public:
 
 public slots:
 	bool start();
-
 	void stop();
 
 	void setCropping(int cropLeft, int cropRight, int cropTop, int cropBottom);
-
+	void setSignalDetectionOffset(double verticalMin, double horizontalMin, double verticalMax, double horizontalMax);
 	void set3D(VideoMode mode);
 
 // signals:

--- a/include/utils/ColorRgb.h
+++ b/include/utils/ColorRgb.h
@@ -61,3 +61,16 @@ inline bool operator<=(const ColorRgb & lhs, const ColorRgb & rhs)
 {
 	return (lhs.red <= rhs.red) && (lhs.green <= rhs.green) && (lhs.blue <= rhs.blue);
 }
+
+/// Compare operator to check if a color is 'greater' to another color
+inline bool operator>(const ColorRgb & lhs, const ColorRgb & rhs)
+{
+	return (lhs.red > rhs.red) && (lhs.green > rhs.green) && (lhs.blue > rhs.blue);
+}
+
+/// Compare operator to check if a color is 'greater' than or 'equal' to another color
+inline bool operator>=(const ColorRgb & lhs, const ColorRgb & rhs)
+{
+	return (lhs.red >= rhs.red) && (lhs.green >= rhs.green) && (lhs.blue >= rhs.blue);
+}
+

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -786,17 +786,32 @@ void V4L2Grabber::process_image(const uint8_t * data)
 	_imageResampler.processImage(data, _width, _height, _lineLength, _pixelFormat, image);
 
 	// check signal (only in center of the resulting image, because some grabbers have noise values along the borders)
-	bool noSignal = true;
-	for (unsigned x = 0; noSignal && x < (image.width()>>1); ++x)
+	bool     noSignal = true;
+
+	float x_frac_min = 0.47;
+	float y_frac_min = 0.2;
+	float x_frac_max = 0.49;
+	float y_frac_max = 0.8;
+
+// 	float x_frac_min = 0.25;
+// 	float y_frac_min = 0.25;
+// 	float x_frac_max = 0.75;
+// 	float y_frac_max = 0.75;
+
+	// top left
+	unsigned xOffset  = image.width()  * x_frac_min;
+	unsigned yOffset  = image.height() * y_frac_min;
+
+	// bottom right
+	unsigned xMax     = image.width()  * x_frac_max;
+	unsigned yMax     = image.height() * y_frac_max;
+
+	
+	for (unsigned x = xOffset; noSignal && x < xMax; ++x)
 	{
-		int xImage = (image.width()>>2) + x;
-
-		for (unsigned y = 0; noSignal && y < (image.height()>>1); ++y)
+		for (unsigned y = yOffset; noSignal && y < yMax; ++y)
 		{
-			int yImage = (image.height()>>2) + y;
-
-			ColorRgb & rgb = image(xImage, yImage);
-			noSignal &= rgb <= _noSignalThresholdColor;
+			noSignal &= (ColorRgb&)image(x, y) <= _noSignalThresholdColor;
 		}
 	}
 

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -23,15 +23,16 @@
 
 #define CLEAR(x) memset(&(x), 0, sizeof(x))
 
-V4L2Grabber::V4L2Grabber(const std::string & device,
-		int input,
-		VideoStandard videoStandard,
-		PixelFormat pixelFormat,
-		int width,
-		int height,
-		int frameDecimation,
-		int horizontalPixelDecimation,
-		int verticalPixelDecimation)
+V4L2Grabber::V4L2Grabber(const std::string & device
+		, int input
+		, VideoStandard videoStandard
+		, PixelFormat pixelFormat
+		, int width
+		, int height
+		, int frameDecimation
+		, int horizontalPixelDecimation
+		, int verticalPixelDecimation
+		)
 	: _deviceName(device)
 	, _input(input)
 	, _videoStandard(videoStandard)
@@ -53,6 +54,12 @@ V4L2Grabber::V4L2Grabber(const std::string & device,
 	, _log(Logger::getInstance("V4L2:"+device))
 	, _initialized(false)
 	, _deviceAutoDiscoverEnabled(false)
+	, _noSignalDetected(false)
+	, _x_frac_min(0.25)
+	, _y_frac_min(0.25)
+	, _x_frac_max(0.75)
+	, _y_frac_max(0.75)
+
 {
 	_imageResampler.setHorizontalPixelDecimation(std::max(1, horizontalPixelDecimation));
 	_imageResampler.setVerticalPixelDecimation(std::max(1, verticalPixelDecimation));
@@ -194,6 +201,24 @@ void V4L2Grabber::setSignalThreshold(double redSignalThreshold, double greenSign
 	std::stringstream ss;
 	ss << _noSignalThresholdColor;
 	Info(_log, "Signal threshold set to: %s", ss.str().c_str() );
+}
+
+void V4L2Grabber::setSignalDetectionOffset(double horizontalMin, double verticalMin, double horizontalMax, double verticalMax)
+{
+	// rainbow 16 stripes 0.47 0.2 0.49 0.8
+	// unicolor: 0.25 0.25 0.75 0.75
+
+	_x_frac_min = horizontalMin;
+	_y_frac_min = verticalMin;
+	_x_frac_max = horizontalMax;
+	_y_frac_max = verticalMax;
+
+	Info(_log, "Signal detection area set to: %f,%f x %f,%f", _x_frac_min, _y_frac_min, _x_frac_max, _y_frac_max );
+}
+
+QRectF V4L2Grabber::getSignalDetectionOffset()
+{
+	return QRectF(_x_frac_min, _y_frac_min, _x_frac_max, _y_frac_max);
 }
 
 bool V4L2Grabber::start()
@@ -786,25 +811,15 @@ void V4L2Grabber::process_image(const uint8_t * data)
 	_imageResampler.processImage(data, _width, _height, _lineLength, _pixelFormat, image);
 
 	// check signal (only in center of the resulting image, because some grabbers have noise values along the borders)
-	bool     noSignal = true;
-
-	float x_frac_min = 0.47;
-	float y_frac_min = 0.2;
-	float x_frac_max = 0.49;
-	float y_frac_max = 0.8;
-
-// 	float x_frac_min = 0.25;
-// 	float y_frac_min = 0.25;
-// 	float x_frac_max = 0.75;
-// 	float y_frac_max = 0.75;
+	bool noSignal = true;
 
 	// top left
-	unsigned xOffset  = image.width()  * x_frac_min;
-	unsigned yOffset  = image.height() * y_frac_min;
+	unsigned xOffset  = image.width()  * _x_frac_min;
+	unsigned yOffset  = image.height() * _y_frac_min;
 
 	// bottom right
-	unsigned xMax     = image.width()  * x_frac_max;
-	unsigned yMax     = image.height() * y_frac_max;
+	unsigned xMax     = image.width()  * _x_frac_max;
+	unsigned yMax     = image.height() * _y_frac_max;
 
 	
 	for (unsigned x = xOffset; noSignal && x < xMax; ++x)
@@ -823,6 +838,7 @@ void V4L2Grabber::process_image(const uint8_t * data)
 	{
 		if (_noSignalCounter >= _noSignalCounterThreshold)
 		{
+			_noSignalDetected = true;
 			Info(_log, "Signal detected");
 		}
 
@@ -835,6 +851,7 @@ void V4L2Grabber::process_image(const uint8_t * data)
 	}
 	else if (_noSignalCounter == _noSignalCounterThreshold)
 	{
+		_noSignalDetected = false;
 		Info(_log, "Signal lost");
 	}
 }

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -74,6 +74,12 @@ void V4L2Wrapper::setCropping(int cropLeft, int cropRight, int cropTop, int crop
 	_grabber.setCropping(cropLeft, cropRight, cropTop, cropBottom);
 }
 
+void V4L2Wrapper::setSignalDetectionOffset(double verticalMin, double horizontalMin, double verticalMax, double horizontalMax)
+{
+	_grabber.setSignalDetectionOffset(verticalMin, horizontalMin, verticalMax, horizontalMax);
+}
+
+
 void V4L2Wrapper::set3D(VideoMode mode)
 {
 	_grabber.set3D(mode);

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -540,7 +540,7 @@
 						"minimum" : 0.0,
 						"maximum" : 1.0,
 						"default" : 0.1,
-						"step" : 0.01,
+						"step" : 0.005,
 						"append" : "edt_append_percent",
 						"propertyOrder" : 16
 					},
@@ -551,7 +551,7 @@
 						"minimum" : 0.0,
 						"maximum" : 1.0,
 						"default" : 0.1,
-						"step" : 0.01,
+						"step" : 0.025,
 						"append" : "edt_append_percent",
 						"propertyOrder" : 17
 					},
@@ -562,9 +562,53 @@
 						"minimum" : 0.0,
 						"maximum" : 1.0,
 						"default" : 0.1,
-						"step" : 0.01,
+						"step" : 0.005,
 						"append" : "edt_append_percent",
 						"propertyOrder" : 18
+					},
+					"signalDetectionVerticalOffsetMin" :
+					{
+						"type" : "number",
+						"title" : "edt_conf_v4l2_signalDetectionVerticalOffsetMin_title",
+						"minimum" : 0.0,
+						"maximum" : 1.0,
+						"default" : 0.1,
+						"step" : 0.005,
+						"append" : "edt_append_percent",
+						"propertyOrder" : 19
+					},
+					"signalDetectionVerticalOffsetMax" :
+					{
+						"type" : "number",
+						"title" : "edt_conf_v4l2_signalDetectionVerticalOffsetMax_title",
+						"minimum" : 0.0,
+						"maximum" : 1.0,
+						"default" : 0.1,
+						"step" : 0.005,
+						"append" : "edt_append_percent",
+						"propertyOrder" : 20
+					},
+					"signalDetectionHorizontalOffsetMin" :
+					{
+						"type" : "number",
+						"title" : "edt_conf_v4l2_signalDetectionHorizontalOffsetMin_title",
+						"minimum" : 0.0,
+						"maximum" : 1.0,
+						"default" : 0.1,
+						"step" : 0.005,
+						"append" : "edt_append_percent",
+						"propertyOrder" : 21
+					},
+					"signalDetectionHorizontalOffsetMax" :
+					{
+						"type" : "number",
+						"title" : "edt_conf_v4l2_signalDetectionHorizontalOffsetMax_title",
+						"minimum" : 0.0,
+						"maximum" : 1.0,
+						"default" : 0.1,
+						"step" : 0.005,
+						"append" : "edt_append_percent",
+						"propertyOrder" : 22
 					}
 				},
 			"additionalProperties" : false

--- a/src/hyperion-v4l2/ScreenshotHandler.cpp
+++ b/src/hyperion-v4l2/ScreenshotHandler.cpp
@@ -5,8 +5,9 @@
 // hyperion-v4l2 includes
 #include "ScreenshotHandler.h"
 
-ScreenshotHandler::ScreenshotHandler(const QString & filename) :
-	_filename(filename)
+ScreenshotHandler::ScreenshotHandler(const QString & filename, const QRectF & signalDetectionOffset)
+	: _filename(filename)
+	, _signalDetectionOffset(signalDetectionOffset)
 {
 }
 
@@ -16,10 +17,20 @@ ScreenshotHandler::~ScreenshotHandler()
 
 void ScreenshotHandler::receiveImage(const Image<ColorRgb> & image)
 {
-	std::cout << std::endl << "Screenshot details" << std::endl << "==================" << std::endl;
-	std::cout << "dimension: " << image.width() << " x " << image.width() << std::endl;
-	std::cout << "no signal detection area: " << (image.width()>>2) << "," << (image.height()>>2) << " x "
-	          << (image.width()>>1)-1 << "," << (image.height()>>1)-1  << std::endl;
+	double x_frac_min = _signalDetectionOffset.x();
+	double y_frac_min = _signalDetectionOffset.y();
+	double x_frac_max = _signalDetectionOffset.width();
+	double y_frac_max = _signalDetectionOffset.height();
+
+	int xOffset   = image.width()  * x_frac_min;
+	int yOffset   = image.height() * y_frac_min;
+	int xMax      = image.width()  * x_frac_max;
+	int yMax      = image.height() * y_frac_max;
+
+	std::cout << std::endl << "Screenshot details"
+	          << std::endl << "=================="
+	          << std::endl << "dimension after decimation: " << image.width() << " x " << image.height()
+	          << std::endl << "signal detection area  : " << xOffset << "," << yOffset << " x "  << xMax << "," << yMax  << std::endl;
 
 	ColorRgb noSignalThresholdColor = {0,0,0};
 
@@ -38,8 +49,8 @@ void ScreenshotHandler::receiveImage(const Image<ColorRgb> & image)
 			}
 		}
 	}
-	std::cout << "no signal threshold Color: " << noSignalThresholdColor << std::endl;
-	std::cout << "no signal threshold values: " << (float)noSignalThresholdColor.red/255.0f << ", "<< (float)noSignalThresholdColor.green/255.0f << ", " << (float)noSignalThresholdColor.blue/255.0f << std::endl;
+	std::cout << "signal threshold color : " << noSignalThresholdColor << std::endl;
+	std::cout << "signal threshold values: " << (float)noSignalThresholdColor.red/255.0f << ", "<< (float)noSignalThresholdColor.green/255.0f << ", " << (float)noSignalThresholdColor.blue/255.0f << std::endl;
 
 	// store as PNG
 	QImage pngImage((const uint8_t *) image.memptr(), image.width(), image.height(), 3*image.width(), QImage::Format_RGB888);

--- a/src/hyperion-v4l2/ScreenshotHandler.cpp
+++ b/src/hyperion-v4l2/ScreenshotHandler.cpp
@@ -16,6 +16,31 @@ ScreenshotHandler::~ScreenshotHandler()
 
 void ScreenshotHandler::receiveImage(const Image<ColorRgb> & image)
 {
+	std::cout << std::endl << "Screenshot details" << std::endl << "==================" << std::endl;
+	std::cout << "dimension: " << image.width() << " x " << image.width() << std::endl;
+	std::cout << "no signal detection area: " << (image.width()>>2) << "," << (image.height()>>2) << " x "
+	          << (image.width()>>1)-1 << "," << (image.height()>>1)-1  << std::endl;
+
+	ColorRgb noSignalThresholdColor = {0,0,0};
+
+	for (unsigned x = 0; x < (image.width()>>1); ++x)
+	{
+		int xImage = (image.width()>>2) + x;
+
+		for (unsigned y = 0; y < (image.height()>>1); ++y)
+		{
+			int yImage = (image.height()>>2) + y;
+
+			ColorRgb rgb = image(xImage, yImage);
+			if (rgb > noSignalThresholdColor)
+			{
+				noSignalThresholdColor = rgb;
+			}
+		}
+	}
+	std::cout << "no signal threshold Color: " << noSignalThresholdColor << std::endl;
+	std::cout << "no signal threshold values: " << (float)noSignalThresholdColor.red/255.0f << ", "<< (float)noSignalThresholdColor.green/255.0f << ", " << (float)noSignalThresholdColor.blue/255.0f << std::endl;
+
 	// store as PNG
 	QImage pngImage((const uint8_t *) image.memptr(), image.width(), image.height(), 3*image.width(), QImage::Format_RGB888);
 	pngImage.save(_filename);

--- a/src/hyperion-v4l2/ScreenshotHandler.h
+++ b/src/hyperion-v4l2/ScreenshotHandler.h
@@ -1,5 +1,6 @@
 // Qt includes
 #include <QObject>
+#include <QRectF>
 
 // hyperionincludes
 #include <utils/Image.h>
@@ -11,7 +12,7 @@ class ScreenshotHandler : public QObject
 	Q_OBJECT
 
 public:
-	ScreenshotHandler(const QString & filename);
+	ScreenshotHandler(const QString & filename, const QRectF & signalDetectionOffset);
 	virtual ~ScreenshotHandler();
 
 public slots:
@@ -21,4 +22,5 @@ public slots:
 
 private:
 	const QString _filename;
+	const QRectF  _signalDetectionOffset;
 };

--- a/src/hyperion-v4l2/hyperion-v4l2.cpp
+++ b/src/hyperion-v4l2/hyperion-v4l2.cpp
@@ -34,6 +34,7 @@ void saveScreenshot(QString filename, const Image<ColorRgb> & image)
 
 int main(int argc, char** argv)
 {
+	Logger *log = Logger::getInstance("V4L2GRABBER");
 	std::cout
 		<< "hyperion-v4l2:" << std::endl
 		<< "\tVersion   : " << HYPERION_VERSION << " (" << HYPERION_BUILD_ID << ")" << std::endl
@@ -68,10 +69,17 @@ int main(int argc, char** argv)
 		IntOption          & argSizeDecimation      = parser.add<IntOption>    ('s', "size-decimator", "Decimation factor for the output size [default=%1]", "1");
 		IntOption          & argFrameDecimation     = parser.add<IntOption>    ('f', "frame-decimator", "Decimation factor for the video frames [default=%1]", "1");
 		BooleanOption      & argScreenshot          = parser.add<BooleanOption>(0x0, "screenshot", "Take a single screenshot, save it to file and quit");
+
 		DoubleOption       & argSignalThreshold     = parser.add<DoubleOption> ('t', "signal-threshold", "The signal threshold for detecting the presence of a signal. Value should be between 0.0 and 1.0.", QString(), 0.0, 1.0);
 		DoubleOption       & argRedSignalThreshold  = parser.add<DoubleOption> (0x0, "red-threshold", "The red signal threshold. Value should be between 0.0 and 1.0. (overrides --signal-threshold)");
 		DoubleOption       & argGreenSignalThreshold= parser.add<DoubleOption> (0x0, "green-threshold", "The green signal threshold. Value should be between 0.0 and 1.0. (overrides --signal-threshold)");
 		DoubleOption       & argBlueSignalThreshold = parser.add<DoubleOption> (0x0, "blue-threshold", "The blue signal threshold. Value should be between 0.0 and 1.0. (overrides --signal-threshold)");
+
+		DoubleOption       & argSignalHorizontalMin = parser.add<DoubleOption> (0x0, "signal-horizontal-min", "area for signal detection - horizontal minimum offset value. Values between 0.0 and 1.0");
+		DoubleOption       & argSignalVerticalMin   = parser.add<DoubleOption> (0x0, "signal-vertical-min"  , "area for signal detection - vertical minimum offset value. Values between 0.0 and 1.0");
+		DoubleOption       & argSignalHorizontalMax = parser.add<DoubleOption> (0x0, "signal-horizontal-max", "area for signal detection - horizontal maximum offset value. Values between 0.0 and 1.0");
+		DoubleOption       & argSignalVerticalMax   = parser.add<DoubleOption> (0x0, "signal-vertical-max"  , "area for signal detection - vertical maximum offset value. Values between 0.0 and 1.0");
+
 		BooleanOption      & arg3DSBS               = parser.add<BooleanOption>(0x0, "3DSBS", "Interpret the incoming video stream as 3D side-by-side");
 		BooleanOption      & arg3DTAB               = parser.add<BooleanOption>(0x0, "3DTAB", "Interpret the incoming video stream as 3D top-and-bottom");
 		Option             & argAddress             = parser.add<Option>       ('a', "address", "Set the address of the hyperion server [default: %1]", "127.0.0.1:19445");
@@ -111,17 +119,55 @@ int main(int argc, char** argv)
 
 		// set signal detection
 		grabber.setSignalThreshold(
-					std::min(1.0, std::max(0.0, parser.isSet(argRedSignalThreshold) ? argRedSignalThreshold.getDouble(parser) : argSignalThreshold.getDouble(parser))),
+					std::min(1.0, std::max(0.0, parser.isSet(argRedSignalThreshold)   ? argRedSignalThreshold.getDouble(parser)   : argSignalThreshold.getDouble(parser))),
 					std::min(1.0, std::max(0.0, parser.isSet(argGreenSignalThreshold) ? argGreenSignalThreshold.getDouble(parser) : argSignalThreshold.getDouble(parser))),
-					std::min(1.0, std::max(0.0, parser.isSet(argBlueSignalThreshold) ? argBlueSignalThreshold.getDouble(parser) : argSignalThreshold.getDouble(parser))),
+					std::min(1.0, std::max(0.0, parser.isSet(argBlueSignalThreshold)  ? argBlueSignalThreshold.getDouble(parser)  : argSignalThreshold.getDouble(parser))),
 					50);
 
 		// set cropping values
 		grabber.setCropping(
-			parser.isSet(argCropLeft) ? argCropLeft.getInt(parser) : argCropWidth.getInt(parser),
-			parser.isSet(argCropRight) ? argCropRight.getInt(parser) : argCropWidth.getInt(parser),
-			parser.isSet(argCropTop) ? argCropTop.getInt(parser) : argCropHeight.getInt(parser),
+			parser.isSet(argCropLeft)   ? argCropLeft.getInt(parser)   : argCropWidth.getInt(parser),
+			parser.isSet(argCropRight)  ? argCropRight.getInt(parser)  : argCropWidth.getInt(parser),
+			parser.isSet(argCropTop)    ? argCropTop.getInt(parser)    : argCropHeight.getInt(parser),
 			parser.isSet(argCropBottom) ? argCropBottom.getInt(parser) : argCropHeight.getInt(parser));
+
+		bool signalAreaOptsOk = true;
+		if (parser.isSet(argSignalHorizontalMin) != parser.isSet(argSignalVerticalMin))
+		{
+			signalAreaOptsOk = false;
+		}
+
+		if (parser.isSet(argSignalHorizontalMin) != parser.isSet(argSignalHorizontalMax))
+		{
+			signalAreaOptsOk = false;
+		}
+
+		if (parser.isSet(argSignalHorizontalMin) != parser.isSet(argSignalVerticalMax))
+		{
+			signalAreaOptsOk = false;
+		}
+
+		if (!signalAreaOptsOk)
+		{
+			Error(log, "aborting, because --signal-[vertical|horizontal]-[min|max] options must be used together");
+			return 1;
+		}
+
+		double x_frac_min = argSignalHorizontalMin.getDouble(parser);
+		double y_frac_min = argSignalVerticalMin.getDouble(parser);
+		double x_frac_max = argSignalHorizontalMax.getDouble(parser);
+		double y_frac_max = argSignalVerticalMax.getDouble(parser);
+
+		if (x_frac_min<0.0 || y_frac_min<0.0 || x_frac_max<0.0 || y_frac_max<0.0 || x_frac_min>1.0 || y_frac_min>1.0 ||  x_frac_max>1.0 ||  y_frac_max>1.0)
+		{
+			Error(log, "aborting, because --signal-[vertical|horizontal]-[min|max] values have to be between 0.0 and 1.0");
+			return 1;
+		}
+
+		if (parser.isSet(argSignalHorizontalMin))
+		{
+			grabber.setSignalDetectionOffset( x_frac_min, y_frac_min, x_frac_max, y_frac_max);
+		}
 
 		// set 3D mode if applicable
 		if (parser.isSet(arg3DSBS))
@@ -136,7 +182,9 @@ int main(int argc, char** argv)
 		// run the grabber
 		if (parser.isSet(argScreenshot))
 		{
-			ScreenshotHandler handler("screenshot.png");
+			const QRectF signalDetectionOffset = grabber.getSignalDetectionOffset();
+
+			ScreenshotHandler handler("screenshot.png", signalDetectionOffset);
 			QObject::connect(&grabber, SIGNAL(newFrame(Image<ColorRgb>)), &handler, SLOT(receiveImage(Image<ColorRgb>)));
 			grabber.start();
 			QCoreApplication::exec();
@@ -154,7 +202,7 @@ int main(int argc, char** argv)
 	catch (const std::runtime_error & e)
 	{
 		// An error occured. Display error and quit
-                Error(Logger::getInstance("V4L2GRABBER"), "%s", e.what());
+		Error(log, "%s", e.what());
 		return 1;
 	}
 

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -582,6 +582,11 @@ void HyperionDaemon::createGrabberV4L2()
 				grabberConfig["cropRight"].toInt(0),
 				grabberConfig["cropTop"].toInt(0),
 				grabberConfig["cropBottom"].toInt(0));
+			grabber->setSignalDetectionOffset(
+				grabberConfig["signalDetectionHorizontalOffsetMin"].toDouble(0.25),
+				grabberConfig["signalDetectionVerticalOffsetMin"].toDouble(0.25),
+				grabberConfig["signalDetectionHorizontalOffsetMax"].toDouble(0.75),
+				grabberConfig["signalDetectionVerticalOffsetMax"].toDouble(0.75));
 			Debug(_log, "V4L2 grabber created");
 
 			QObject::connect(grabber, SIGNAL(emitImage(int, const Image<ColorRgb>&, const int)), _protoServer, SLOT(sendImageToProtoSlaves(int, const Image<ColorRgb>&, const int)));


### PR DESCRIPTION
**1.** Tell us something about your changes.

some HDMI2AV generates rainbow patterns when no signal is detected. This is not detectable with current signal detection mechanism.

More details here:
https://hyperion-project.org/threads/v4l2-add-shutdown-detection.146/
https://github.com/hyperion-project/hyperion/issues/92

I tested with this picture
![rainbow](https://cloud.githubusercontent.com/assets/6893049/21248393/17d6bff6-c337-11e6-912f-704f7d59b588.jpg)

to activate add following lines to grabberv4l section in config:
```
"signalDetectionVerticalOffsetMin"   : 0.25,
"signalDetectionHorizontalOffsetMin" : 0.25,
"signalDetectionVerticalOffsetMax"   : 0.75,
"signalDetectionHorizontalOffsetMax" : 0.75
```
This describes the area where to analyze the signal threshold. This values in particular are the current state. The values for the rainbow pic shown above are `0.47 0.2 0.49 0.8` - only the left blue line is evaluated.

**Additional feature**
hyperion-v4l gets new feature - auto evaluation of threshold values.
make a screenshot with hyperion-v4l2, then some details are displayed:

```
hyperion.ng2/build$ bin/hyperion-v4l2 -s8 -d usbtv --screenshot
hyperion-v4l2:
        Version   : 2.0.0 (rainbow (redpanther-0da749d/96fd841-1481800592))
        build time: Dec 16 2016 02:17:24
[HYPERION-V4L2 V4L2:usbtv] <INFO> Signal threshold set to: {0,0,0}
[HYPERION-V4L2 V4L2:usbtv] <INFO> available V4L2 devices:
        /dev/video0     BT878 video (Hauppauge (bt878))
        /dev/video1     usbtv

[HYPERION-V4L2 V4L2:usbtv] <INFO> found v4l2 device with configured name: usbtv (/dev/video1)
[HYPERION-V4L2 V4L2:usbtv] <INFO> Started

Screenshot details
==================
dimension after decimation: 90 x 60
signal detection area  : 22,15 x 67,45
signal threshold color : {2,6,255}
signal threshold values: 0.00784314, 0.0235294, 1
[HYPERION-V4L2 V4L2:usbtv] <INFO> Stopped
```
I have a lightberry grabber with blue no signal picture. My evaluated threshold values are: 0.00784314, 0.0235294, 1 and rounded: 0.03, 0.03, 1.0

**2.** If this changes affect the .conf file. Please provide the changed section
yes, see above

**3.** Reference an issue (optional)
yes, see above

