### PR TITLE
OSX add x11 new include path

### DIFF
--- a/libsrc/grabber/x11/CMakeLists.txt
+++ b/libsrc/grabber/x11/CMakeLists.txt
@@ -7,6 +7,10 @@ find_package(X11 REQUIRED)
 
 include_directories( ${X11_INCLUDES} )
 
+if(APPLE)
+	include_directories("/opt/X11/include")
+endif(APPLE)
+
 FILE ( GLOB X11_SOURCES "${CURRENT_HEADER_DIR}/X11*.h"  "${CURRENT_SOURCE_DIR}/*.h"  "${CURRENT_SOURCE_DIR}/*.cpp" )
 
 add_library(x11-grabber ${X11_SOURCES} )

--- a/src/hyperion-x11/CMakeLists.txt
+++ b/src/hyperion-x11/CMakeLists.txt
@@ -10,6 +10,10 @@ include_directories(
 	${FLATBUFFERS_INCLUDE_DIRS}
 )
 
+if(APPLE)
+	include_directories("/opt/X11/include")
+endif(APPLE)
+
 set(Hyperion_X11_HEADERS
 	X11Wrapper.h
 )

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -77,6 +77,9 @@ if (ENABLE_AMLOGIC)
 endif ()
 
 if (ENABLE_X11)
+	if(APPLE)
+		include_directories("/opt/X11/include")
+	endif(APPLE)
 	target_link_libraries(hyperiond	x11-grabber)
 endif ()
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Maybe not necessary, but I had problems compiling hyperion.ng on macOS Catalina and got various `fatal error: 'X11/Xlib.h' file not found` x11-grabber errors, even after installing XQuartz, because X11 is no longer part of macOS. I'm not sure if other include paths like "/usr/X11/lib" are also needed, but these PR changes have helped fix the bugs.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
