### PR TITLE
Fix latchtime logic - it was always ignored

### DIFF
--- a/libsrc/leddevice/ProviderSpi.cpp
+++ b/libsrc/leddevice/ProviderSpi.cpp
@@ -99,7 +99,7 @@ int ProviderSpi::writeBytes(const unsigned size, const uint8_t * data)
 	int retVal = ioctl(_fid, SPI_IOC_MESSAGE(1), &_spi);
 	ErrorIf((retVal < 0), _log, "SPI failed to write. errno: %d, %s", errno,  strerror(errno) );
 
-	if (retVal == 0 && _latchTime_ns > 0)
+	if (retVal >= 0 && _latchTime_ns > 0)
 	{
 		// The 'latch' time for latching the shifted-value into the leds
 		timespec latchTime;


### PR DESCRIPTION
**1.** Tell us something about your changes.
the SPI write ioctl returns # bytes written, not 0....
(unless of course you have 0 leds!)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

