### PR TITLE
Fix Memoryleaks & Coredump, if no Grabber compiled

### DIFF
--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -86,8 +86,8 @@ void ImageProcessor::setLedString(const LedString& ledString)
 		_ledString = ledString;
 
 		// get current width/height
-		const unsigned width = _imageToLeds->width();
-		const unsigned height = _imageToLeds->height();
+		unsigned width = _imageToLeds->width();
+		unsigned height = _imageToLeds->height();
 
 		// Clean up the old buffer and mapping
 		delete _imageToLeds;

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -69,8 +69,11 @@ void ImageProcessor::setSize(const unsigned width, const unsigned height)
 		return;
 	}
 
-	// Clean up the old buffer and mapping
-	_imageToLeds = 0;
+	if ( _imageToLeds != nullptr)
+	{
+		// Clean up the old buffer and mapping
+		delete _imageToLeds;
+	}
 
 	// Construct a new buffer and mapping
 	_imageToLeds = (width>0 && height>0) ? (new ImageToLedsMap(width, height, 0, 0, _ledString.leds())) : nullptr;
@@ -78,17 +81,20 @@ void ImageProcessor::setSize(const unsigned width, const unsigned height)
 
 void ImageProcessor::setLedString(const LedString& ledString)
 {
-	_ledString = ledString;
+	if ( _imageToLeds != nullptr)
+	{
+		_ledString = ledString;
 
-	// get current width/height
-	const unsigned width = _imageToLeds->width();
-	const unsigned height = _imageToLeds->height();
+		// get current width/height
+		const unsigned width = _imageToLeds->width();
+		const unsigned height = _imageToLeds->height();
 
-	// Clean up the old buffer and mapping
-	_imageToLeds = 0;
+		// Clean up the old buffer and mapping
+		delete _imageToLeds;
 
-	// Construct a new buffer and mapping
-	_imageToLeds = new ImageToLedsMap(width, height, 0, 0, _ledString.leds());
+		// Construct a new buffer and mapping
+		_imageToLeds = new ImageToLedsMap(width, height, 0, 0, _ledString.leds());
+	}
 }
 
 void ImageProcessor::setBlackbarDetectDisable(bool enable)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- Fix Coredump, in case (X11) Grabber was excluded from compile.
A Led-settings update triggers setLedString where _imageToLeds has not been initialised yet.
Call _imageToLeds->width(); results in a coredump.
- Fix Memory Leaks,as object _imageToLeds is not properly deleted

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
