### PR TITLE
Embed QSQLITE driver at Amlogic platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,13 @@ IF ( "${Qt5Core_VERSION}" VERSION_LESS "${QT_MIN_VERSION}" )
 	message( FATAL_ERROR "Your Qt version is to old! Minimum required ${QT_MIN_VERSION}" )
 ENDIF()
 
+if (ENABLE_AMLOGIC)
+	foreach(plugin ${Qt5Sql_PLUGINS} Qt5::Sql)
+		get_target_property(_loc ${plugin} LOCATION)
+		set(plugin_libs ${plugin_libs} ${_loc})
+	endforeach()
+endif()
+
 # Add libusb and pthreads
 find_package(libusb-1.0 REQUIRED)
 find_package(Threads REQUIRED)

--- a/libsrc/db/CMakeLists.txt
+++ b/libsrc/db/CMakeLists.txt
@@ -16,3 +16,9 @@ target_link_libraries(database
 	Qt5::Core
 	Qt5::Sql
 )
+
+if (ENABLE_AMLOGIC)
+	target_link_libraries(database
+		${plugin_libs}
+	)
+endif()

--- a/libsrc/db/DBManager.cpp
+++ b/libsrc/db/DBManager.cpp
@@ -1,3 +1,6 @@
+// Hyperion includes
+#include <HyperionConfig.h>
+
 #include <db/DBManager.h>
 
 #include <QSqlDatabase>
@@ -7,6 +10,11 @@
 #include <QThreadStorage>
 #include <QUuid>
 #include <QDir>
+
+#ifdef ENABLE_AMLOGIC
+#include <QtPlugin>
+Q_IMPORT_PLUGIN(QSQLiteDriverPlugin)
+#endif
 
 // not in header because of linking
 static QString _rootPath;

--- a/src/hyperion-aml/CMakeLists.txt
+++ b/src/hyperion-aml/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${PROJECT_NAME}
 
 if (ENABLE_AMLOGIC)
 	target_link_libraries(${PROJECT_NAME}
-		pcre16 dl z
+		pcre16 dl z ${plugin_libs}
 	)
 endif()
 

--- a/src/hyperion-framebuffer/CMakeLists.txt
+++ b/src/hyperion-framebuffer/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries( ${PROJECT_NAME}
 
 if (ENABLE_AMLOGIC)
 	target_link_libraries( ${PROJECT_NAME}
-		pcre16 dl z
+		pcre16 dl z ${plugin_libs}
 	)
 endif()
 

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(${PROJECT_NAME}
 
 if (ENABLE_AMLOGIC)
 	target_link_libraries(${PROJECT_NAME}
-		pcre16 dl z
+		pcre16 dl z ${plugin_libs}
 	)
 endif()
 

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(hyperiond
 if (ENABLE_AMLOGIC)
 	target_link_libraries(hyperiond
 		Qt5::Core
-		pcre16 dl z
+		pcre16 dl z ${plugin_libs}
 	)
 endif()
 


### PR DESCRIPTION
**1.** Tell us something about your changes.
Embed QSQLITE driver on Amlogic platform into hyperiond binary by `Q_IMPORT_PLUGIN`

**2.** If this changes affect the .conf file. Please provide the changed section
none

**3.** Reference an issue (optional)
QSQLITE is not part of the system.
I am not sure if this would be needed on other platforms too.

Note: For further discussions use our forum: forum.hyperion-project.org

