### PR TITLE
Add PWM channel option for ws281x device in web interface

### DIFF
--- a/assets/webconfig/i18n/cs.json
+++ b/assets/webconfig/i18n/cs.json
@@ -633,6 +633,7 @@
     "wiz_hue_ident": "Identifikovat",
     "edt_dev_spec_ledType_title": "Typ LED",
     "edt_dev_spec_dmaNumber_title": "Kanál DMA",
+    "edt_dev_spec_pwmChannel_title": "Kanál PWM",
     "effectsconfigurator_editdeleff": "Smazat / načíst efekt",
     "effectsconfigurator_button_editeffect": "Efekt načíst",
     "edt_conf_v4l2_sDVOffsetMin_title": "Detekce signálu VMin",

--- a/assets/webconfig/i18n/de.json
+++ b/assets/webconfig/i18n/de.json
@@ -429,6 +429,7 @@
 	"edt_dev_spec_maximumLedCount_title": "Maximale Anzahl LEDs",
 	"edt_dev_spec_gpioNumber_title": "GPIO Nummer",
 	"edt_dev_spec_dmaNumber_title": "DMA Kanal",
+	"edt_dev_spec_pwmChannel_title": "PWM Kanal",
 	"edt_dev_spec_gpioMap_title": "GPIO Zuweisung",
 	"edt_dev_spec_PBFiFo_title": "Pi-Blaster FiFo",
 	"edt_dev_spec_gpioBcm_title": "GPIO Pin",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -428,6 +428,7 @@
 	"edt_dev_spec_maximumLedCount_title" : "Maximum LED count",
 	"edt_dev_spec_gpioNumber_title" : "GPIO number",
 	"edt_dev_spec_dmaNumber_title" : "DMA channel",
+	"edt_dev_spec_pwmChannel_title": "PWM channel",
 	"edt_dev_spec_gpioMap_title" : "GPIO mapping",
 	"edt_dev_spec_PBFiFo_title" : "Pi-Blaster FiFo",
 	"edt_dev_spec_gpioBcm_title" : "GPIO Pin",

--- a/assets/webconfig/i18n/es.json
+++ b/assets/webconfig/i18n/es.json
@@ -633,6 +633,7 @@
     "wiz_hue_ident": "Identificar",
     "edt_dev_spec_ledType_title": "Tipo de LED",
     "edt_dev_spec_dmaNumber_title": "Canal DMA",
+    "edt_dev_spec_pwmChannel_title": "Canal PWM",
     "effectsconfigurator_editdeleff": "Eliminar/Cargar Efecto",
     "effectsconfigurator_button_editeffect": "Cargar Efecto",
     "edt_conf_v4l2_sDVOffsetMin_title": "Detección de señal VMin",

--- a/assets/webconfig/i18n/it.json
+++ b/assets/webconfig/i18n/it.json
@@ -633,6 +633,7 @@
     "wiz_hue_ident": "Identifica",
     "edt_dev_spec_ledType_title": "Tipo LED",
     "edt_dev_spec_dmaNumber_title": "Canale DMA",
+    "edt_dev_spec_pwmChannel_title": "Canale PWM",
     "effectsconfigurator_editdeleff": "Cancella/Carica Effetto",
     "effectsconfigurator_button_editeffect": "Carica Effetto",
     "edt_conf_v4l2_sDVOffsetMin_title": "Min Vert. Riconoscimento Segnale",

--- a/libsrc/leddevice/schemas/schema-ws281x.json
+++ b/libsrc/leddevice/schemas/schema-ws281x.json
@@ -20,17 +20,25 @@
 			"default": 5,
 			"propertyOrder" : 3
 		},
+		"pwmchannel": {
+			"type": "integer",
+			"title":"edt_dev_spec_pwmChannel_title",
+			"default": 0,
+			"minimum": 0,
+			"maximum": 1,
+			"propertyOrder" : 4
+		},
 		"invert": {
 			"type": "boolean",
 			"title":"edt_dev_spec_invert_title",
 			"default": false,
-			"propertyOrder" : 4
+			"propertyOrder" : 5
 		},
 		"rgbw": {
 			"type": "boolean",
 			"title":"edt_dev_spec_useRgbwProtocol_title",
 			"default": false,
-			"propertyOrder" : 5
+			"propertyOrder" : 6
 		},
 		"whiteAlgorithm": {
 			"type": "string",
@@ -40,7 +48,7 @@
 			"options" : {
 				"enum_titles" : ["edt_dev_enum_subtract_minimum", "edt_dev_enum_sub_min_cool_adjust","edt_dev_enum_sub_min_warm_adjust", "edt_dev_enum_white_off"]
 			},
-			"propertyOrder" : 6
+			"propertyOrder" : 7
 		},
 		"latchTime": {
 			"type": "integer",
@@ -50,7 +58,7 @@
 			"minimum": 1,
 			"maximum": 1000,
 			"access" : "expert",
-			"propertyOrder" : 7
+			"propertyOrder" : 8
 		}
 	},
 	"additionalProperties": true


### PR DESCRIPTION
The ws281x device has a PWM channel [option](https://github.com/hyperion-project/hyperion.ng/blob/master/libsrc/leddevice/dev_rpi_pwm/LedDeviceWS281x.cpp#L33) which was missing from the web interface.