### PR TITLE
fix(ssdp): ssdp:all provide better feedback

### DIFF
--- a/libsrc/ssdp/SSDPHandler.cpp
+++ b/libsrc/ssdp/SSDPHandler.cpp
@@ -9,6 +9,8 @@
 #include <QNetworkInterface>
 #include <QNetworkConfigurationManager>
 
+static const QString SSDP_HYPERION_ST("urn:hyperion-project.org:device:basic:1");
+
 SSDPHandler::SSDPHandler(WebServer* webserver, const quint16& flatBufPort, const quint16& jsonServerPort, const QString& name, QObject * parent)
 	: SSDPServer(parent)
 	, _webserver(webserver)
@@ -33,7 +35,7 @@ void SSDPHandler::initServer()
 	// announce targets
 	_deviceList.push_back("upnp:rootdevice");
 	_deviceList.push_back("uuid:"+_uuid);
-	_deviceList.push_back("urn:hyperion-project.org:device:basic:1");
+	_deviceList.push_back(SSDP_HYPERION_ST);
 
 	// prep server
 	SSDPServer::initServer();
@@ -145,7 +147,9 @@ void SSDPHandler::handleMSearchRequest(const QString& target, const QString& mx,
 	// TODO Response delay according to MX field (sec) random between 0 and MX
 
 	// when searched for all devices / root devices / basic device
-	if(target == "ssdp:all" || target == "upnp:rootdevice" || target == "urn:schemas-upnp-org:device:basic:1" || target == "urn:hyperion-project.org:device:basic:1")
+	if(target == "ssdp:all")
+		sendMSearchResponse(SSDP_HYPERION_ST, address, port);
+	else if(target == "upnp:rootdevice" || target == "urn:schemas-upnp-org:device:basic:1" || target == SSDP_HYPERION_ST)
 		sendMSearchResponse(target, address, port);
 }
 

--- a/libsrc/webserver/WebServer.cpp
+++ b/libsrc/webserver/WebServer.cpp
@@ -29,6 +29,7 @@ WebServer::~WebServer()
 
 void WebServer::initServer()
 {
+	Debug(_log, "Initialize Webserver");
 	_server = new QtHttpServer (this);
 	_server->setServerName (QStringLiteral ("Hyperion Webserver"));
 
@@ -85,6 +86,7 @@ void WebServer::handleSettingsUpdate(const settings::type& type, const QJsonDocu
 {
 	if(type == settings::WEBSERVER)
 	{
+		Debug(_log, "Apply Webserver settings");
 		const QJsonObject& obj = config.object();
 
 		_baseUrl = obj["document_root"].toString(WEBSERVER_DEFAULT_PATH);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

SSDP Server should at least answer on `ssdp:all` with `urn:hyperion-project.org:device:basic:1` instead of `ssdp:all`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
