### PR TITLE
DBManager: ORDER BY parameter added to getRecord(s)

### DIFF
--- a/include/db/DBManager.h
+++ b/include/db/DBManager.h
@@ -83,18 +83,20 @@ public:
 	/// @param[in]  conditions  condition to search for (WHERE)
 	/// @param[out] results     results of query
 	/// @param[in]  tColumns    target columns to search in (optional) if not provided returns all columns
+	/// @param[in]  tOrder      target order columns with order by ASC/DESC (optional)
 	/// @return                 True on success else false
 	///
-	bool getRecord(const VectorPair& conditions, QVariantMap& results, const QStringList& tColumns = QStringList()) const;
+	bool getRecord(const VectorPair& conditions, QVariantMap& results, const QStringList& tColumns = QStringList(), const QStringList& tOrder = QStringList()) const;
 
 	///
 	/// @brief Get data of multiple records, you need to specify the columns. This search is without conditions. Good to grab all data from db
 	/// @param[in]  conditions  condition to search for (WHERE)
 	/// @param[out] results     results of query
-	/// @param[in]  tColumns    target columns to search in (optional)  if not provided returns all columns
+	/// @param[in]  tColumns    target columns to search in (optional) if not provided returns all columns
+	/// @param[in]  tOrder      target order columns with order by ASC/DESC (optional)
 	/// @return                 True on success else false
 	///
-	bool getRecords(QVector<QVariantMap>& results, const QStringList& tColumns = QStringList()) const;
+	bool getRecords(QVector<QVariantMap>& results, const QStringList& tColumns = QStringList(), const QStringList& tOrder = QStringList()) const;
 
 	///
 	/// @brief Delete a record determined by conditions

--- a/include/db/InstanceTable.h
+++ b/include/db/InstanceTable.h
@@ -122,7 +122,7 @@ public:
 	inline QVector<QVariantMap> getAllInstances(const bool& justEnabled = false)
 	{
 		QVector<QVariantMap> results;
-		getRecords(results);
+		getRecords(results, QStringList(), QStringList() << "instance ASC");
 		if(justEnabled)
 		{
 			for (auto it = results.begin(); it != results.end();)

--- a/libsrc/db/DBManager.cpp
+++ b/libsrc/db/DBManager.cpp
@@ -181,7 +181,7 @@ bool DBManager::updateRecord(const VectorPair& conditions, const QVariantMap& co
 	return true;
 }
 
-bool DBManager::getRecord(const VectorPair& conditions, QVariantMap& results, const QStringList& tColumns) const
+bool DBManager::getRecord(const VectorPair& conditions, QVariantMap& results, const QStringList& tColumns, const QStringList& tOrder) const
 {
 	QSqlDatabase idb = getDB();
 	QSqlQuery query(idb);
@@ -191,18 +191,24 @@ bool DBManager::getRecord(const VectorPair& conditions, QVariantMap& results, co
 	if(!tColumns.isEmpty())
 		sColumns = tColumns.join(", ");
 
+	QString sOrder("");
+	if(!tOrder.isEmpty())
+	{
+		sOrder = " ORDER BY ";
+		sOrder.append(tOrder.join(", "));
+	}
 	// prep conditions
 	QStringList prepCond;
 	QVariantList bindVal;
 	if(!conditions.isEmpty())
-		prepCond << "WHERE";
+		prepCond << " WHERE";
 
 	for(const auto& pair : conditions)
 	{
 		prepCond << pair.first+"=?";
 		bindVal << pair.second;
 	}
-	query.prepare(QString("SELECT %1 FROM %2 %3").arg(sColumns,_table).arg(prepCond.join(" ")));
+	query.prepare(QString("SELECT %1 FROM %2%3%4").arg(sColumns,_table).arg(prepCond.join(" ")).arg(sOrder));
 	doAddBindValue(query, bindVal);
 
 	if(!query.exec())
@@ -223,7 +229,7 @@ bool DBManager::getRecord(const VectorPair& conditions, QVariantMap& results, co
 	return true;
 }
 
-bool DBManager::getRecords(QVector<QVariantMap>& results, const QStringList& tColumns) const
+bool DBManager::getRecords(QVector<QVariantMap>& results, const QStringList& tColumns, const QStringList& tOrder) const
 {
 	QSqlDatabase idb = getDB();
 	QSqlQuery query(idb);
@@ -233,7 +239,14 @@ bool DBManager::getRecords(QVector<QVariantMap>& results, const QStringList& tCo
 	if(!tColumns.isEmpty())
 		sColumns = tColumns.join(", ");
 
-	query.prepare(QString("SELECT %1 FROM %2").arg(sColumns,_table));
+	QString sOrder("");
+	if(!tOrder.isEmpty())
+	{
+		sOrder = " ORDER BY ";
+		sOrder.append(tOrder.join(", "));
+	}
+
+	query.prepare(QString("SELECT %1 FROM %2%3").arg(sColumns,_table,sOrder));
 
 	if(!query.exec())
 	{


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->


**Summary**

DBManager: ORDER BY parameter added to getRecord/getRecords.
All instances are now sorted in ascending order using the instance field / ID.
The web interface gets an incorrect instance order, which causes further problems.

**Steps to reproduce:**
- create more than 1 instance, in my case, the new instance has become ID "1"
- create 1 or 2 more instances (with different names) and you will have 3-4 instances with IDs : 0,1,2,3
- delete instance with ID "1" and the remaining IDs are: 0,2,3
- create a new instance again (in my case, i used the same name from previouse deleted instance  again) and the IDs are now saved in DB order: 0,2,3,1
- start and switch to your last instance (with ID "1", sorted and displayed as 4. instance).
- If everything went to reproduce, the wrong instance name should be displayed ...

**Why this is a Problem now?**
The Web-Interface receive all instances in created order from DB, but uses the array indexes as instance IDs: 0 = 0, 1 = 2, 2 = 3, 3 = 1  ( content_index.js [L#227/228](https://github.com/hyperion-project/hyperion.ng/blob/77ee96ab4c5984e4ab5722c026cf38b0fc8b8b03/assets/webconfig/js/content_index.js#L228). )
So every switch to another instance has the wrong instance settings...
and i'm not sure, but changed settings may where also saved for the wrong instance-ID!?

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
