### PR TITLE
Allow to switch on LED device, if currently disabled

### DIFF
--- a/bin/create_all_releases.sh
+++ b/bin/create_all_releases.sh
@@ -10,12 +10,12 @@ make_release()
 	PLATFORM=$2
 	shift 2
 
-	rm -r hyperion.ng-${RELEASE}
-	mkdir -p hyperion.ng-${RELEASE}
+	rm -r build-${RELEASE}
+	mkdir -p build-${RELEASE}
 	rm -r deploy/${RELEASE}
 	mkdir -p deploy/${RELEASE}
 
-	cd  hyperion.ng-${RELEASE}
+	cd  build-${RELEASE}
 	cmake -DCMAKE_INSTALL_PREFIX=/usr -DPLATFORM=${PLATFORM} $@ -DCMAKE_BUILD_TYPE=Release -Wno-dev .. || exit 1
 	make -j $(nproc)  || exit 1
 	#strip bin/*
@@ -25,8 +25,8 @@ make_release()
 	bin/create_release.sh . ${RELEASE}
 }
 
-CMAKE_PROTOC_FLAG="-DIMPORT_PROTOC=../hyperion.ng-x86x64/protoc_export.cmake"
-CMAKE_FLATC_FLAG="-DIMPORT_FLATC=../hyperion.ng-x86x64/flatc_export.cmake"
+CMAKE_PROTOC_FLAG="-DIMPORT_PROTOC=../build-x86x64/protoc_export.cmake"
+CMAKE_FLATC_FLAG="-DIMPORT_FLATC=../build-x86x64/flatc_export.cmake"
 
 make_release x86x64  x86
 #make_release x32     x86   -DCMAKE_TOOLCHAIN_FILE="../cmake/Toolchain-x32.cmake" ${CMAKE_PROTOC_FLAG} ${CMAKE_FLATC_FLAG}

--- a/bin/create_all_releases.sh
+++ b/bin/create_all_releases.sh
@@ -10,23 +10,23 @@ make_release()
 	PLATFORM=$2
 	shift 2
 
-	rm -r build-${RELEASE}
-	mkdir -p build-${RELEASE}
+	rm -r hyperion.ng-${RELEASE}
+	mkdir -p hyperion.ng-${RELEASE}
 	rm -r deploy/${RELEASE}
 	mkdir -p deploy/${RELEASE}
 
-	cd  build-${RELEASE}
+	cd  hyperion.ng-${RELEASE}
 	cmake -DCMAKE_INSTALL_PREFIX=/usr -DPLATFORM=${PLATFORM} $@ -DCMAKE_BUILD_TYPE=Release -Wno-dev .. || exit 1
 	make -j $(nproc)  || exit 1
 	#strip bin/*
 	make package -j $(nproc)
-	mv Hyperion-*.* ../deploy/${RELEASE}
+	mv Hyperion.NG-* ../deploy/${RELEASE}
 	cd ..
 	bin/create_release.sh . ${RELEASE}
 }
 
-CMAKE_PROTOC_FLAG="-DIMPORT_PROTOC=../build-x86x64/protoc_export.cmake"
-CMAKE_FLATC_FLAG="-DIMPORT_FLATC=../build-x86x64/flatc_export.cmake"
+CMAKE_PROTOC_FLAG="-DIMPORT_PROTOC=../hyperion.ng-x86x64/protoc_export.cmake"
+CMAKE_FLATC_FLAG="-DIMPORT_FLATC=../hyperion.ng-x86x64/flatc_export.cmake"
 
 make_release x86x64  x86
 #make_release x32     x86   -DCMAKE_TOOLCHAIN_FILE="../cmake/Toolchain-x32.cmake" ${CMAKE_PROTOC_FLAG} ${CMAKE_FLATC_FLAG}

--- a/bin/create_release.sh
+++ b/bin/create_release.sh
@@ -7,7 +7,7 @@ fi
 
 repodir="$1"
 buildid="$2"
-builddir=$repodir/hyperion.ng-$buildid
+builddir=$repodir/build-$buildid
 echo build directory = $builddir
 echo repository root directory = $repodir
 if ! [ -d "$builddir" ]; then

--- a/bin/create_release.sh
+++ b/bin/create_release.sh
@@ -7,24 +7,24 @@ fi
 
 repodir="$1"
 buildid="$2"
-builddir=$repodir/build-$buildid
+builddir=$repodir/hyperion.ng-$buildid
 echo build directory = $builddir
-echo repository root dirrectory = $repodir
+echo repository root directory = $repodir
 if ! [ -d "$builddir" ]; then
 	echo "Could not find build director"
 	exit 1
 fi
 	
-outfile="$repodir/deploy/hyperion_$buildid.tar.gz"
+outfile="$repodir/deploy/hyperion.ng_$buildid.tar.gz"
 echo create $outfile
 
 tar --create --gzip --absolute-names --show-transformed-names --ignore-failed-read\
 	--file "$outfile" \
 	--transform "s:$builddir/bin/:hyperion/bin/:" \
 	--transform "s:$repodir/config/:hyperion/config/:" \
-	--transform "s:$repodir/bin/service/hyperion.init.sh:hyperion/services/hyperion.init.sh:" \
-	--transform "s:$repodir/bin/service/hyperion.systemd.sh:hyperion/services/hyperion.systemd.sh:" \
-	--transform "s:$repodir/bin/service/hyperion.initctl.sh:hyperion/services/hyperion.initctl.sh:" \
+	--transform "s:$repodir/bin/service/hyperion.init:hyperion/services/hyperion.init:" \
+	--transform "s:$repodir/bin/service/hyperion.systemd:hyperion/services/hyperion.systemd:" \
+	--transform "s:$repodir/bin/service/hyperion.initctl:hyperion/services/hyperion.initctl:" \
 	--transform "s://:/:g" \
 	"$builddir/bin/hyperion"* \
 	"$repodir/bin/service/hyperion.init" \

--- a/libsrc/leddevice/LedDevice.cpp
+++ b/libsrc/leddevice/LedDevice.cpp
@@ -45,12 +45,22 @@ void LedDevice::setEnable(bool enable)
 {
 	// emit signal when state changed
 	if (_enabled != enable)
+	{
 		emit enableStateChanged(enable);
-
-	// set black to leds when they should go off
+	}
+	// switch off device when disabled, default: set black to leds when they should go off
 	if ( _enabled && !enable)
+	{
 		switchOff();
-
+	}
+	else
+	{
+		// switch on device when enabled
+		if ( !_enabled && enable)
+		{
+			switchOn();
+		}
+	}
 	_enabled = enable;
 }
 


### PR DESCRIPTION
Reimplement to be able to switch on/off devices via the LED Device UI button.
Before the change devices will only be switched off, but not on again.

This is mainly relevant for devices which override the LedDevice switchOn/Off methods to do API calls
rather than have a black output stream.
