### PR TITLE
MacOS packages (currently without dependencies)

### DIFF
--- a/.ci/ci_build.sh
+++ b/.ci/ci_build.sh
@@ -30,7 +30,7 @@ if [[ "$CI_NAME" == 'osx' || "$CI_NAME" == 'darwin' ]]; then
 	mkdir build || exit 1
 	cd build
 	cmake -DPLATFORM=${PLATFORM} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../ || exit 2
-	make -j $(sysctl -n hw.ncpu) || exit 3 # Notes: The package creation is currently not supported because of strange errors.
+	make -j $(sysctl -n hw.ncpu) package || exit 3
 	cd ${CI_BUILD_DIR} && source /${CI_BUILD_DIR}/test/testrunner.sh || exit 4
 	exit 0;
 	exit 1 || { echo "---> Hyperion compilation failed! Abort"; exit 5; }

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -256,5 +256,7 @@ if(CMAKE_HOST_UNIX)
 	install(CODE "FILE (REMOVE ${CMAKE_BINARY_DIR}/symlink_hyperiond )" COMPONENT "${PLATFORM}" )
 endif(CMAKE_HOST_UNIX)
 
-# Copy dependencies
-InstallDependencies("hyperiond" ${PLATFORM})
+# Copy dependencies (not for OSX)
+if (NOT ENABLE_OSX)
+	InstallDependencies("hyperiond" ${PLATFORM})
+endif ()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
_MacOS packages are again created without packed dependencies
As stated in_ [README.md](https://github.com/Paulchen-Panther/hyperion.ng/tree/mac_os#requirements), we do not support MacOS builds.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

_Reactivation of MacOS package creation_

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
