### PR TITLE
adjustable image2led mode for grabbers

### DIFF
--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -30,6 +30,8 @@
 	/// Color manipulation configuration used to tune the output colors to specific surroundings. 
 	/// The configuration contains a list of color-transforms. Each transform contains the 
 	/// following fields:
+	///  * 'imageToLedMappingType'      : multicolor_mean - every led has it's own calculatedmean color
+	///                                   unicolor_mean   - every led has same color, color is the mean of whole image
 	///  * 'channelAdjustment_enable'   : true/false enables/disables this channelAdjustment section
 	///  * 'channelAdjustment_v4l_only' : if enabled and set to true, then channelAdjustment is only for v4l devices
 	///  * 'channelAdjustment'
@@ -56,6 +58,7 @@
 	///            - 'gamma'           The gamma-curve correction factor
 	"color" :
 	{
+		"imageToLedMappingType" : "multicolor_mean",
 		"channelAdjustment_enable" : true,
 		"channelAdjustment_v4l_only" : true,
 		"channelAdjustment" :

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -16,6 +16,7 @@
 
 	"color" :
 	{
+		"imageToLedMappingType" : "multicolor_mean",
 		"channelAdjustment_enable" : true,
 		"channelAdjustment_v4l_only" : true,
 		"channelAdjustment" :

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -93,7 +93,7 @@ public:
 	///
 	unsigned getLedCount() const;
 
-	QSize getLedGridSize() const { return _ledGridSize; }
+	QSize getLedGridSize() const { return _ledGridSize; };
 
 	///
 	/// Returns the current priority
@@ -264,6 +264,9 @@ public slots:
 	/// @param timeout The timeout of the effect (after the timout, the effect will be cleared)
 	int setEffect(const QString & effectName, const QJsonObject & args, int priority, int timeout = -1, QString pythonScript = "");
 
+	/// sets the methode how image is maped to leds
+	void setLedMappingType(int mappingType);
+
 public:
 	static Hyperion *_hyperion;
 
@@ -303,6 +306,7 @@ signals:
 
 	void componentStateChanged(const hyperion::Components component, bool enabled);
 
+	void imageToLedsMappingChanged(int mappingType);
 private slots:
 	///
 	/// Updates the priority muxer with the current time and (re)writes the led color with applied

--- a/include/hyperion/ImageProcessor.h
+++ b/include/hyperion/ImageProcessor.h
@@ -18,9 +18,12 @@
 /// performed in two steps. First the average color per led-region is computed. Second a
 /// color-tranform is applied based on a gamma-correction.
 ///
-class ImageProcessor
+class ImageProcessor : public QObject 
 {
+	Q_OBJECT
+
 public:
+
 	~ImageProcessor();
 
 	///
@@ -38,12 +41,21 @@ public:
 	///
 	void setSize(const unsigned width, const unsigned height);
 
-	/// Enable or disable the black border detector
-	void enableBlackBorderDetector(bool enable);
 
 	/// Returns starte of black border detector
 	bool blackBorderDetectorEnabled();
 	
+	/// Returns starte of black border detector
+	int ledMappingType();
+
+public slots:
+	/// Enable or disable the black border detector
+	void enableBlackBorderDetector(bool enable);
+
+	/// Enable or disable the black border detector
+	void setLedMappingType(int mapType);
+
+public:	
 	///
 	/// Processes the image to a list of led colors. This will update the size of the buffer-image
 	/// if required and call the image-to-leds mapping to determine the mean color per led.
@@ -62,7 +74,12 @@ public:
 		verifyBorder(image);
 
 		// Create a result vector and call the 'in place' functionl
-		std::vector<ColorRgb> colors = _imageToLeds->getMeanLedColor(image);
+		std::vector<ColorRgb> colors;
+		switch (_mappingType)
+		{
+			case 1: colors = _imageToLeds->getUniLedColor(image); break;
+			default: colors = _imageToLeds->getMeanLedColor(image);
+		}
 
 		// return the computed colors
 		return colors;
@@ -84,7 +101,12 @@ public:
 		verifyBorder(image);
 
 		// Determine the mean-colors of each led (using the existing mapping)
-		_imageToLeds->getMeanLedColor(image, ledColors);
+		switch (_mappingType)
+		{
+			case 1: _imageToLeds->getUniLedColor(image, ledColors); break;
+			default: _imageToLeds->getMeanLedColor(image, ledColors);
+		}
+
 	}
 
 	///
@@ -161,4 +183,7 @@ private:
 
 	/// The mapping of image-pixels to leds
 	hyperion::ImageToLedsMap* _imageToLeds;
+
+	/// Type of image 2 led mapping
+	int _mappingType;
 };

--- a/include/hyperion/ImageProcessor.h
+++ b/include/hyperion/ImageProcessor.h
@@ -1,5 +1,6 @@
-
 #pragma once
+
+#include <QString>
 
 // Utils includes
 #include <utils/Image.h>
@@ -47,6 +48,8 @@ public:
 	
 	/// Returns starte of black border detector
 	int ledMappingType();
+
+	static int mappingTypeToInt(QString mappingType);
 
 public slots:
 	/// Enable or disable the black border detector
@@ -175,6 +178,7 @@ private:
 	}
 
 private:
+	Logger * _log;
 	/// The Led-string specification
 	const LedString _ledString;
 

--- a/include/hyperion/ImageProcessorFactory.h
+++ b/include/hyperion/ImageProcessorFactory.h
@@ -32,7 +32,7 @@ public:
 	/// @param[in] ledString  The led configuration
 	/// @param[in] blackborderConfig Contains the blackborder configuration
 	///
-	void init(const LedString& ledString, const QJsonObject &blackborderConfig);
+	void init(const LedString& ledString, const QJsonObject &blackborderConfig, int mappingType);
 
 	///
 	/// Creates a new ImageProcessor. The onwership of the processor is transferred to the caller.
@@ -45,6 +45,9 @@ private:
 	/// The Led-string specification
 	LedString _ledString;
 
-	// Reference to the blackborder json configuration values
+	/// Reference to the blackborder json configuration values
 	QJsonObject _blackborderConfig;
+
+	// image 2 led mapping type
+	int _mappingType;
 };

--- a/libsrc/hyperion/CMakeLists.txt
+++ b/libsrc/hyperion/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(CURRENT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/libsrc/hyperion)
 # Group the headers that go through the MOC compiler
 SET(Hyperion_QT_HEADERS
 	${CURRENT_HEADER_DIR}/Hyperion.h
+	${CURRENT_HEADER_DIR}/ImageProcessor.h
 
 	${CURRENT_SOURCE_DIR}/LinearColorSmoothing.h
 	${CURRENT_HEADER_DIR}/GrabberWrapper.h
@@ -13,7 +14,6 @@ SET(Hyperion_QT_HEADERS
 )
 
 SET(Hyperion_HEADERS
-	${CURRENT_HEADER_DIR}/ImageProcessor.h
 	${CURRENT_HEADER_DIR}/ImageProcessorFactory.h
 	${CURRENT_HEADER_DIR}/ImageToLedsMap.h
 	${CURRENT_HEADER_DIR}/LedString.h

--- a/libsrc/hyperion/GrabberWrapper.cpp
+++ b/libsrc/hyperion/GrabberWrapper.cpp
@@ -20,7 +20,7 @@ GrabberWrapper::GrabberWrapper(std::string grabberName, const int priority, hype
 	_hyperion->getComponentRegister().componentStateChanged(hyperion::COMP_BLACKBORDER, _processor->blackBorderDetectorEnabled());
 	qRegisterMetaType<hyperion::Components>("hyperion::Components");
 
-	connect(_hyperion, SIGNAL(imageToLedsMappingChanged(int mappingType)), _processor, SLOT(setLedMappingType(int mappingType))); 
+	connect(_hyperion, SIGNAL(imageToLedsMappingChanged(int)), _processor, SLOT(setLedMappingType(int))); 
 	connect(_hyperion, SIGNAL(componentStateChanged(hyperion::Components,bool)), this, SLOT(componentStateChanged(hyperion::Components,bool)));
 	connect(&_timer, SIGNAL(timeout()), this, SLOT(action()));
 }
@@ -122,4 +122,3 @@ void GrabberWrapper::setColors(const std::vector<ColorRgb> &ledColors, const int
 {
 	_hyperion->setColors(_priority, ledColors, timeout_ms, true, _grabberComponentId);
 }
-

--- a/libsrc/hyperion/GrabberWrapper.cpp
+++ b/libsrc/hyperion/GrabberWrapper.cpp
@@ -20,6 +20,7 @@ GrabberWrapper::GrabberWrapper(std::string grabberName, const int priority, hype
 	_hyperion->getComponentRegister().componentStateChanged(hyperion::COMP_BLACKBORDER, _processor->blackBorderDetectorEnabled());
 	qRegisterMetaType<hyperion::Components>("hyperion::Components");
 
+	connect(_hyperion, SIGNAL(imageToLedsMappingChanged(int mappingType)), _processor, SLOT(setLedMappingType(int mappingType))); 
 	connect(_hyperion, SIGNAL(componentStateChanged(hyperion::Components,bool)), this, SLOT(componentStateChanged(hyperion::Components,bool)));
 	connect(&_timer, SIGNAL(timeout()), this, SLOT(action()));
 }

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -17,6 +17,7 @@
 // hyperion include
 #include <hyperion/Hyperion.h>
 #include <hyperion/ImageProcessorFactory.h>
+#include <hyperion/ImageProcessor.h>
 #include <hyperion/ColorTransform.h>
 #include <hyperion/ColorAdjustment.h>
 
@@ -558,15 +559,11 @@ Hyperion::Hyperion(const QJsonObject &qjsonConfig, const QString configFile)
 	InfoIf(_colorTransformV4Lonly  , _log, "Color transformation for v4l inputs only" );
 	InfoIf(_colorAdjustmentV4Lonly , _log, "Color adjustment for v4l inputs only" );
 	
-	int mappingType = 0;
-	if (color["imageToLedMappingType"].toString() == "unicolor_mean" )
-		mappingType = 1;
-
 	// initialize the image processor factory
 	ImageProcessorFactory::getInstance().init(
 				_ledString,
 				qjsonConfig["blackborderdetector"].toObject(),
-				mappingType
+				ImageProcessor::mappingTypeToInt(color["imageToLedMappingType"].toString())
 	);
 	getComponentRegister().componentStateChanged(hyperion::COMP_FORWARDER, _messageForwarder->forwardingEnabled());
 

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -558,10 +558,15 @@ Hyperion::Hyperion(const QJsonObject &qjsonConfig, const QString configFile)
 	InfoIf(_colorTransformV4Lonly  , _log, "Color transformation for v4l inputs only" );
 	InfoIf(_colorAdjustmentV4Lonly , _log, "Color adjustment for v4l inputs only" );
 	
+	int mappingType = 0;
+	if (color["imageToLedMappingType"].toString() == "unicolor_mean" )
+		mappingType = 1;
+
 	// initialize the image processor factory
 	ImageProcessorFactory::getInstance().init(
 				_ledString,
-				qjsonConfig["blackborderdetector"].toObject()
+				qjsonConfig["blackborderdetector"].toObject(),
+				mappingType
 	);
 	getComponentRegister().componentStateChanged(hyperion::COMP_FORWARDER, _messageForwarder->forwardingEnabled());
 
@@ -842,6 +847,11 @@ int Hyperion::setEffect(const QString &effectName, int priority, int timeout)
 int Hyperion::setEffect(const QString &effectName, const QJsonObject &args, int priority, int timeout, QString pythonScript)
 {
 	return _effectEngine->runEffect(effectName, args, priority, timeout, pythonScript);
+}
+
+void Hyperion::setLedMappingType(int mappingType)
+{
+	emit imageToLedsMappingChanged(mappingType);
 }
 
 void Hyperion::update()

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -1,5 +1,6 @@
 
 // Hyperion includes
+#include <hyperion/Hyperion.h>
 #include <hyperion/ImageProcessor.h>
 #include <hyperion/ImageToLedsMap.h>
 
@@ -10,12 +11,14 @@ using namespace hyperion;
 
 ImageProcessor::ImageProcessor(const LedString& ledString, const QJsonObject & blackborderConfig)
 	: QObject()
+	, _log(Logger::getInstance("BLACKBORDER"))
 	, _ledString(ledString)
 	, _borderProcessor(new BlackBorderProcessor(blackborderConfig) )
 	, _imageToLeds(nullptr)
 	, _mappingType(0)
 {
-	// empty
+// this is when we want to change the mapping for all input sources
+// 	connect(Hyperion::getInstance(), SIGNAL(imageToLedsMappingChanged(int)), this, SLOT(setLedMappingType(int))); 
 }
 
 ImageProcessor::~ImageProcessor()
@@ -56,12 +59,21 @@ bool ImageProcessor::blackBorderDetectorEnabled()
 
 void ImageProcessor::setLedMappingType(int mapType)
 {
+	Debug(_log, "set led mapping to type %d", mapType);
 	_mappingType = mapType;
 }
 
 int ImageProcessor::ledMappingType()
 {
 	return _mappingType;
+}
+
+int ImageProcessor::mappingTypeToInt(QString mappingType)
+{
+	if (mappingType == "unicolor_mean" )
+		return 1;
+
+	return 0;
 }
 
 bool ImageProcessor::getScanParameters(size_t led, double &hscanBegin, double &hscanEnd, double &vscanBegin, double &vscanEnd) const

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -8,11 +8,12 @@
 
 using namespace hyperion;
 
-//ImageProcessor::ImageProcessor(const LedString& ledString, bool enableBlackBorderDetector, uint8_t blackborderThreshold) :
-ImageProcessor::ImageProcessor(const LedString& ledString, const QJsonObject & blackborderConfig) :
-	_ledString(ledString),
-	_borderProcessor(new BlackBorderProcessor(blackborderConfig) ),
-	_imageToLeds(nullptr)
+ImageProcessor::ImageProcessor(const LedString& ledString, const QJsonObject & blackborderConfig)
+	: QObject()
+	, _ledString(ledString)
+	, _borderProcessor(new BlackBorderProcessor(blackborderConfig) )
+	, _imageToLeds(nullptr)
+	, _mappingType(0)
 {
 	// empty
 }
@@ -51,6 +52,16 @@ void ImageProcessor::enableBlackBorderDetector(bool enable)
 bool ImageProcessor::blackBorderDetectorEnabled()
 {
 	return _borderProcessor->enabled();
+}
+
+void ImageProcessor::setLedMappingType(int mapType)
+{
+	_mappingType = mapType;
+}
+
+int ImageProcessor::ledMappingType()
+{
+	return _mappingType;
 }
 
 bool ImageProcessor::getScanParameters(size_t led, double &hscanBegin, double &hscanEnd, double &vscanBegin, double &vscanEnd) const

--- a/libsrc/hyperion/ImageProcessorFactory.cpp
+++ b/libsrc/hyperion/ImageProcessorFactory.cpp
@@ -9,13 +9,16 @@ ImageProcessorFactory& ImageProcessorFactory::getInstance()
 	return instance;
 }
 
-void ImageProcessorFactory::init(const LedString& ledString, const QJsonObject & blackborderConfig)
+void ImageProcessorFactory::init(const LedString& ledString, const QJsonObject & blackborderConfig, int mappingType)
 {
 	_ledString = ledString;
 	_blackborderConfig = blackborderConfig;
+	_mappingType = mappingType;
 }
 
 ImageProcessor* ImageProcessorFactory::newImageProcessor() const
 {
-	return new ImageProcessor(_ledString, _blackborderConfig);
+	ImageProcessor* ip = new ImageProcessor(_ledString, _blackborderConfig);
+	ip->setLedMappingType(_mappingType);
+	return ip;
 }

--- a/libsrc/hyperion/ImageProcessorFactory.cpp
+++ b/libsrc/hyperion/ImageProcessorFactory.cpp
@@ -20,5 +20,6 @@ ImageProcessor* ImageProcessorFactory::newImageProcessor() const
 {
 	ImageProcessor* ip = new ImageProcessor(_ledString, _blackborderConfig);
 	ip->setLedMappingType(_mappingType);
+
 	return ip;
 }

--- a/libsrc/hyperion/ImageToLedsMap.cpp
+++ b/libsrc/hyperion/ImageToLedsMap.cpp
@@ -18,26 +18,26 @@ ImageToLedsMap::ImageToLedsMap(
 	, _height(height)
 	, _horizontalBorder(horizontalBorder)
 	, _verticalBorder(verticalBorder)
-	, mColorsMap()
+	, _colorsMap()
 {
 	// Sanity check of the size of the borders (and width and height)
-	assert(width  > 2*verticalBorder);
-	assert(height > 2*horizontalBorder);
+	assert(_width  > 2*_verticalBorder);
+	assert(_height > 2*_horizontalBorder);
 
 	// Reserve enough space in the map for the leds
-	mColorsMap.reserve(leds.size());
+	_colorsMap.reserve(leds.size());
 
-	const unsigned xOffset = verticalBorder;
-	const unsigned actualWidth  = width  - 2 * verticalBorder;
-	const unsigned yOffset = horizontalBorder;
-	const unsigned actualHeight = height - 2 * horizontalBorder;
+	const unsigned xOffset      = _verticalBorder;
+	const unsigned actualWidth  = _width  - 2 * _verticalBorder;
+	const unsigned yOffset      = _horizontalBorder;
+	const unsigned actualHeight = _height - 2 * _horizontalBorder;
 
 	for (const Led& led : leds)
 	{
 		// skip leds without area
 		if ((led.maxX_frac-led.minX_frac) < 1e-6 || (led.maxY_frac-led.minY_frac) < 1e-6)
 		{
-			mColorsMap.emplace_back();
+			_colorsMap.emplace_back();
 			continue;
 		}
 
@@ -70,7 +70,7 @@ ImageToLedsMap::ImageToLedsMap(
 		}
 
 		// Add the constructed vector to the map
-		mColorsMap.push_back(ledColors);
+		_colorsMap.push_back(ledColors);
 	}
 }
 

--- a/libsrc/hyperion/hyperion.schema.json
+++ b/libsrc/hyperion/hyperion.schema.json
@@ -51,6 +51,7 @@
 					"type" : "string",
 					"title" : "edt_dev_general_colorOrder_title",
 					"enum" : ["rgb", "bgr", "rbg", "brg", "gbr", "grb"],
+					"default" : "rgb",
 					"propertyOrder" : 3
 				},
 				"rewriteTime": {
@@ -70,26 +71,33 @@
 			"type":"object",
 			"title" : "edt_conf_color_heading_title",
 			"required" : true,
-			"defaultProperties": ["channelAdjustment_enable","channelAdjustment","transform_enable","transform"],
+			"defaultProperties": ["imageToLedMappingType","channelAdjustment_enable","channelAdjustment","transform_enable","transform"],
 			"properties":
 			{
+				"imageToLedMappingType" :
+				{
+					"type" : "string",
+					"enum" : ["multicolor_mean", "unicolor_mean"],
+					"default" : "multicolor_mean",
+					"propertyOrder" : 1
+				},
 				"channelAdjustment_enable" :
 				{
 					"type" : "boolean",
 					"default" : true,
-					"propertyOrder" : 1
+					"propertyOrder" : 2
 				},
 				"channelAdjustment_v4l_only" :
 				{
 					"type" : "boolean",
 					"default" : false,
-					"propertyOrder" : 2
+					"propertyOrder" : 3
 				},
 				"channelAdjustment" :
 				{
 					"type" : "array",
 					"required" : true,
-					"propertyOrder" : 3,
+					"propertyOrder" : 4,
 					"items" :
 					{
 						"type" : "object",
@@ -204,19 +212,19 @@
 				{
 					"type" : "boolean",
 					"default" : true,
-					"propertyOrder" : 4
+					"propertyOrder" : 5
 				},
 				"transform_v4l_only" :
 				{
 					"type" : "boolean",
 					"default" : false,
-					"propertyOrder" : 5
+					"propertyOrder" : 6
 				},
 				"transform" :
 				{
 					"type" : "array",
 					"required" : true,
-					"propertyOrder" : 6,
+					"propertyOrder" : 7,
 					"items" :
 					{
 						"type" : "object",

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -312,6 +312,8 @@ void JsonClientConnection::handleMessage(const QString& messageString)
 			handleLedColorsCommand(message, command, tan);
 		else if (command == "logging")
 			handleLoggingCommand(message, command, tan);
+		else if (command == "processing")
+			handleProcessingCommand(message, command, tan);
 		else
 			handleNotImplemented();
  	}
@@ -1253,6 +1255,13 @@ void JsonClientConnection::handleLoggingCommand(const QJsonObject& message, cons
 	}
 	
 	sendSuccessReply(command+"-"+subcommand,tan);
+}
+
+void JsonClientConnection::handleProcessingCommand(const QJsonObject& message, const QString &command, const int tan)
+{
+	_hyperion->setLedMappingType(ImageProcessor::mappingTypeToInt( message["mappingType"].toString("multicolor_mean")) );
+
+	sendSuccessReply(command, tan);
 }
 
 void JsonClientConnection::incommingLogMessage(Logger::T_LOG_MESSAGE msg)

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -263,6 +263,12 @@ private:
 	///
 	void handleLoggingCommand(const QJsonObject & message, const QString &command, const int tan);
 
+	/// Handle an incoming JSON Proccessing message
+	///
+	/// @param message the incoming message
+	///
+	void handleProcessingCommand(const QJsonObject & message, const QString &command, const int tan);
+
 	///
 	/// Handle an incoming JSON message of unknown type
 	///

--- a/libsrc/jsonserver/JsonSchemas.qrc
+++ b/libsrc/jsonserver/JsonSchemas.qrc
@@ -16,5 +16,6 @@
         <file alias="schema-componentstate">schema/schema-componentstate.json</file>
         <file alias="schema-ledcolors">schema/schema-ledcolors.json</file>
         <file alias="schema-logging">schema/schema-logging.json</file>
+        <file alias="schema-processing">schema/schema-processing.json</file>
     </qresource>
 </RCC>

--- a/libsrc/jsonserver/schema/schema.json
+++ b/libsrc/jsonserver/schema/schema.json
@@ -5,7 +5,7 @@
 		"command": {
 			"type" : "string",
 			"required" : true,
-			"enum" : ["color", "image", "effect", "create-effect", "delete-effect", "serverinfo", "clear", "clearall", "transform", "adjustment", "sourceselect", "config", "componentstate", "ledcolors", "logging"]
+			"enum" : ["color", "image", "effect", "create-effect", "delete-effect", "serverinfo", "clear", "clearall", "transform", "adjustment", "sourceselect", "config", "componentstate", "ledcolors", "logging", "processing"]
 		}
 	}
 }

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -545,6 +545,17 @@ void JsonConnection::setAdjustment(const QString &adjustmentId,
 	parseReply(reply);
 }
 
+
+void JsonConnection::setLedMapping(QString mappingType)
+{
+	QJsonObject command;
+	command["command"] = QString("processing");
+	command["mappingType"] = mappingType;
+
+	QJsonObject reply = sendMessage(command);
+	parseReply(reply);
+}
+
 QJsonObject JsonConnection::sendMessage(const QJsonObject & message)
 {
 	// serialize message

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -90,7 +90,7 @@ public:
 	/// Clear all priority channels
 	///
 	void clearAll();
-	
+
 	///
 	/// Enable/Disable components during runtime
 	///
@@ -105,12 +105,12 @@ public:
 	/// @param priority The priority
 	///
 	void setSource(int priority);
-	
+
 	///
 	/// Enables auto source, if disabled prio by manual selecting input source
 	///
 	void setSourceAutoSelect();
-	
+
 	///
 	/// Print the current loaded Hyperion configuration file 
 	///
@@ -166,6 +166,12 @@ public:
 		const QColor & redAdjustment,
 		const QColor & greenAdjustment,
 		const QColor & blueAdjustment);
+
+	///
+	/// sets the image to leds mapping type
+	///
+	/// @param mappingType led mapping type
+	void setLedMapping(QString mappingType);
 
 private:
 	///

--- a/src/hyperion-remote/hyperion-remote.cpp
+++ b/src/hyperion-remote/hyperion-remote.cpp
@@ -87,6 +87,7 @@ int main(int argc, char * argv[])
 		ColorOption     & argRAdjust     = parser.add<ColorOption>  ('R', "redAdjustment" , "Set the adjustment of the red color (requires colors in hex format as RRGGBB)");
 		ColorOption     & argGAdjust     = parser.add<ColorOption>  ('G', "greenAdjustment", "Set the adjustment of the green color (requires colors in hex format as RRGGBB)");
 		ColorOption     & argBAdjust     = parser.add<ColorOption>  ('B', "blueAdjustment", "Set the adjustment of the blue color (requires colors in hex format as RRGGBB)");
+		Option          & argMapping     = parser.add<Option>       ('M', "ledMapping"   , "Set the methode for image to led mapping valif values: multicolor:mean, unicolor_mean");
 		IntOption       & argSource      = parser.add<IntOption>    (0x0, "sourceSelect"  , "Set current active priority channel and deactivate auto source switching");
 		BooleanOption   & argSourceAuto  = parser.add<BooleanOption>(0x0, "sourceAutoSelect", "Enables auto source, if disabled prio by manual selecting input source");
 		BooleanOption   & argSourceOff   = parser.add<BooleanOption>(0x0, "sourceOff", "select no source, this results in leds activly set to black (=off)");
@@ -104,12 +105,16 @@ int main(int argc, char * argv[])
 		}
 
 		// check if at least one of the available color transforms is set
-		bool colorTransform = parser.isSet(argSaturation) || parser.isSet(argValue) || parser.isSet(argSaturationL) || parser.isSet(argLuminance) || parser.isSet(argLuminanceMin) || parser.isSet(argThreshold) || parser.isSet(argGamma) || parser.isSet(argBlacklevel) || parser.isSet(argWhitelevel);
+		bool colorTransform = parser.isSet(argSaturation) || parser.isSet(argValue) || parser.isSet(argSaturationL) || parser.isSet(argLuminance)
+		                   || parser.isSet(argLuminanceMin) || parser.isSet(argThreshold) || parser.isSet(argGamma) || parser.isSet(argBlacklevel) || parser.isSet(argWhitelevel);
 		bool colorAdjust = parser.isSet(argRAdjust) || parser.isSet(argGAdjust) || parser.isSet(argBAdjust);
 		bool colorModding = colorTransform || colorAdjust;
 		
 		// check that exactly one command was given
-		int commandCount = count({parser.isSet(argColor), parser.isSet(argImage), parser.isSet(argEffect), parser.isSet(argCreateEffect), parser.isSet(argDeleteEffect), parser.isSet(argServerInfo), parser.isSet(argClear), parser.isSet(argClearAll), parser.isSet(argEnableComponent), parser.isSet(argDisableComponent), colorModding, parser.isSet(argSource), parser.isSet(argSourceAuto), parser.isSet(argSourceOff), parser.isSet(argConfigGet), parser.isSet(argSchemaGet), parser.isSet(argConfigSet)});
+		int commandCount = count({ parser.isSet(argColor), parser.isSet(argImage), parser.isSet(argEffect), parser.isSet(argCreateEffect), parser.isSet(argDeleteEffect), 
+		    parser.isSet(argServerInfo), parser.isSet(argClear), parser.isSet(argClearAll), parser.isSet(argEnableComponent), parser.isSet(argDisableComponent), colorModding,
+		    parser.isSet(argSource), parser.isSet(argSourceAuto), parser.isSet(argSourceOff), parser.isSet(argConfigGet), parser.isSet(argSchemaGet), parser.isSet(argConfigSet),
+			parser.isSet(argMapping) });
 		if (commandCount != 1)
 		{
 			qWarning() << (commandCount == 0 ? "No command found." : "Multiple commands found.") << " Provide exactly one of the following options:";
@@ -215,6 +220,10 @@ int main(int argc, char * argv[])
 		else if (parser.isSet(argConfigSet))
 		{
 			connection.setConfig(argConfigSet.value(parser));
+		}
+		else if (parser.isSet(argMapping))
+		{
+			connection.setLedMapping(argMapping.value(parser));
 		}
 		else if (colorModding)
 		{	


### PR DESCRIPTION
**1.** Tell us something about your changes.
you can switch between multicolor (all leds could have different colors) und unicolor mode.
unicolor means all leds have sa same color. The color is calculated from the average of the whole(!) image.
This method is not the best, because it gets sometimes to dark, but it's a start. This methode is very cool when you watch pictures.
In general we have now a methode to implement other image to led mapping algorithms.

usage:
use it via hyperion-remote or json interface with you own application:
unicolor mode
```
bin/hyperion-remote -M unicolor_mean --print
hyperion-remote:
        Version   : 2.0.0 (unicolor (redpanther-90f27a1/cbec2f4-1482083992))
        build time: Dec 18 2016 19:02:32
Connected to: "localhost:19444" 
Command: {"command": "processing","mappingType": "unicolor_mean"}
Reply: {"command": "processing","success": true,"tan": 0}
```

multicolor mode:
```
bin/hyperion-remote -M multicolor_mean --print
hyperion-remote:
        Version   : 2.0.0 (unicolor (redpanther-90f27a1/cbec2f4-1482083992))
        build time: Dec 18 2016 19:02:32
Connected to: "localhost:19444" 
Command: {"command": "processing","mappingType": "multicolor_mean"}
Reply: {"command": "processing","success": true,"tan": 0}
```


**2.** If this changes affect the .conf file. Please provide the changed section
you can set default mode in hyperion.config:
```
	"color" :
	{
		"imageToLedMappingType" : "multicolor_mean",
```
or "unicolor_mean" ...

**3.** Reference an issue (optional)
 #10

Note: For further discussions use our forum: forum.hyperion-project.org

