### PR TITLE
Fix RPI WS281x LED device initialization

### DIFF
--- a/libsrc/leddevice/dev_rpi_pwm/LedDeviceWS281x.cpp
+++ b/libsrc/leddevice/dev_rpi_pwm/LedDeviceWS281x.cpp
@@ -36,6 +36,7 @@ bool LedDeviceWS281x::init(const QJsonObject &deviceConfig)
 		throw std::runtime_error("WS281x: invalid PWM channel; must be 0 or 1.");
 	}
 
+	memset(&_led_string, 0, sizeof(_led_string));
 	_led_string.freq   = deviceConfig["freq"].toInt(800000ul);
 	_led_string.dmanum = deviceConfig["dma"].toInt(5);
 	_led_string.channel[_channel].gpionum    = deviceConfig["gpio"].toInt(18);


### PR DESCRIPTION
When initializing LedDeviceWS281x `_led_string` field (ws2811_t) was not filled with zeros (thus was filled with garbage) and that prevented proper initialization of it's `gamma` pointer, accessing which causes a SIGSEGV.

Added initialization of `_led_string` field with zeros which results in proper memory allocation for `gamma`.

Tested locally.

Fixes #564