### PR TITLE
Fix Nanoleaf - Udp Network init was missing

### DIFF
--- a/libsrc/leddevice/LedDevice.cpp
+++ b/libsrc/leddevice/LedDevice.cpp
@@ -166,7 +166,7 @@ int LedDevice::updateLeds(const std::vector<ColorRgb>& ledValues)
 	int retval = 0;
 	if ( !_deviceReady || _deviceInError)
 	{
-		std::cout << "LedDevice::updateLeds(), LedDevice NOT ready!" <<  std::endl;
+		//std::cout << "LedDevice::updateLeds(), LedDevice NOT ready!" <<  std::endl;
 		return -1;
 	}
 	else

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
@@ -258,7 +258,7 @@ int LedDeviceNanoleaf::open()
 	{
 		if ( !initNetwork() )
 		{
-			this->setInError( "Network error!" );
+			this->setInError( "UDP Network error!" );
 		}
 		else
 		{

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
@@ -256,11 +256,18 @@ int LedDeviceNanoleaf::open()
 
 	if ( init(_devConfig) )
 	{
-		if ( initLeds() )
+		if ( !initNetwork() )
 		{
-			_deviceReady = true;
-			setEnable(true);
-			retval = 0;
+			this->setInError( "Network error!" );
+		}
+		else
+		{
+			if ( initLeds() )
+			{
+				_deviceReady = true;
+				setEnable(true);
+				retval = 0;
+			}
 		}
 	}
 	return retval;

--- a/libsrc/leddevice/dev_net/ProviderUdp.cpp
+++ b/libsrc/leddevice/dev_net/ProviderUdp.cpp
@@ -76,10 +76,21 @@ bool ProviderUdp::init(const QJsonObject &deviceConfig)
 
 bool ProviderUdp::initNetwork()
 {
-	bool isInitOK = true;
+	bool isInitOK = false;
 
-	// TODO: Add Network-Error handling
-	_udpSocket = new QUdpSocket(this);
+	_udpSocket =new QUdpSocket(this);
+
+	if ( _udpSocket != nullptr)
+	{
+		QHostAddress localAddress = QHostAddress::Any;
+		quint16      localPort = 0;
+		if ( !_udpSocket->bind(localAddress, localPort) )
+		{
+			Warning ( _log, "Could not bind local address: %s", strerror(errno));
+		}
+		isInitOK = true;
+	}
+
 	return isInitOK;
 }
 
@@ -93,17 +104,10 @@ int ProviderUdp::open()
 	{
 		if ( ! initNetwork())
 		{
-			this->setInError( "Network error!" );
+			this->setInError( "UDP Network error!" );
 		}
 		else
 		{
-			QHostAddress localAddress = QHostAddress::Any;
-			quint16      localPort = 0;
-
-			if ( !_udpSocket->bind(localAddress, localPort) )
-			{
-				Warning ( _log, "Could not bind local address: %s", strerror(errno));
-			}
 			// Everything is OK -> enable device
 			_deviceReady = true;
 			setEnable(true);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix Nanoleaf - UDP Network initialisation was missing
LedDevice - Suppress debug output, if device is not ready

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fix addresses issue reported in forum:
https://hyperion-project.org/threads/segmentation-fault-hyperion-ng-auf-raspbian-pi3.10432/