### PR TITLE
fix V4L2 grabber enable

### DIFF
--- a/include/grabber/V4L2Wrapper.h
+++ b/include/grabber/V4L2Wrapper.h
@@ -24,6 +24,7 @@ public slots:
 	void setCropping(int cropLeft, int cropRight, int cropTop, int cropBottom);
 	void setSignalDetectionOffset(double verticalMin, double horizontalMin, double verticalMax, double horizontalMax);
 	void setSignalDetectionEnable(bool enable);
+	void setDeviceVideoStandard(QString device, VideoStandard videoStandard);
 
 private slots:
 	void newFrame(const Image<ColorRgb> & image);

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -54,9 +54,6 @@ V4L2Grabber::V4L2Grabber(const QString & device
 {
 	setPixelDecimation(pixelDecimation);
 	getV4Ldevices();
-
-	// init
-	setDeviceVideoStandard(device, videoStandard);
 }
 
 V4L2Grabber::~V4L2Grabber()

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -76,3 +76,8 @@ bool V4L2Wrapper::getSignalDetectionEnable()
 {
 	return _grabber.getSignalDetectionEnabled();
 }
+
+void V4L2Wrapper::setDeviceVideoStandard(QString device, VideoStandard videoStandard)
+{
+	_grabber.setDeviceVideoStandard(device, videoStandard);
+}

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -376,6 +376,7 @@ void HyperionDaemon::handleSettingsUpdate(const settings::type& type, const QJso
 			#ifdef ENABLE_V4L2
 
 			const QJsonObject & grabberConfig = v4lArray.at(idx).toObject();
+			bool enableV4l = grabberConfig["enable"].toBool(true);
 
 			V4L2Wrapper* grabber = new V4L2Wrapper(
 				grabberConfig["device"].toString("auto"),
@@ -402,6 +403,14 @@ void HyperionDaemon::handleSettingsUpdate(const settings::type& type, const QJso
 			// connect to HyperionDaemon signal
 			connect(this, &HyperionDaemon::videoMode, grabber, &V4L2Wrapper::setVideoMode);
 			connect(this, &HyperionDaemon::settingsChanged, grabber, &V4L2Wrapper::handleSettingsUpdate);
+
+			if (enableV4l)
+			{
+				v4lEnableCount++;
+
+				// init
+				grabber->setDeviceVideoStandard(grabberConfig["device"].toString("auto"), parseVideoStandard(grabberConfig["standard"].toString("no-change")));				
+			}
 
 			_v4l2Grabbers.push_back(grabber);
 			#endif


### PR DESCRIPTION
**1.** Tell us something about your changes.
re-enable the "enable" config flag for V4L2 grabber

**3.** Reference an issue (optional)
V4L2 would start everytime, also if enabled == false


