### PR TITLE
Fixes PhilipsHue Brightness, ColorGamut + new Lights

### DIFF
--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -36,9 +36,10 @@ CiColor CiColor::rgbToCiColor(float red, float green, float blue, CiColorTriangl
 	{
 		cy = 0.0f;
 	}
-	// Brightness is simply Y in the XYZ space.
+	// RGB to HSV/B Conversion after gamma correction use V for brightness, not Y from XYZ Space.
+	float bri = fmax(fmax(r, g), b);
 	CiColor xy =
-	{ cx, cy, Y };
+	{ cx, cy, bri };
 	// Check if the given XY value is within the color reach of our lamps.
 	if (!isPointInLampsReach(xy, colorSpace))
 	{
@@ -212,7 +213,7 @@ const std::set<QString> PhilipsHueLight::GAMUT_A_MODEL_IDS =
 const std::set<QString> PhilipsHueLight::GAMUT_B_MODEL_IDS =
 { "LCT001", "LCT002", "LCT003", "LCT007", "LLM001" };
 const std::set<QString> PhilipsHueLight::GAMUT_C_MODEL_IDS =
-{ "LLC020", "LST002", "LCT011", "LCT012", "LCT010", "LCT014" };
+{ "LLC020", "LST002", "LCT011", "LCT012", "LCT010", "LCT014", "LCT015", "LCT016", "LCT024" };
 
 PhilipsHueLight::PhilipsHueLight(Logger* log, PhilipsHueBridge* bridge, unsigned int id, QJsonObject values)
 	: log(log)
@@ -249,7 +250,7 @@ PhilipsHueLight::PhilipsHueLight(Logger* log, PhilipsHueBridge* bridge, unsigned
 	{
 		Debug(log, "Recognized model id %s of light ID %d as gamut A", modelId.toStdString().c_str(), id);
 		colorSpace.red =
-		{	0.703f, 0.296f};
+		{	0.704f, 0.296f};
 		colorSpace.green =
 		{	0.2151f, 0.7106f};
 		colorSpace.blue =
@@ -261,7 +262,7 @@ PhilipsHueLight::PhilipsHueLight(Logger* log, PhilipsHueBridge* bridge, unsigned
 		colorSpace.red =
 		{	0.675f, 0.322f};
 		colorSpace.green =
-		{	0.4091f, 0.518f};
+		{	0.409f, 0.518f};
 		colorSpace.blue =
 		{	0.167f, 0.04f};
 	}
@@ -269,11 +270,11 @@ PhilipsHueLight::PhilipsHueLight(Logger* log, PhilipsHueBridge* bridge, unsigned
 	{
 		Debug(log, "Recognized model id %s of light ID %d as gamut C", modelId.toStdString().c_str(), id);
 		colorSpace.red =
-		{	0.675f, 0.322f};
+		{	0.6915f, 0.3083f};
 		colorSpace.green =
-		{	0.2151f, 0.7106f};
+		{	0.17f, 0.7f};
 		colorSpace.blue =
-		{	0.167f, 0.04f};
+		{	0.1532f, 0.0475f};
 	}
 	else
 	{


### PR DESCRIPTION
Hue RGB Color Conversion for Brightness is wrong! - use RGB to HSV instead of XYZ Space! 
For correct use, reset brightnessFactor back to 1.0 in config! - It was just a Workaround, not the Solution!
Fixed wrong ColorGamut A/B/C Values + Added New Lamp/Light Models: LCT015, LCT016, LCT024