### PR TITLE
clearall don't remove prio 254/255 

### DIFF
--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -76,9 +76,13 @@ void PriorityMuxer::clearInput(const int priority)
 
 void PriorityMuxer::clearAll()
 {
-	_activeInputs.clear();
-	_currentPriority = LOWEST_PRIORITY;
-	_activeInputs[_currentPriority] = _lowestPriorityInfo;
+	for(auto key : _activeInputs.keys())
+	{
+		if (key < LOWEST_PRIORITY-1)
+		{
+			_activeInputs.remove(key);
+		}
+	}
 }
 
 void PriorityMuxer::setCurrentTime(const int64_t& now)


### PR DESCRIPTION
**1.** Tell us something about your changes.
prio 254/255 are used by system for background stuff. This shouldn't be affected by clearall

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

