### PR TITLE
Reworked Amlogic "ge2d" mode and add single ioctl call

### DIFF
--- a/assets/webconfig/i18n/de.json
+++ b/assets/webconfig/i18n/de.json
@@ -534,6 +534,8 @@
 	"edt_conf_fg_pixelDecimation_expl" : "Bildverkleinerung (Faktor) ausgehend von der original Größe. 1 für unveränderte/originale Größe.",
 	"edt_conf_fg_device_title" : "Device",
 	"edt_conf_fg_display_title" : "Display",
+	"edt_conf_fg_amlogic_grabber_title" : "Amlogic Grabber Device",
+	"edt_conf_fg_ge2d_mode_title" : "Amlogic ge2d Grabber Modus",
 	"edt_conf_fg_display_expl" : "Gebe an von welchem Desktop aufgenommen werden soll. (Multi Monitor Setup)",
 	"edt_conf_bb_heading_title" : "Schwarze Balken Erkennung",
 	"edt_conf_bb_threshold_title" : "Schwelle",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -535,6 +535,8 @@
 	"edt_conf_fg_pixelDecimation_expl" : "Reduce picture size (factor) based on original size. A factor of 1 means no change",
 	"edt_conf_fg_device_title" : "Device",
 	"edt_conf_fg_display_title" : "Display",
+	"edt_conf_fg_amlogic_grabber_title" : "Amlogic Grabber Device",
+	"edt_conf_fg_ge2d_mode_title" : "Amlogic ge2d Grabber Modus",
 	"edt_conf_fg_display_expl" : "Select which desktop should be captured (multi monitor setup)",
 	"edt_conf_bb_heading_title" : "Blackbar detector",
 	"edt_conf_bb_threshold_title" : "Threshold",

--- a/config/hyperion.config.json.commented
+++ b/config/hyperion.config.json.commented
@@ -162,7 +162,11 @@
 		"display" 0,
 
 		// valid for framebuffer
-		"device"     : "/dev/fb0"
+		"device"     : "/dev/fb0",
+
+		// valid for amlogic
+		"amlogic_grabber" : "amvideocap0",
+		"ge2d_mode"       : 1
 	},
 
 	/// The black border configuration, contains the following items:

--- a/config/hyperion.config.json.default
+++ b/config/hyperion.config.json.default
@@ -88,7 +88,9 @@
 		"cropRight"					: 0,
 		"cropTop"					: 0,
 		"cropBottom"				: 0,
-		"device"					: "/dev/fb0"
+		"device"					: "/dev/fb0",
+		"amlogic_grabber"			: "amvideocap0",
+		"ge2d_mode"					: 1
 	},
 
 	"blackborderdetector" :

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 set(USE_SYSTEM_FLATBUFFERS_LIBS ${DEFAULT_USE_SYSTEM_FLATBUFFERS_LIBS} CACHE BOOL "use flatbuffers library from system")
 
 if (USE_SYSTEM_FLATBUFFERS_LIBS)
-	find_package(flatbuffers REQUIRED)
+	find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc REQUIRED)
 	include_directories(${FLATBUFFERS_INCLUDE_DIRS})
 else ()
 	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared flatbuffers library")
@@ -47,6 +47,5 @@ function(compile_flattbuffer_schema SRC_FBS OUTPUT_DIR)
     COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" -c --no-includes --gen-mutable
 			--gen-object-api
 			-o "${OUTPUT_DIR}"
-			"${SRC_FBS}"
-    DEPENDS flatc)
+			"${SRC_FBS}")
 endfunction()

--- a/include/grabber/AmlogicGrabber.h
+++ b/include/grabber/AmlogicGrabber.h
@@ -8,6 +8,111 @@
 
 class IonBuffer;
 
+struct rectangle_s {
+	int x;   /* X coordinate of its top-left point */
+	int y;   /* Y coordinate of its top-left point */
+	int w;   /* width of it */
+	int h;   /* height of it */
+};
+
+struct ge2d_para_s {
+	unsigned int    color;
+	struct rectangle_s src1_rect;
+	struct rectangle_s src2_rect;
+	struct rectangle_s dst_rect;
+	int op;
+};
+
+struct config_planes_s {
+	unsigned long addr;
+	unsigned int w;
+	unsigned int h;
+};
+
+struct src_key_ctrl_s {
+	int key_enable;
+	int key_color;
+	int key_mask;
+	int key_mode;
+};
+
+struct config_para_s {
+	int  src_dst_type;
+	int  alu_const_color;
+	unsigned int src_format;
+	unsigned int dst_format; /* add for src&dst all in user space. */
+
+	struct config_planes_s src_planes[4];
+	struct config_planes_s dst_planes[4];
+	struct src_key_ctrl_s  src_key;
+};
+
+struct src_dst_para_ex_s {
+	int  canvas_index;
+	int  top;
+	int  left;
+	int  width;
+	int  height;
+	int  format;
+	int  mem_type;
+	int  color;
+	unsigned char x_rev;
+	unsigned char y_rev;
+	unsigned char fill_color_en;
+	unsigned char fill_mode;
+};
+
+struct config_para_ex_s {
+	struct src_dst_para_ex_s src_para;
+	struct src_dst_para_ex_s src2_para;
+	struct src_dst_para_ex_s dst_para;
+
+	/* key mask */
+	struct src_key_ctrl_s  src_key;
+	struct src_key_ctrl_s  src2_key;
+
+	int alu_const_color;
+	unsigned src1_gb_alpha;
+	unsigned op_mode;
+	unsigned char bitmask_en;
+	unsigned char bytemask_only;
+	unsigned int  bitmask;
+	unsigned char dst_xy_swap;
+
+	/* scaler and phase releated */
+	unsigned hf_init_phase;
+	int hf_rpt_num;
+	unsigned hsc_start_phase_step;
+	int hsc_phase_slope;
+	unsigned vf_init_phase;
+	int vf_rpt_num;
+	unsigned vsc_start_phase_step;
+	int vsc_phase_slope;
+	unsigned char src1_vsc_phase0_always_en;
+	unsigned char src1_hsc_phase0_always_en;
+	/* 1bit, 0: using minus, 1: using repeat data */
+	unsigned char src1_hsc_rpt_ctrl;
+	/* 1bit, 0: using minus  1: using repeat data */
+	unsigned char src1_vsc_rpt_ctrl;
+
+	/* canvas info */
+	struct config_planes_s src_planes[4];
+	struct config_planes_s src2_planes[4];
+	struct config_planes_s dst_planes[4];
+};
+
+struct amvideo_grabber_data {
+	int canvas_index;
+	uint32_t canvas0Addr;
+	uint32_t ge2dformat;
+	uint64_t size;
+};
+
+enum ge2d_mode {
+    ge2d_single = 0,
+    ge2d_combined = 1
+};
+
 ///
 ///
 class AmlogicGrabber : public Grabber
@@ -18,8 +123,9 @@ public:
 	///
 	/// @param[in] width  The width of the captured screenshot
 	/// @param[in] height The heigth of the captured screenshot
+	/// @param[in] ge2d_mode The ge2d mode, 0: single icotl calls, 1: combined data ioctl call
 	///
-	AmlogicGrabber(const unsigned width, const unsigned height);
+	AmlogicGrabber(const unsigned width, const unsigned height, const unsigned ge2d_mode, const QString device);
 	~AmlogicGrabber();
 
 	///
@@ -51,12 +157,17 @@ private:
 	int             _ge2dDev;
 
 	Image<ColorBgr> _image_bgr;
-	
+	void*           _image_ptr;
+	ssize_t         _bytesToRead;
+
 	int             _lastError;
 	bool            _videoPlaying;
 	FramebufferFrameGrabber _fbGrabber;
 	int             _grabbingModeNotification;
-	bool            _ge2dAvailable;
 	void*           _ge2dVideoBufferPtr;
 	IonBuffer*      _ge2dIonBuffer;
+	struct config_para_ex_s _configex;
+	ge2d_para_s     _blitRect;
+	int             _ge2d_mode;
+	QString         _device;
 };

--- a/include/grabber/AmlogicWrapper.h
+++ b/include/grabber/AmlogicWrapper.h
@@ -18,8 +18,10 @@ public:
 	/// @param[in] grabWidth  The width of the grabbed image [pixels]
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	/// @param[in] updateRate_Hz  The image grab rate [Hz]
+	/// @param[in] ge2d_mode use single or combine ge2d ioctl call
+	/// @param[in] device amlogic grabber device
 	///
-	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const unsigned ge2d_mode, const QString device);
 
 	///
 	/// Destructor of this dispmanx frame grabber. Releases any claimed resources.

--- a/libsrc/grabber/amlogic/AmlogicWrapper.cpp
+++ b/libsrc/grabber/amlogic/AmlogicWrapper.cpp
@@ -1,8 +1,8 @@
 #include <grabber/AmlogicWrapper.h>
 
-AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz)
+AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const unsigned ge2d_mode, const QString device)
 	: GrabberWrapper("AmLogic", &_grabber, grabWidth, grabHeight, updateRate_Hz)
-	, _grabber(grabWidth, grabHeight)
+	, _grabber(grabWidth, grabHeight, ge2d_mode, device)
 {}
 
 void AmlogicWrapper::action()

--- a/libsrc/grabber/amlogic/Amvideocap.h
+++ b/libsrc/grabber/amlogic/Amvideocap.h
@@ -40,29 +40,15 @@ GE2D_FORMAT_S24_RGB
 #define AMVIDEO_EXT_CURRENT_VIDEOFRAME_GET_GE2D_FORMAT _IOR((AMVIDEO_MAGIC), 0x03, uint32_t)
 #define AMVIDEO_EXT_CURRENT_VIDEOFRAME_GET_SIZE _IOR((AMVIDEO_MAGIC), 0x04, uint64_t)
 #define AMVIDEO_EXT_CURRENT_VIDEOFRAME_GET_CANVAS0ADDR _IOR((AMVIDEO_MAGIC), 0x05, uint32_t)
+#define AMVIDEO_EXT_CURRENT_VIDEOFRAME_GET_DATA _IOR((AMVIDEO_MAGIC), 0x06, struct amvideo_grabber_data)
 
 // GE2D commands
+#define	GE2D_IOC_MAGIC  'G'
 #define	GE2D_STRETCHBLIT_NOALPHA            0x4702
-#define	GE2D_CONFIG_EX                      0x46fa
+#define	GE2D_CONFIG_EX                      _IOW(GE2D_IOC_MAGIC, 0x01,  struct config_para_ex_s)
 
 
 // data structures
-struct rectangle_s {
-	int x;   /* X coordinate of its top-left point */
-	int y;   /* Y coordinate of its top-left point */
-	int w;   /* width of it */
-	int h;   /* height of it */
-};
-
-struct ge2d_para_s {
-	unsigned int    color;
-	struct rectangle_s src1_rect;
-	struct rectangle_s src2_rect;
-	struct rectangle_s dst_rect;
-	int op;
-};
-
-
 enum ge2d_src_dst_e {
 	OSD0_OSD0 = 0,
 	OSD0_OSD1,
@@ -81,7 +67,6 @@ enum ge2d_src_canvas_type_e {
 	CANVAS_TYPE_INVALID,
 };
 
-
 struct src_dst_para_s {
 	int  xres;
 	int  yres;
@@ -97,82 +82,4 @@ enum ge2d_op_type_e {
 	GE2D_OP_STRETCHBLIT,
 	GE2D_OP_BLEND,
 	GE2D_OP_MAXNUM
-};
-
-struct config_planes_s {
-	unsigned long addr;
-	unsigned int w;
-	unsigned int h;
-};
-
-struct src_key_ctrl_s {
-	int key_enable;
-	int key_color;
-	int key_mask;
-	int key_mode;
-};
-
-struct config_para_s {
-	int  src_dst_type;
-	int  alu_const_color;
-	unsigned int src_format;
-	unsigned int dst_format; /* add for src&dst all in user space. */
-
-	struct config_planes_s src_planes[4];
-	struct config_planes_s dst_planes[4];
-	struct src_key_ctrl_s  src_key;
-};
-
-struct src_dst_para_ex_s {
-	int  canvas_index;
-	int  top;
-	int  left;
-	int  width;
-	int  height;
-	int  format;
-	int  mem_type;
-	int  color;
-	unsigned char x_rev;
-	unsigned char y_rev;
-	unsigned char fill_color_en;
-	unsigned char fill_mode;
-};
-
-struct config_para_ex_s {
-	struct src_dst_para_ex_s src_para;
-	struct src_dst_para_ex_s src2_para;
-	struct src_dst_para_ex_s dst_para;
-
-	/* key mask */
-	struct src_key_ctrl_s  src_key;
-	struct src_key_ctrl_s  src2_key;
-
-	int alu_const_color;
-	unsigned src1_gb_alpha;
-	unsigned op_mode;
-	unsigned char bitmask_en;
-	unsigned char bytemask_only;
-	unsigned int  bitmask;
-	unsigned char dst_xy_swap;
-
-	/* scaler and phase releated */
-	unsigned hf_init_phase;
-	int hf_rpt_num;
-	unsigned hsc_start_phase_step;
-	int hsc_phase_slope;
-	unsigned vf_init_phase;
-	int vf_rpt_num;
-	unsigned vsc_start_phase_step;
-	int vsc_phase_slope;
-	unsigned char src1_vsc_phase0_always_en;
-	unsigned char src1_hsc_phase0_always_en;
-	/* 1bit, 0: using minus, 1: using repeat data */
-	unsigned char src1_hsc_rpt_ctrl;
-	/* 1bit, 0: using minus  1: using repeat data */
-	unsigned char src1_vsc_rpt_ctrl;
-
-	/* canvas info */
-	struct config_planes_s src_planes[4];
-	struct config_planes_s src2_planes[4];
-	struct config_planes_s dst_planes[4];
 };

--- a/libsrc/hyperion/schema/schema-framegrabber.json
+++ b/libsrc/hyperion/schema/schema-framegrabber.json
@@ -96,6 +96,20 @@
 			"title" : "edt_conf_fg_display_title",
 			"minimum" : 0,
 			"propertyOrder" : 12
+		},
+		"amlogic_grabber" :
+		{
+			"type" : "string",
+			"title" : "edt_conf_fg_amlogic_grabber_title",
+			"default" : "amvideocap0",
+			"propertyOrder" : 13
+		},
+		"ge2d_mode" :
+		{
+			"type" : "integer",
+			"title" : "edt_conf_fg_ge2d_mode_title",
+			"default" : 0,
+			"propertyOrder" : 14
 		}
 	},
 	"additionalProperties" : false

--- a/src/hyperion-aml/AmlogicWrapper.cpp
+++ b/src/hyperion-aml/AmlogicWrapper.cpp
@@ -2,9 +2,9 @@
 // Hyperion-AmLogic includes
 #include "AmlogicWrapper.h"
 
-AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz) :
+AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const unsigned ge2d_mode, const QString device) :
 	_timer(this),
-	_grabber(grabWidth, grabHeight)
+	_grabber(grabWidth, grabHeight, ge2d_mode, device)
 {
 	_timer.setSingleShot(false);
 	_timer.setInterval(updateRate_Hz);

--- a/src/hyperion-aml/AmlogicWrapper.h
+++ b/src/hyperion-aml/AmlogicWrapper.h
@@ -9,7 +9,7 @@ class AmlogicWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz, const unsigned ge2d_mode, const QString device);
 
 	const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(${PROJECT_NAME}
 	Qt5::Core
 	Qt5::Gui
 	Qt5::Network
+	pcre16 dl z
 )
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "share/hyperion/bin/" COMPONENT "${PLATFORM}" )

--- a/src/hyperion-aml/hyperion-aml.cpp
+++ b/src/hyperion-aml/hyperion-aml.cpp
@@ -41,6 +41,8 @@ int main(int argc, char ** argv)
 		IntOption     & argWidth      = parser.add<IntOption>    (0x0, "width",      "Width of the captured image [default: %1]", "160", 160, 4096);
 		IntOption     & argHeight     = parser.add<IntOption>    (0x0, "height",     "Height of the captured image [default: %1]", "160", 160, 4096);
 		BooleanOption & argScreenshot = parser.add<BooleanOption>(0x0, "screenshot",   "Take a single screenshot, save it to file and quit");
+		IntOption     & argge2d_mode  = parser.add<IntOption>    (0x0, "ge2d-mode",  "ge2d ioctl mode, 0 single ioctl, 1 combined ioctl [default: %1]", "0");
+		Option        & argDevice     = parser.add<Option>       (0x0, "device",     "The Amlogic device to use  [default: %1]", "amvideocap0");
 		Option        & argAddress    = parser.add<Option>       ('a', "address",    "Set the address of the hyperion server [default: %1]", "127.0.0.1:19400");
 		IntOption     & argPriority   = parser.add<IntOption>    ('p', "priority",   "Use the provided priority channel (suggested 100-199) [default: %1]", "150");
 		BooleanOption & argSkipReply  = parser.add<BooleanOption>(0x0, "skip-reply", "Do not receive and check reply messages from Hyperion");
@@ -55,7 +57,7 @@ int main(int argc, char ** argv)
 			parser.showHelp(0);
 		}
 
-		AmlogicWrapper amlWrapper(argWidth.getInt(parser), argHeight.getInt(parser), 1000 / argFps.getInt(parser));
+		AmlogicWrapper amlWrapper(argWidth.getInt(parser), argHeight.getInt(parser), 1000 / argFps.getInt(parser), argge2d_mode.getInt(parser), argDevice.value(parser));
 
 		if (parser.isSet(argScreenshot))
 		{

--- a/src/hyperion-framebuffer/CMakeLists.txt
+++ b/src/hyperion-framebuffer/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries( ${PROJECT_NAME}
 	Qt5::Core
 	Qt5::Gui
 	Qt5::Network
+	pcre16 dl z
 )
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "share/hyperion/bin/" COMPONENT "${PLATFORM}" )

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -27,7 +27,8 @@ target_link_libraries(${PROJECT_NAME}
 	hyperion-utils
 	Qt5::Gui
 	Qt5::Core
-	Qt5::Network)
+	Qt5::Network
+	pcre16 dl z)
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "share/hyperion/bin/" COMPONENT "${PLATFORM}" )
 

--- a/src/hyperion-v4l2/CMakeLists.txt
+++ b/src/hyperion-v4l2/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(${PROJECT_NAME}
 	Qt5::Core
 	Qt5::Gui
 	Qt5::Network
+	pcre16 dl z
 )
 
 install ( TARGETS ${PROJECT_NAME} DESTINATION "share/hyperion/bin/" COMPONENT "${PLATFORM}" )

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(hyperiond
 		python
 		resources
 		${PYTHON_LIBRARIES}
+		Qt5::Core
+		pcre16 dl z
 )
 
 if (ENABLE_DISPMANX)

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -250,6 +250,9 @@ void HyperionDaemon::handleSettingsUpdate(const settings::type& type, const QJso
 		_grabber_cropTop    = grabberConfig["cropTop"].toInt(0);
 		_grabber_cropBottom = grabberConfig["cropBottom"].toInt(0);
 
+		_grabber_ge2d_mode  = grabberConfig["ge2d_mode"].toInt(0);
+		_grabber_device     = grabberConfig["amlogic_grabber"].toString("amvideocap0");
+
 		#ifdef ENABLE_OSX
 			QString type = "osx";
 		#else
@@ -265,9 +268,12 @@ void HyperionDaemon::handleSettingsUpdate(const settings::type& type, const QJso
 				type = "dispmanx";
 			}
 			// amlogic -> /dev/amvideo exists
-			else if ( QFile::exists("/dev/amvideo") && ( QFile::exists("/dev/amvideocap0") || QFile::exists("/dev/ge2d") ) )
+			else if ( QFile::exists("/dev/amvideo") )
 			{
 				type = "amlogic";
+
+					if ( !QFile::exists("/dev/" + _grabber_device) )
+						{ Error( _log, "grabber device '%s' for type amlogic not found!", QSTRING_CSTR(_grabber_device)); }
 			}
 			// x11 -> if DISPLAY is set
 			else if (getenv("DISPLAY") != NULL )
@@ -431,7 +437,7 @@ void HyperionDaemon::createGrabberDispmanx()
 void HyperionDaemon::createGrabberAmlogic()
 {
 #ifdef ENABLE_AMLOGIC
-	_amlGrabber = new AmlogicWrapper(_grabber_width, _grabber_height, _grabber_frequency);
+	_amlGrabber = new AmlogicWrapper(_grabber_width, _grabber_height, _grabber_frequency, _grabber_ge2d_mode, _grabber_device);
 	_amlGrabber->setCropping(_grabber_cropLeft, _grabber_cropRight, _grabber_cropTop, _grabber_cropBottom);
 
 	// connect to HyperionDaemon signal

--- a/src/hyperiond/hyperiond.h
+++ b/src/hyperiond/hyperiond.h
@@ -155,6 +155,8 @@ private:
 	unsigned            _grabber_cropRight;
 	unsigned            _grabber_cropTop;
 	unsigned            _grabber_cropBottom;
+	int                 _grabber_ge2d_mode;
+	QString             _grabber_device;
 
 	QString _prevType;
 


### PR DESCRIPTION
**1.** Tell us something about your changes.

Fixed and reworked Amlogic "ge2d" mode. Added a option to use a single ioctl call to grab a frame instead of single ioctl calls. For this "ge2d" mode CoreELEC hyperion patch got fixed too:
https://github.com/CoreELEC/CoreELEC/commit/62346ccad544a73d61181e9a518b668983b880d2
https://github.com/CoreELEC/CoreELEC/commit/6db794cb59b2979e8659b6218e617b815544e878
https://github.com/CoreELEC/CoreELEC/commit/2f6adf4b4dff4062af3fae6fc546d9722dd88bd3

Also added paramter to use amvideocap0 or ge2d grabber device. If ge2d is choosen the ioctl method can also be chossen by "ge2d_mode".

**2.** If this changes affect the .conf file. Please provide the changed section

    "framegrabber": {
        "amlogic_grabber": "amvideocap0/ge2d",
        "ge2d_mode": 0/1
    },

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

