### PR TITLE
New attempt to find PR artifate faster

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,22 +6,48 @@ on:
 
 jobs:
 
-###########################################
-###### GitHub Actions bot comment #########
-###########################################
+################################################################
+###### Hyperion-Bot comment on open or synchronized PR #########
+################################################################
 
   comment_pr:
     runs-on: ubuntu-latest
-    name: GitHub Actions bot comment
+    name: Create PR comment
     steps:
       - name: Checkout
+        if: success() && github.repository == 'hyperion-project/hyperion.ng' && (github.event.action == 'opened' || github.event.action == 'synchronize')
         uses: actions/checkout@v1
 
-      - name: Comment on PR
-        uses: thollander/actions-comment-pull-request@master
+      - name: Opened
+        if: success() && github.repository == 'hyperion-project/hyperion.ng' && github.event.action == 'opened'
+        uses: peter-evans/create-or-update-comment@v1.0.0
         with:
-          message: "PR Artifacts on: [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HYPERION_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Hello ${{ github.event.pull_request.user.login }} :wave:
+
+            I'm your friendly neighborhood bot and would like to say thank you for
+            submitting a pull request to Hyperion!
+
+            To help you and other users test your changes faster,
+            see [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for finished workflow artifacts.
+
+            If you make changes to your PR, i create a new link to your finished
+            workflow artifacts for each commit.
+
+            Best regards,
+            Hyperion-Bot
+
+      - name: Synchronized
+        if: success() && github.repository == 'hyperion-project/hyperion.ng' && github.event.action == 'synchronize'
+        uses: peter-evans/create-or-update-comment@v1.0.0
+        with:
+          token: ${{ secrets.HYPERION_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            I have a new link to your workflow artifacts for your:
+            [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
 ######################
 ###### Linux #########


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This is my second attempt to persuade our bot to leave a message to the PR writer that there are finished workflow artifacts on GitHub Action. Let's see what happens.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
