### PR TITLE
Refactored Exceptions in main & PythonInit

### DIFF
--- a/libsrc/python/PythonInit.cpp
+++ b/libsrc/python/PythonInit.cpp
@@ -19,6 +19,11 @@ PythonInit::PythonInit()
 	// init Python
 	Debug(Logger::getInstance("DAEMON"), "Initializing Python interpreter");
 	Py_InitializeEx(0);
+	if ( !Py_IsInitialized() )
+	{
+		throw std::runtime_error("Initializing Python failed!");
+	}
+
 	PyEval_InitThreads(); // Create the GIL
 	mainThreadState = PyEval_SaveThread();
 }


### PR DESCRIPTION
- Refactored exception handling in main
Exceptions thrown by HyperionDaemon did not result in stopping the application, but had the qt application still running. Exception thrown for rootPaths were even not caught, as thrown outside a try block. In case hyperion should run without daemon ,come back to me.

- During my testing to ship libraries with the app, I identified that hyperiond starts even, if Python failed to initialise. Added an exception, if Python failed initialisation.

