### PR TITLE
Fixing PhilipsHue wizard, Fixing issue #545

### DIFF
--- a/assets/webconfig/js/wizard.js
+++ b/assets/webconfig/js/wizard.js
@@ -26,6 +26,7 @@
 		if(withKodi)
 			sendToKodi("stop");
 		step = 0;
+		location.reload();
 	}
 
 	//rgb byte order wizard
@@ -658,7 +659,7 @@
 	function getHueIPs(){
 		$('#wiz_hue_ipstate').html($.i18n('wiz_hue_searchb'));
 		$.ajax({
-			url: 'https://www.meethue.com/api/nupnp',
+			url: 'https://discovery.meethue.com',
 			crossDomain: true,
 			type: 'GET',
 			timeout: 3000
@@ -697,7 +698,7 @@
 		}
 
 		$('#retry_bridge').off().on('click', function(){
-			hueIPs[0].internalipaddress = $('#ip').val();
+			hueIPs.push({internalipaddress : $('#ip').val()});
 			hueIPsinc = 0;
 			checkHueBridge(checkBridgeResult);
 		});

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -446,10 +446,10 @@ int LedDevicePhilipsHue::write(const std::vector<ColorRgb> & ledValues)
 		else
 		{
 			light.setOn(true);
+			// Write color if color has been changed.
+			light.setTransitionTime(transitionTime);
+			light.setColor(xy, brightnessFactor);
 		}
-		// Write color if color has been changed.
-		light.setTransitionTime(transitionTime);
-		light.setColor(xy, brightnessFactor);
 
 		idx++;
 	}


### PR DESCRIPTION
**1.** Tell us something about your changes.

- Fixing PhilipsHue Wizard: The Wizard had trouble updating the values to the JSONEditor. Besides of that the manual IP entry in the wizard was broken (is needed when auto lookup fails). The auto lookup page from Philips moved to an other URL. Old URL is officially not available anymore since 1st July 2019. See this post: https://developers.meethue.com/news/ (Bridge Discovery Endpoint Change)

- Fixes #545 I have tested this on my Philips Hue Setup as well

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org
