### PR TITLE
Section "Integrating hyperion into your system"

### DIFF
--- a/CompileHowto.md
+++ b/CompileHowto.md
@@ -161,4 +161,4 @@ This will install to ``/home/pi/apps/share/hyperion``
 
 ### Integrating hyperion into your system
 
-... ToDo
+... ToDo.


### PR DESCRIPTION
Hi! This section is just written "ToDo" and I believe it is one thing that is missing for me to conclude the installation. I am sorry to use this way here to ask it but no other places and forum can help on this...
I compiled Hyperion.ng on my OSMC Raspberry 3B+ and the service is not created to start on boot. Also I tried to run "install_hyperion.sh" but it says "Critical Error: CPU information does not match any known releases"
How can I make hyperion.ng start on boot as a service!?


**1.** Tell us something about your changes.

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

