### PR TITLE
check config when writing

### DIFF
--- a/CompileHowto.md
+++ b/CompileHowto.md
@@ -107,8 +107,8 @@ To generate make files on OS X:
 
 After which you can run cmake with the correct qt5 path:
 ```
-cmake -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.7.0  -DCMAKE_BUILD_TYPE=Release ..
-```
+export QVER=$(find  /usr/local/Cellar/qt5 -type d -name "5.*" | sort -n  | head -n1)
+cmake -DCMAKE_PREFIX_PATH=$QVER  -DCMAKE_BUILD_TYPE=Release ..```
 
 ### Run make to build Hyperion
 The `-j $(nproc)` specifies the amount of CPU cores to use.

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -1028,7 +1028,7 @@ void JsonClientConnection::handleSchemaGetCommand(const QJsonObject& message, co
 
 	// read the hyperion json schema from the resource
 	QFile schemaData(":/hyperion-schema-"+QString::number(_hyperion->getConfigVersionId()));
-	
+
 	if (!schemaData.open(QIODevice::ReadOnly))
 	{
 		std::stringstream error;
@@ -1039,7 +1039,7 @@ void JsonClientConnection::handleSchemaGetCommand(const QJsonObject& message, co
 	QByteArray schema = schemaData.readAll();
 	QJsonDocument doc = QJsonDocument::fromJson(schema, &error);
 	schemaData.close();
-	
+
 	if (error.error != QJsonParseError::NoError)
 	{
 		// report to the user the failure and their locations in the document.


### PR DESCRIPTION
**1.** Tell us something about your changes.
should solve #404 
currently missing: a proper message in web ui when config write fails. To test use led layout edit box and write valid json, but invalid content (e.g. xhscan instead of hscan)

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

