### PR TITLE
Fix #604, #605 ...

### DIFF
--- a/include/api/JsonAPI.h
+++ b/include/api/JsonAPI.h
@@ -2,22 +2,17 @@
 
 // hyperion includes
 #include <utils/Logger.h>
-#include <utils/jsonschema/QJsonSchemaChecker.h>
 #include <utils/Components.h>
 #include <hyperion/Hyperion.h>
+#include <hyperion/HyperionIManager.h>
 
 // qt includes
 #include <QJsonObject>
-#include <QMutex>
 #include <QString>
-#include <QTimer>
 
-// HyperionInstanceManager
-#include <hyperion/HyperionIManager.h>
-
+class QTimer;
 class JsonCB;
 class AuthManager;
-class HyperionIManager;
 
 class JsonAPI : public QObject
 {

--- a/include/api/JsonAPI.h
+++ b/include/api/JsonAPI.h
@@ -10,6 +10,7 @@
 #include <QJsonObject>
 #include <QMutex>
 #include <QString>
+#include <QTimer>
 
 // HyperionInstanceManager
 #include <hyperion/HyperionIManager.h>
@@ -43,15 +44,20 @@ public:
 
 public slots:
 	///
-	/// @brief is called whenever the current Hyperion instance pushes new led raw values (if enabled)
-	/// @param ledColors  The current ledColors
+	/// @brief Is called whenever the current Hyperion instance pushes new led raw values (if enabled)
+	/// @param ledColors  The current led colors
 	///
 	void streamLedcolorsUpdate(const std::vector<ColorRgb>& ledColors);
 
-	/// push images whenever hyperion emits (if enabled)
+	///
+	/// @brief Push images whenever hyperion emits (if enabled)
+	/// @param image  The current image
+	///
 	void setImage(const Image<ColorRgb> & image);
 
-	/// process and push new log messages from logger (if enabled)
+	///
+	/// @brief Process and push new log messages from logger (if enabled)
+	///
 	void incommingLogMessage(const Logger::T_LOG_MESSAGE&);
 
 private slots:
@@ -128,17 +134,23 @@ private:
 	/// flag to determine state of log streaming
 	bool _streaming_logging_activated;
 
-	/// mutex to determine state of image streaming
-	QMutex _image_stream_mutex;
+	/// timer for live video refresh
+	QTimer* _imageStreamTimer;
 
-	/// mutex to determine state of led streaming
-	QMutex _led_stream_mutex;
+	/// image stream connection handle
+	QMetaObject::Connection _imageStreamConnection;
 
-	/// timeout for live video refresh
-	volatile qint64 _image_stream_timeout;
+	/// the current streaming image
+	Image<ColorRgb> _currentImage;
 
-	/// timeout for led color refresh
-	volatile qint64 _led_stream_timeout;
+	/// timer for led color refresh
+	QTimer* _ledStreamTimer;
+
+	/// led stream connection handle
+	QMetaObject::Connection _ledStreamConnection;
+
+	/// the current streaming led values
+	std::vector<ColorRgb> _currentLedValues;
 
 	///
 	/// @brief Handle the switches of Hyperion instances

--- a/include/utils/Image.h
+++ b/include/utils/Image.h
@@ -245,6 +245,17 @@ public:
 		return  (ssize_t) _width * _height * sizeof(Pixel_T);
 	}
 
+	/// Clear the image
+	//
+	void clear()
+	{
+		_width = 1;
+		_height = 1;
+		_pixels = new Pixel_T[2];
+		_endOfPixels = _pixels + 1;
+		memset(_pixels, 0, _width * _height * sizeof(Pixel_T));
+	}
+
 private:
 
 	///

--- a/libsrc/api/JSONRPC_schema/schema-ledcolors.json
+++ b/libsrc/api/JSONRPC_schema/schema-ledcolors.json
@@ -19,7 +19,9 @@
 			"type" : "bool"
 		},
 		"interval": {
-			"type" : "integer"
+			"type" : "integer",
+			"required" : false,
+			"minimum": 50
 		}
 	},
 

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -1041,13 +1041,13 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 
 			// start the timer
 			if (!_ledStreamTimer->isActive() || _ledStreamTimer->interval() != streaming_interval)
-				QMetaObject::invokeMethod(_ledStreamTimer, "start", Qt::QueuedConnection, Q_ARG(int, streaming_interval));
+				_ledStreamTimer->start(streaming_interval);
 		}, Qt::UniqueConnection);
 	}
 	else if (subcommand == "ledstream-stop")
 	{
 		disconnect(_hyperion, &Hyperion::rawLedColors, this, 0);
-		QMetaObject::invokeMethod(_ledStreamTimer, "stop", Qt::QueuedConnection);
+		_ledStreamTimer->stop();
 		disconnect(_ledStreamConnection);
 	}
 	else if (subcommand == "imagestream-start")
@@ -1070,7 +1070,7 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 
 			// start timer
 			if (!_imageStreamTimer->isActive() || _imageStreamTimer->interval() != streaming_interval)
-				QMetaObject::invokeMethod(_imageStreamTimer, "start", Qt::QueuedConnection, Q_ARG(int, streaming_interval));
+				_imageStreamTimer->start(streaming_interval);
 		}, Qt::UniqueConnection);
 
 		_hyperion->update();
@@ -1078,7 +1078,7 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 	else if (subcommand == "imagestream-stop")
 	{
 		disconnect(_hyperion, &Hyperion::currentImage, this, 0);
-		QMetaObject::invokeMethod(_imageStreamTimer, "stop", Qt::QueuedConnection);
+		_imageStreamTimer->stop();
 		disconnect(_imageStreamConnection);
 	}
 	else

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -53,8 +53,8 @@ JsonAPI::JsonAPI(QString peerAddress, Logger* log, const bool& localConnection, 
 	, _hyperion(nullptr)
 	, _jsonCB(nullptr)
 	, _streaming_logging_activated(false)
-	, _imageStreamTimer(new QTimer())
-	, _ledStreamTimer(new QTimer())
+	, _imageStreamTimer(new QTimer(this))
+	, _ledStreamTimer(new QTimer(this))
 {
 	Q_INIT_RESOURCE(JSONRPC_schemas);
 

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -12,17 +12,16 @@
 #include <QImage>
 #include <QBuffer>
 #include <QByteArray>
-#include <QDateTime>
-#include <QHostInfo>
-#include <QMutexLocker>
+#include <QTimer>
 
 // hyperion includes
-#include <utils/jsonschema/QJsonFactory.h>
-#include <utils/SysInfo.h>
-#include <HyperionConfig.h>
-#include <utils/ColorSys.h>
 #include <leddevice/LedDeviceWrapper.h>
 #include <hyperion/GrabberWrapper.h>
+#include <utils/jsonschema/QJsonFactory.h>
+#include <utils/jsonschema/QJsonSchemaChecker.h>
+#include <HyperionConfig.h>
+#include <utils/SysInfo.h>
+#include <utils/ColorSys.h>
 #include <utils/Process.h>
 #include <utils/JsonUtils.h>
 

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -53,8 +53,8 @@ JsonAPI::JsonAPI(QString peerAddress, Logger* log, const bool& localConnection, 
 	, _hyperion(nullptr)
 	, _jsonCB(nullptr)
 	, _streaming_logging_activated(false)
-	, _image_stream_timeout(0)
-	, _led_stream_timeout(0)
+	, _imageStreamTimer(new QTimer())
+	, _ledStreamTimer(new QTimer())
 {
 	Q_INIT_RESOURCE(JSONRPC_schemas);
 
@@ -1018,37 +1018,68 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 	// create result
 	QString subcommand = message["subcommand"].toString("");
 
+	// max 20 Hz (50ms) interval for streaming (default: 10 Hz (100ms))
+	qint64 streaming_interval = qMax(message["interval"].toInt(100), 50);
+
 	if (subcommand == "ledstream-start")
 	{
 		_streaming_leds_reply["success"] = true;
 		_streaming_leds_reply["command"] = command+"-ledstream-update";
 		_streaming_leds_reply["tan"]  = tan;
-		connect(_hyperion, &Hyperion::rawLedColors, this, &JsonAPI::streamLedcolorsUpdate, Qt::UniqueConnection);
 
-		const std::vector<ColorRgb> lastColor = _hyperion->getPriorityInfo(_hyperion->getCurrentPriority()).ledColors;
-		if (!lastColor.empty())
-			QMetaObject::invokeMethod(this, "streamLedcolorsUpdate", Qt::QueuedConnection, Q_ARG(const std::vector<ColorRgb>&, lastColor));
+		connect(_hyperion, &Hyperion::rawLedColors, this, [=](const std::vector<ColorRgb>& ledValues)
+		{
+			_currentLedValues = ledValues;
+
+			// necessary because Qt::UniqueConnection for lambdas does not work until 5.9
+			// see: https://bugreports.qt.io/browse/QTBUG-52438
+			if (!_ledStreamConnection)
+				_ledStreamConnection = connect(_ledStreamTimer, &QTimer::timeout, this, [=]()
+				{
+					emit streamLedcolorsUpdate(_currentLedValues);
+				}, Qt::UniqueConnection);
+
+			// start the timer
+			if (!_ledStreamTimer->isActive() || _ledStreamTimer->interval() != streaming_interval)
+				QMetaObject::invokeMethod(_ledStreamTimer, "start", Qt::QueuedConnection, Q_ARG(int, streaming_interval));
+		}, Qt::UniqueConnection);
 	}
 	else if (subcommand == "ledstream-stop")
 	{
-		disconnect(_hyperion, &Hyperion::rawLedColors, this, &JsonAPI::streamLedcolorsUpdate);
+		disconnect(_hyperion, &Hyperion::rawLedColors, this, 0);
+		QMetaObject::invokeMethod(_ledStreamTimer, "stop", Qt::QueuedConnection);
+		disconnect(_ledStreamConnection);
 	}
 	else if (subcommand == "imagestream-start")
 	{
 		_streaming_image_reply["success"] = true;
 		_streaming_image_reply["command"] = command+"-imagestream-update";
 		_streaming_image_reply["tan"]  = tan;
-		connect(_hyperion, &Hyperion::currentImage, this, &JsonAPI::setImage, Qt::UniqueConnection);
 
-		const Image<ColorRgb> lastImage = _hyperion->getPriorityInfo(_hyperion->getCurrentPriority()).image;
-		if(lastImage.size() > 3)
-			QMetaObject::invokeMethod(this, "setImage", Qt::QueuedConnection, Q_ARG(const Image<ColorRgb>&, lastImage));
+		connect(_hyperion, &Hyperion::currentImage, this, [=](const Image<ColorRgb>& image)
+		{
+			_currentImage = image;
+
+			// necessary because Qt::UniqueConnection for lambdas does not work until 5.9
+			// see: https://bugreports.qt.io/browse/QTBUG-52438
+			if (!_imageStreamConnection)
+				_imageStreamConnection = connect(_imageStreamTimer, &QTimer::timeout, this, [=]()
+				{
+					emit setImage(_currentImage);
+				}, Qt::UniqueConnection);
+
+			// start timer
+			if (!_imageStreamTimer->isActive() || _imageStreamTimer->interval() != streaming_interval)
+				QMetaObject::invokeMethod(_imageStreamTimer, "start", Qt::QueuedConnection, Q_ARG(int, streaming_interval));
+		}, Qt::UniqueConnection);
 
 		_hyperion->update();
 	}
 	else if (subcommand == "imagestream-stop")
 	{
-		disconnect(_hyperion, &Hyperion::currentImage, this, &JsonAPI::setImage);
+		disconnect(_hyperion, &Hyperion::currentImage, this, 0);
+		QMetaObject::invokeMethod(_imageStreamTimer, "stop", Qt::QueuedConnection);
+		disconnect(_imageStreamConnection);
 	}
 	else
 	{
@@ -1429,52 +1460,40 @@ void JsonAPI::sendErrorReply(const QString &error, const QString &command, const
 	emit callbackMessage(reply);
 }
 
-
 void JsonAPI::streamLedcolorsUpdate(const std::vector<ColorRgb>& ledColors)
 {
-	QMutexLocker lock(&_led_stream_mutex);
-	if ( (_led_stream_timeout+100) < QDateTime::currentMSecsSinceEpoch() )
+	QJsonObject result;
+	QJsonArray leds;
+
+	for(auto color = ledColors.begin(); color != ledColors.end(); ++color)
 	{
-		_led_stream_timeout = QDateTime::currentMSecsSinceEpoch();
-		QJsonObject result;
-		QJsonArray leds;
-
-		for(auto color = ledColors.begin(); color != ledColors.end(); ++color)
-		{
-			QJsonObject item;
-			item["index"] = int(color - ledColors.begin());
-			item["red"]   = color->red;
-			item["green"] = color->green;
-			item["blue"]  = color->blue;
-			leds.append(item);
-		}
-
-		result["leds"] = leds;
-		_streaming_leds_reply["result"] = result;
-
-		// send the result
-		emit callbackMessage(_streaming_leds_reply);
+		QJsonObject item;
+		item["index"] = int(color - ledColors.begin());
+		item["red"]   = color->red;
+		item["green"] = color->green;
+		item["blue"]  = color->blue;
+		leds.append(item);
 	}
+
+	result["leds"] = leds;
+	_streaming_leds_reply["result"] = result;
+
+	// send the result
+	emit callbackMessage(_streaming_leds_reply);
 }
 
 void JsonAPI::setImage(const Image<ColorRgb> & image)
 {
-	QMutexLocker lock(&_image_stream_mutex);
-	if ( (_image_stream_timeout+100) < QDateTime::currentMSecsSinceEpoch() )
-	{
-		_image_stream_timeout = QDateTime::currentMSecsSinceEpoch();
+	QImage jpgImage((const uint8_t *) image.memptr(), image.width(), image.height(), 3*image.width(), QImage::Format_RGB888);
+	QByteArray ba;
+	QBuffer buffer(&ba);
+	buffer.open(QIODevice::WriteOnly);
+	jpgImage.save(&buffer, "jpg");
 
-		QImage jpgImage((const uint8_t *) image.memptr(), image.width(), image.height(), 3*image.width(), QImage::Format_RGB888);
-		QByteArray ba;
-		QBuffer buffer(&ba);
-		buffer.open(QIODevice::WriteOnly);
-		jpgImage.save(&buffer, "jpg");
-
-		QJsonObject result;
-		result["image"] = "data:image/jpg;base64,"+QString(ba.toBase64());
-		_streaming_image_reply["result"] = result;
-		emit callbackMessage(_streaming_image_reply);
-	}
+	QJsonObject result;
+	result["image"] = "data:image/jpg;base64,"+QString(ba.toBase64());
+	_streaming_image_reply["result"] = result;
+	emit callbackMessage(_streaming_image_reply);
 }
 
 void JsonAPI::incommingLogMessage(const Logger::T_LOG_MESSAGE &msg)

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -1024,6 +1024,10 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 		_streaming_leds_reply["command"] = command+"-ledstream-update";
 		_streaming_leds_reply["tan"]  = tan;
 		connect(_hyperion, &Hyperion::rawLedColors, this, &JsonAPI::streamLedcolorsUpdate, Qt::UniqueConnection);
+
+		const std::vector<ColorRgb> lastColor = _hyperion->getPriorityInfo(_hyperion->getCurrentPriority()).ledColors;
+		if (!lastColor.empty())
+			QMetaObject::invokeMethod(this, "streamLedcolorsUpdate", Qt::QueuedConnection, Q_ARG(const std::vector<ColorRgb>&, lastColor));
 	}
 	else if (subcommand == "ledstream-stop")
 	{
@@ -1035,6 +1039,11 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject& message, const QString &
 		_streaming_image_reply["command"] = command+"-imagestream-update";
 		_streaming_image_reply["tan"]  = tan;
 		connect(_hyperion, &Hyperion::currentImage, this, &JsonAPI::setImage, Qt::UniqueConnection);
+
+		const Image<ColorRgb> lastImage = _hyperion->getPriorityInfo(_hyperion->getCurrentPriority()).image;
+		if(lastImage.size() > 3)
+			QMetaObject::invokeMethod(this, "setImage", Qt::QueuedConnection, Q_ARG(const Image<ColorRgb>&, lastImage));
+
 		_hyperion->update();
 	}
 	else if (subcommand == "imagestream-stop")

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -368,6 +368,9 @@ void Hyperion::setColor(const int priority, const ColorRgb &color, const int tim
 	// create led vector from single color
 	std::vector<ColorRgb> ledColors(_ledString.leds().size(), color);
 
+	if (getPriorityInfo(priority).componentId != hyperion::COMP_COLOR)
+		clear(priority);
+
 	// register color
 	registerInput(priority, hyperion::COMP_COLOR, origin);
 

--- a/libsrc/hyperion/LinearColorSmoothing.h
+++ b/libsrc/hyperion/LinearColorSmoothing.h
@@ -88,6 +88,20 @@ private slots:
 	///
 	void componentStateChange(const hyperion::Components component, const bool state);
 
+	///
+	/// @brief Handle modifyTimerHelper slot, can be removed with signal
+	/// @param enable The new state of the Timer
+	///
+	void handleModifyTimerHelper(const bool& enable);
+
+signals:
+	///
+	/// @brief Start the timer until we fixed the proper thread usage against Hyperion class
+	/// @param enable If true start the timer, else stop it
+	///
+	void modifyTimerHelper(const bool& enable);
+
+
 private:
 	/**
 	 * Pushes the colors into the output queue and popping the head to the led-device

--- a/libsrc/hyperion/LinearColorSmoothing.h
+++ b/libsrc/hyperion/LinearColorSmoothing.h
@@ -88,20 +88,6 @@ private slots:
 	///
 	void componentStateChange(const hyperion::Components component, const bool state);
 
-	///
-	/// @brief Handle modifyTimerHelper slot, can be removed with signal
-	/// @param enable The new state of the Timer
-	///
-	void handleModifyTimerHelper(const bool& enable);
-
-signals:
-	///
-	/// @brief Start the timer until we fixed the proper thread usage against Hyperion class
-	/// @param enable If true start the timer, else stop it
-	///
-	void modifyTimerHelper(const bool& enable);
-
-
 private:
 	/**
 	 * Pushes the colors into the output queue and popping the head to the led-device

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -185,6 +185,7 @@ bool PriorityMuxer::setInput(const int priority, const std::vector<ColorRgb>& le
 	// update input
 	input.timeoutTime_ms = timeout_ms;
 	input.ledColors      = ledColors;
+	input.image.clear();
 
 	// emit active change
 	if(activeChange)
@@ -224,6 +225,7 @@ bool PriorityMuxer::setInputImage(const int priority, const Image<ColorRgb>& ima
 	// update input
 	input.timeoutTime_ms = timeout_ms;
 	input.image          = image;
+	input.ledColors.clear();
 
 	// emit active change
 	if(activeChange)


### PR DESCRIPTION
**1.** Tell us something about your changes.
- The image/ledColors data in the PriorityMuxer struct InputInfo is cleared on the setInput/setInputImage command
- send initial color/image when opening LED Visualization in WebUI
- hide the error message when opening webbrowser via systray

**2.** If this changes affect the .conf file. Please provide the changed section
no

**3.** Reference an issue (optional)
#604 #605 

