### PR TITLE
Removed PR comment job from Github Actions 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,23 +6,6 @@ on:
 
 jobs:
 
-###########################################
-###### GitHub Actions bot comment #########
-###########################################
-
-  comment_pr:
-    runs-on: ubuntu-latest
-    name: GitHub Actions bot comment
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Comment on PR
-        uses: thollander/actions-comment-pull-request@master
-        with:
-          message: "PR Artifacts on: [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 ######################
 ###### Linux #########
 ######################


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Now our GitHub app should ensure that the link to GitHub Actions is integrated into PR.
Unfortunately I have not yet figured out how to extract the "run_id" from the current GitHub Actions workflow under Probot in order to provide a direct link to the artifacts. Should anyone know more about this. Please report.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:



If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
