### PR TITLE
HyperionUsbAsp ws2812 broken

### DIFF
--- a/assets/webconfig/i18n/de.json
+++ b/assets/webconfig/i18n/de.json
@@ -390,6 +390,7 @@
 	"edt_dev_spec_gpioBcm_title" : "GPIO Pin",
 	"edt_dev_spec_ledIndex_title" : "LED index",
 	"edt_dev_spec_colorComponent_title" : "Farbkomponente",
+	"edt_dev_spec_ledType_title" : "LED typ",
 	"edt_conf_general_enable_title" : "Aktiviert",
 	"edt_conf_general_enable_expl" : "Wenn aktiviert, ist die Komponente aktiv.",
 	"edt_conf_general_priority_title" : "Priorität",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -372,6 +372,7 @@
 	"edt_dev_spec_transistionTime_title" : "Transistion time",
 	"edt_dev_spec_switchOffOnBlack_title" : "Switch off on black",
 	"edt_dev_spec_brightnessFactor_title" : "Brightness factor",
+	"edt_dev_spec_ledType_title" : "LED Type",
 	"edt_dev_spec_uid_title" : "UID",
 	"edt_dev_spec_intervall_title" : "Intervall",
 	"edt_dev_spec_latchtime_title" : "Latch time",

--- a/assets/webconfig/i18n/es.json
+++ b/assets/webconfig/i18n/es.json
@@ -347,6 +347,7 @@
     "edt_dev_spec_gpioBcm_title": "Pin GPIO",
     "edt_dev_spec_ledIndex_title": "Índice LED",
     "edt_dev_spec_colorComponent_title": "Componente de color",
+    "edt_dev_spec_ledType_title": "Tipo de LED",
     "edt_conf_general_enable_title": "Activar",
     "edt_conf_general_enable_expl": "Si está marcada, el componente está habilitado",
     "edt_conf_general_priority_title": "Canal prioritario",

--- a/libsrc/leddevice/LedDeviceHyperionUsbasp.cpp
+++ b/libsrc/leddevice/LedDeviceHyperionUsbasp.cpp
@@ -41,10 +41,10 @@ bool LedDeviceHyperionUsbasp::init(const QJsonObject &deviceConfig)
 {
 	LedDevice::init(deviceConfig);
 
-	QString ledType = deviceConfig["output"].toString("ws2801");
+	QString ledType = deviceConfig["ledType"].toString("ws2801");
 	if (ledType != "ws2801" && ledType != "ws2812")
 	{
-		throw std::runtime_error("HyperionUsbasp: invalid output; must be 'ws2801' or 'ws2812'.");
+		throw std::runtime_error("HyperionUsbasp: invalid ledType; must be 'ws2801' or 'ws2812'.");
 	}
 
 	_writeLedsCommand = (ledType == "ws2801") ? CMD_WRITE_WS2801 : CMD_WRITE_WS2812;

--- a/libsrc/leddevice/schemas/schema-hyperionusbasp.json
+++ b/libsrc/leddevice/schemas/schema-hyperionusbasp.json
@@ -11,7 +11,14 @@
 			"maximum": 1000,
 			"access" : "expert",
 			"propertyOrder" : 1
-		}
+		},
+                "ledType": {
+                        "type": "string",
+                        "title":"edt_dev_spec_ledType_title",
+                        "enum" : ["ws2801","ws2812"],
+                        "default": "ws2801",
+                        "propertyOrder" : 2
+                }
 	},
 	"additionalProperties": true
 }


### PR DESCRIPTION
**1.** Tell us something about your changes.
HyperionUsbAsp supports both ws2801 and ws2812 led strips
Re-add this option to the schema

**2.** If this changes affect the .conf file. Please provide the changed section
```
    "device": {
        "colorOrder": "grb",
        "latchTime": 10,
        "ledType": "ws2812",
        "rewriteTime": 5000,
        "type": "hyperionusbasp"
    },
```
