### PR TITLE
Add RS232 timeout for asynchronous connection

### DIFF
--- a/libsrc/leddevice/dev_serial/ProviderRs232.h
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.h
@@ -45,6 +45,7 @@ private slots:
 	int rewriteLeds();
 
 	/// Unblock the device after a connection delay
+	void writeTimeout();
 	void unblockAfterDelay();
 	void error(QSerialPort::SerialPortError error);
 	void bytesWritten(qint64 bytes);
@@ -84,12 +85,14 @@ protected:
 	/// The RS232 serial-device
 	QSerialPort _rs232Port;
 
+	/// A timeout timer for the asynchronous connection
+	QTimer _writeTimeout;
+
 	bool _blockedForDelay;
 	
 	bool _stateChanged;
 
 	qint64 _bytesToWrite;
-	qint64 _bytesWritten;
 	qint64 _frameDropCounter;
 	QSerialPort::SerialPortError _lastError;
 	qint64                       _preOpenDelayTimeOut;


### PR DESCRIPTION
**1.** Tell us something about your changes.
Add a timeout on asynchronous write. Sometimes it happen that the `.write` is successful but no bytes are written at all. This will be  catched by the timeout timer like the QSerialPort example is showing.

Also the handling of written bytes in function `bytesWritten` got modified as only one single transfer can be handled in one shot on the asynchronous connection.

**2.** If this changes affect the .conf file. Please provide the changed section
none

**3.** Reference an issue (optional)
See 1.

Note: For further discussions use our forum: forum.hyperion-project.org

