### PR TITLE
fix warning: throw will always call terminate

### DIFF
--- a/libsrc/grabber/amlogic/IonBuffer.h
+++ b/libsrc/grabber/amlogic/IonBuffer.h
@@ -142,7 +142,7 @@ public:
 // 		fprintf(stderr, "ion phys_addr=%lu\n", physicalAddress);
 	}
 
-	virtual ~IonBuffer()
+	virtual ~IonBuffer() noexcept(false)
 	{
 		ion_handle_data ionHandleData = { 0 };
 		ionHandleData.handle = handle;


### PR DESCRIPTION
**1.** Tell us something about your changes.
https://discourse.coreelec.org/t/slow-down-of-hyperion-ng/341/356?u=portisch

**2.** If this changes affect the .conf file. Please provide the changed section
none
**3.** Reference an issue (optional)
warning: throw will always call terminate

Note: For further discussions use our forum: forum.hyperion-project.org

