### PR TITLE
Fix systemd unit

### DIFF
--- a/bin/service/hyperion.systemd
+++ b/bin/service/hyperion.systemd
@@ -1,11 +1,11 @@
 [Unit]
-Description=Hyperion ambient light systemd service  for user %i
+Description=Hyperion ambient light systemd service for user root
 After=network.target
 
 [Service]
 ExecStart=/usr/bin/hyperiond
 WorkingDirectory=/usr/share/hyperion/bin
-User=%i
+User=root
 TimeoutStopSec=5
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
Variables like `%i` don't appear to be supported in systemd unit files.  This means a config file cannot be created and `hyperiond` fails to start.  It might be possible that some distributions have newer versions of systemd that have fixed this, but not all.
