### PR TITLE
Fixes for multiple memory leaks and segfault issues in Flatbuffer Forwarder

### DIFF
--- a/libsrc/flatbufserver/FlatBufferClient.cpp
+++ b/libsrc/flatbufserver/FlatBufferClient.cpp
@@ -44,7 +44,7 @@ void FlatBufferClient::readyRead()
 		if((uint32_t) _receiveBuffer.size() < messageSize + 4) return;
 
 		// extract message only and remove header + msg from buffer :: QByteArray::remove() does not return the removed data
-		const QByteArray msg = _receiveBuffer.right(messageSize);
+		const QByteArray msg = _receiveBuffer.mid(4, messageSize);
 		_receiveBuffer.remove(0, messageSize + 4);
 
 		const auto* msgData = reinterpret_cast<const uint8_t*>(msg.constData());
@@ -113,6 +113,8 @@ void FlatBufferClient::registationRequired(const int priority)
 
 		// send reply
 		sendMessage();
+
+		_builder.Clear();
 	}
 }
 
@@ -133,6 +135,8 @@ void FlatBufferClient::handleRegisterCommand(const hyperionnet::Register *regReq
 
 	// send reply
 	sendMessage();
+
+	_builder.Clear();
 }
 
 void FlatBufferClient::handleImageCommand(const hyperionnet::Image *image)
@@ -192,7 +196,6 @@ void FlatBufferClient::sendMessage()
 	_socket->write((const char *) sizeData, sizeof(sizeData));
 	_socket->write((const char *)buffer, size);
 	_socket->flush();
-	_builder.Clear();
 }
 
 void FlatBufferClient::sendSuccessReply()
@@ -202,6 +205,8 @@ void FlatBufferClient::sendSuccessReply()
 
 	// send reply
 	sendMessage();
+
+	_builder.Clear();
 }
 
 void FlatBufferClient::sendErrorReply(const std::string &error)
@@ -212,4 +217,6 @@ void FlatBufferClient::sendErrorReply(const std::string &error)
 
 	// send reply
 	sendMessage();
+
+	_builder.Clear();
 }

--- a/libsrc/flatbufserver/FlatBufferConnection.cpp
+++ b/libsrc/flatbufserver/FlatBufferConnection.cpp
@@ -66,7 +66,7 @@ void FlatBufferConnection::readData()
 		if((uint32_t) _receiveBuffer.size() < messageSize + 4) return;
 
 		// extract message only and remove header + msg from buffer :: QByteArray::remove() does not return the removed data
-		const QByteArray msg = _receiveBuffer.right(messageSize);
+		const QByteArray msg = _receiveBuffer.mid(4, messageSize);
 		_receiveBuffer.remove(0, messageSize + 4);
 
 		const uint8_t* msgData = reinterpret_cast<const uint8_t*>(msg.constData());
@@ -117,6 +117,7 @@ void FlatBufferConnection::setColor(const ColorRgb & color, int priority, int du
 
 	_builder.Finish(req);
 	sendMessage(_builder.GetBufferPointer(), _builder.GetSize());
+	_builder.Clear();
 }
 
 void FlatBufferConnection::setImage(const Image<ColorRgb> &image)
@@ -128,6 +129,7 @@ void FlatBufferConnection::setImage(const Image<ColorRgb> &image)
 
 	_builder.Finish(req);
 	sendMessage(_builder.GetBufferPointer(), _builder.GetSize());
+	_builder.Clear();
 }
 
 void FlatBufferConnection::clear(int priority)
@@ -137,6 +139,7 @@ void FlatBufferConnection::clear(int priority)
 
 	_builder.Finish(req);
 	sendMessage(_builder.GetBufferPointer(), _builder.GetSize());
+	_builder.Clear();
 }
 
 void FlatBufferConnection::clearAll()
@@ -193,7 +196,6 @@ void FlatBufferConnection::sendMessage(const uint8_t* buffer, uint32_t size)
 	count += _socket.write(reinterpret_cast<const char *>(header), 4);
 	count += _socket.write(reinterpret_cast<const char *>(buffer), size);
 	_socket.flush();
-	_builder.Clear();
 }
 
 bool FlatBufferConnection::parseReply(const hyperionnet::Reply *reply)

--- a/libsrc/hyperion/MessageForwarder.cpp
+++ b/libsrc/hyperion/MessageForwarder.cpp
@@ -118,9 +118,9 @@ void MessageForwarder::handlePriorityChanges(const quint8 &priority)
 		hyperion::Components activeCompId = _hyperion->getPriorityInfo(priority).componentId;
 		if (activeCompId == hyperion::COMP_GRABBER || activeCompId == hyperion::COMP_V4L)
 		{
-			if ( !obj["proto"].isNull() )
+			if ( !obj["flat"].isNull() )
 			{
-				const QJsonArray & addr = obj["proto"].toArray();
+				const QJsonArray & addr = obj["flat"].toArray();
 				for (const auto& entry : addr)
 				{
 					addFlatbufferSlave(entry.toString());
@@ -202,7 +202,7 @@ void MessageForwarder::addFlatbufferSlave(QString slave)
 		return;
 	}
 
-	// verify loop with protoserver
+	// verify loop with flatbufserver
 	const QJsonObject &obj = _hyperion->getSetting(settings::FLATBUFSERVER).object();
 	if(QHostAddress(parts[0]) == QHostAddress::LocalHost && parts[1].toInt() == obj["port"].toInt())
 	{


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Flatbuffer forwarder was not working correctly, and crashing Hyperion.

The issue turned out to be caused by incorrectly assuming that the socket buffer would only contain one header and one flatbuffer message, resulting in a race condition which could cause the flatbuffer library to fail to verify the corrupted buffer it was passed. 

Upon failing to verify the buffer, the client attempts to sendErrorReply, which due to the same issue on the server causes Hyperion to crash with "Unable to parse reply".

Additionally, after fixing this issue, I discovered there was a memory leak caused by sendMessage on the server only conditionally clearing the flatbuffer builder. If a client was not connected, this caused the builder to grow without bound until it causes a segfault/badalloc. I fixed this by clearing the builder outside of sendMessage wherever it is used, and edited the client class to be consistent.

I believe this PR fixes #652 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
