### PR TITLE
Debian post-inst script fails to correctly create system service when multiple users are present

### DIFF
--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/debian/preinst
+++ b/cmake/debian/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/debian/preinst
+++ b/cmake/debian/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/debian/preinst
+++ b/cmake/debian/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/debian/prerm
+++ b/cmake/debian/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false

--- a/cmake/debian/prerm
+++ b/cmake/debian/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false

--- a/cmake/debian/prerm
+++ b/cmake/debian/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false

--- a/cmake/rpm/postinst
+++ b/cmake/rpm/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/rpm/postinst
+++ b/cmake/rpm/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/rpm/postinst
+++ b/cmake/rpm/postinst
@@ -29,7 +29,7 @@ BOOT_BERRYBOOT=$(grep -m1 -c '\(/var/media\|/media/pi\)/berryboot' /etc/mtab)
 NET_IP=`hostname -I | cut -d " " -f1`
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # determine if we should use a service
 ENABLE_SERVICE=0

--- a/cmake/rpm/preinst
+++ b/cmake/rpm/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/rpm/preinst
+++ b/cmake/rpm/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/rpm/preinst
+++ b/cmake/rpm/preinst
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light preinst ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # stop running daemon before we install
 if pgrep hyperiond > /dev/null 2>&1

--- a/cmake/rpm/prerm
+++ b/cmake/rpm/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o '^\w*\b'` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false

--- a/cmake/rpm/prerm
+++ b/cmake/rpm/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
+FOUND_USR=`whoami` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false

--- a/cmake/rpm/prerm
+++ b/cmake/rpm/prerm
@@ -3,7 +3,7 @@
 echo "---Hyperion ambient light prerm ---"
 
 # search for users in system, returns first entry
-FOUND_USR=`whoami` || "root"
+FOUND_USR=`who | grep -o -m1 '^\w*\b'` || "root"
 
 # stop running daemon before we delete it
 HYPERION_RUNNING=false


### PR DESCRIPTION
Fixes an issue where multiple users returned from `who` causes grep to be greedy and return a regex matched string containing all users, not the first user as intended.
This caused the package installation on Raspbian to create an incorrect service name which could not be started as there was a mismatch in user vs expected user.

As discussed with @Paulchen-Panther [HERE](https://hyperion-project.org/threads/installing-hyperion-ng.3491/page-3#post-15695)

Fresh install of Raspbian Stretch, calling `who` from the terminal returns two users. Doing the same on an SSH session returns 3:
```
pi@raspberrypi:~ $ who
pi       tty1         2019-08-07 17:38
pi       tty7         2019-08-07 17:39 (:0)
pi       pts/0        2019-08-07 17:41 (10.26.25.176)
```
After regexp:
```
pi@raspberrypi:~ $ who | grep -o '^\w*\b'
pi
pi
pi
```

Fix changes to:
```
pi@raspberrypi:~ $ who | grep -o -m1 '^\w*\b'
pi
```
Tested installing .deb on Raspbian Buster - now works. can someone please check the .rpm please, as i have made the same changes there.
Fixes #588 