### PR TITLE
Fix a segfault in debug mode with lightpack

### DIFF
--- a/libsrc/leddevice/dev_hid/LedDeviceLightpack.cpp
+++ b/libsrc/leddevice/dev_hid/LedDeviceLightpack.cpp
@@ -231,7 +231,7 @@ int LedDeviceLightpack::testAndOpen(libusb_device * device, const QString & requ
 				_ledBuffer[0] = CMD_UPDATE_LEDS;
 
 				// return success
-				Debug(_log, "Lightpack device opened: bus=%d address=%d serial=%s version=%s.%s.", _busNumber, _addressNumber, QSTRING_CSTR(_serialNumber), _firmwareVersion.majorVersion, _firmwareVersion.minorVersion );
+				Debug(_log, "Lightpack device opened: bus=%d address=%d serial=%s version=%d.%d.", _busNumber, _addressNumber, QSTRING_CSTR(_serialNumber), _firmwareVersion.majorVersion, _firmwareVersion.minorVersion );
 				return 0;
 			}
 			catch(int e)


### PR DESCRIPTION
**1.** Tell us something about your changes.

This fixes a segmentation fault in debug mode with a Lightpack device.

Without this change:

```
# 
./bin/hyperiond  -d                                                                                                                                                                        
[hyperiond MAIN] <INFO> Set user data path to '/home/patrick/.hyperion'
...
[hyperiond LEDDEVICE] <DEBUG> <LedDeviceLightpack.cpp:97:open()> USB context initialized
[hyperiond LEDDEVICE] <INFO> Found a lightpack device. Retrieving more information...
[hyperiond LEDDEVICE] <DEBUG> <LedDeviceLightpack.cpp:168:testAndOpen()> Lightpack device found: bus=3 address=116 serial=9523030323**********
[hyperiond LEDDEVICE] <INFO> Lightpack device successfully opened
Segmentation fault (core dumped)
```

With this change:

```
./bin/hyperiond  -d
[hyperiond MAIN] <INFO> Set user data path to '/home/patrick/.hyperion'
...
[hyperiond LEDDEVICE] <INFO> Found a lightpack device. Retrieving more information...
[hyperiond LEDDEVICE] <DEBUG> <LedDeviceLightpack.cpp:162:testAndOpen()> Lightpack device found: bus=3 address=116 serial=9523030323**********
[hyperiond LEDDEVICE] <INFO> Lightpack device successfully opened
[hyperiond LEDDEVICE] <DEBUG> <LedDeviceLightpack.cpp:228:testAndOpen()> Lightpack device opened: bus=3 address=116 serial=9523030323********** version=6.5.
...
```


**2.** If this changes affect the .conf file. Please provide the changed section

N/A

**3.** Reference an issue (optional)

N/A

Note: For further discussions use our forum: forum.hyperion-project.org

