### PR TITLE
Fix LEDDeviceWrapper coredump when killing hyperiond

### DIFF
--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -146,5 +146,5 @@ void LedDeviceWrapper::stopDeviceThread()
 	QThread* oldThread = _ledDevice->thread();
 	delete _ledDevice; // fast desctruction
 	oldThread->quit(); // non blocking
-    oldThread->wait();
+	oldThread->wait();
 }

--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -146,4 +146,5 @@ void LedDeviceWrapper::stopDeviceThread()
 	QThread* oldThread = _ledDevice->thread();
 	delete _ledDevice; // fast desctruction
 	oldThread->quit(); // non blocking
+    oldThread->wait();
 }


### PR DESCRIPTION
In case a running hyperiond is "killed", a core-dump is created due to the fact that a QThread for LEDDevice is still running.
Add QThread->wait() ensuring QThread completes before further destructors are called.
