### PR TITLE
Fix - Philips Hue RGB Brightness Color Conversion

### DIFF
--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -36,9 +36,10 @@ CiColor CiColor::rgbToCiColor(float red, float green, float blue, CiColorTriangl
 	{
 		cy = 0.0f;
 	}
-	// Brightness is simply Y in the XYZ space.
+	// RGB to HSV Convertion for Brightness Value, not XYZ Space.
+	float bri = qMax(qMax(r, g), b);
 	CiColor xy =
-	{ cx, cy, Y };
+	{ cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.
 	if (!isPointInLampsReach(xy, colorSpace))
 	{

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -37,7 +37,7 @@ CiColor CiColor::rgbToCiColor(float red, float green, float blue, CiColorTriangl
 		cy = 0.0f;
 	}
 	// RGB to HSV Convertion for Brightness Value, not XYZ Space.
-	float bri = qMax(qMax(r, g), b);
+	float bri = qMax(qMax(red, green), blue);
 	CiColor xy =
 	{ cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -36,8 +36,8 @@ CiColor CiColor::rgbToCiColor(float red, float green, float blue, CiColorTriangl
 	{
 		cy = 0.0f;
 	}
-	// RGB to HSV Convertion for Brightness Value, not XYZ Space.
-	float bri = fmax(fmax(red, green), blue);
+	// RGB to HSV/B Conversion after gamma correction use V for brightness, not Y from XYZ Space.
+	float bri = fmax(fmax(r, g), b);
 	CiColor xy =
 	{ cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -37,7 +37,7 @@ CiColor CiColor::rgbToCiColor(float red, float green, float blue, CiColorTriangl
 		cy = 0.0f;
 	}
 	// RGB to HSV Convertion for Brightness Value, not XYZ Space.
-	float bri = qMax(qMax(red, green), blue);
+	float bri = fmax(fmax(red, green), blue);
 	CiColor xy =
 	{ cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.


### PR DESCRIPTION
Hue RGB Color Conversion for Brightness is wrong! - use RGB to HSV instead of XYZ Space!
For correct use, reset brightnessFactor back to 1.0 in config! - It was just a Workaround, not the Solution!