### PR TITLE
Add SIGUSR1 and SIGUSR2 signals to disable/enable the LEDs

### DIFF
--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -98,6 +98,8 @@ int LinearColorSmoothing::switchOff()
 		_outputQueue.pop_front();
 	}
 
+	emit _hyperion->ledDeviceData(std::vector<ColorRgb>(_ledCount, ColorRgb::BLACK));
+
 	return 0;
 }
 

--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -20,6 +20,7 @@ LedDeviceWrapper::LedDeviceWrapper(Hyperion* hyperion)
 	: QObject(hyperion)
 	, _hyperion(hyperion)
 	, _ledDevice(nullptr)
+	, _enabled(true)
 {
 	// prepare the device constrcutor map
 	#define REGISTER(className) LedDeviceWrapper::addToDeviceMap(QString(#className).toLower(), LedDevice##className::construct);

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -41,10 +41,31 @@ using namespace commandline;
 
 void signal_handler(const int signum)
 {
+	/// Hyperion instance
+	Hyperion* _hyperion = Hyperion::getInstance();
+
 	if(signum == SIGCHLD)
 	{
 		// only quit when a registered child process is gone
 		// currently this feature is not active ...
+		return;
+	}
+	else if (signum == SIGUSR1)
+	{
+		if (_hyperion != nullptr)
+		{
+			_hyperion->setComponentState(hyperion::COMP_SMOOTHING, false);
+			_hyperion->setComponentState(hyperion::COMP_LEDDEVICE, false);
+		}
+		return;
+	}
+	else if (signum == SIGUSR2)
+	{
+		if (_hyperion != nullptr)
+		{
+			_hyperion->setComponentState(hyperion::COMP_LEDDEVICE, true);
+			_hyperion->setComponentState(hyperion::COMP_SMOOTHING, true);
+		}
 		return;
 	}
 	QCoreApplication::quit();
@@ -132,6 +153,8 @@ int main(int argc, char** argv)
 	signal(SIGABRT, signal_handler);
 	signal(SIGCHLD, signal_handler);
 	signal(SIGPIPE, signal_handler);
+	signal(SIGUSR1, signal_handler);
+	signal(SIGUSR2, signal_handler);
 
 	// force the locale
 	setlocale(LC_ALL, "C");


### PR DESCRIPTION
**1.** Tell us something about your changes.
Add SIGUSR1 and SIGUSR2 signals to disable/enable the LEDs for suspend mode or more.
Fixed missing enable on LedDeviceWrapper constructor.
**2.** If this changes affect the .conf file. Please provide the changed section
None
**3.** Reference an issue (optional)
The LEDs remain on if the control box goes offline without setting the LEDs to off.


Note: For further discussions use our forum: forum.hyperion-project.org

