### PR TITLE
Reset/V4L2/Systemd/rpi_ws281x/Profiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "dependencies/external/rpi_ws281x"]
-	path = dependencies/external/rpi_ws281x
-	url = https://github.com/hyperion-project/rpi_ws281x.git
-	branch = master
 [submodule "dependencies/external/flatbuffers"]
 	path = dependencies/external/flatbuffers
 	url = https://github.com/google/flatbuffers

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "dependencies/external/rpi_ws281x"]
+	path = dependencies/external/rpi_ws281x
+	url = https://github.com/jgarff/rpi_ws281x
+	branch = master
 [submodule "dependencies/external/flatbuffers"]
 	path = dependencies/external/flatbuffers
 	url = https://github.com/google/flatbuffers

--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -19,7 +19,7 @@ install_file()
 echo "---Hyperion ambient light postinstall ---"
 
 #check system
-CPU_RPI=`grep -m1 -c 'BCM2708\|BCM2709\|BCM2710\|BCM2835' /proc/cpuinfo`
+CPU_RPI=`grep -m1 -c 'BCM2708\|BCM2709\|BCM2710\|BCM2835\|BCM2836\|BCM2837\|BCM2711' /proc/cpuinfo`
 CPU_X32X64=`uname -m | grep 'x86_32\|i686\|x86_64' | wc -l`
 
 #Check for a bootloader as Berryboot
@@ -42,6 +42,8 @@ fi
 
 start_msg=""
 restart_msg=""
+
+echo "DEBUG --> FOUND_USR: ${FOUND_USR}"
 
 if grep -m1 systemd /proc/1/comm > /dev/null
 then

--- a/cmake/debian/postinst
+++ b/cmake/debian/postinst
@@ -43,8 +43,6 @@ fi
 start_msg=""
 restart_msg=""
 
-echo "DEBUG --> FOUND_USR: ${FOUND_USR}"
-
 if grep -m1 systemd /proc/1/comm > /dev/null
 then
 	echo "---> init deamon: systemd"

--- a/include/utils/Profiler.h
+++ b/include/utils/Profiler.h
@@ -5,15 +5,30 @@
 #include <utils/Logger.h>
 #include <HyperionConfig.h>
 
+/*
+The performance (real time) of any function can be tested with the help of profiler.
+The determined times are determined using clock cycles.
+
+To do this, compile with the cmake option: -DENABLE_PROFILER=ON
+This header file (utils/Profiler.h) must be included in the respective file that contains the function to be measured
+
+The start time is set in a function with the following instructions:
+PROFILER_TIMER_START("test_performance")
+The end point is set as follows:
+PROFILER_TIMER_GET("test_performance")
+
+For more profiler function see the macros listed below
+*/
+
 #ifndef ENABLE_PROFILER
 	#error "Profiler is not for productive code, enable it via cmake or remove header include"
 #endif
 
 // profiler
-#define PROFILER_BLOCK_EXECUTION_TIME Profiler DEBUG_PROFILE__BLOCK__EXECUTION__TIME_messure_object(__FILE__, _FUNCNAME_, __LINE__ );
-#define PROFILER_TIMER_START(stopWatchName)   Profiler::TimerStart(stopWatchName, __FILE__, _FUNCNAME_, __LINE__);
-#define PROFILER_TIMER_GET(stopWatchName)    Profiler::TimerGetTime(stopWatchName, __FILE__, _FUNCNAME_, __LINE__);
-#define PROFILER_TIMER_GET_IF(condition, stopWatchName) { if (condition) {Profiler::TimerGetTime(stopWatchName, __FILE__, _FUNCNAME_, __LINE__);} }
+#define PROFILER_BLOCK_EXECUTION_TIME Profiler DEBUG_PROFILE__BLOCK__EXECUTION__TIME_messure_object(__FILE__, __FUNCTION__, __LINE__ );
+#define PROFILER_TIMER_START(stopWatchName)   Profiler::TimerStart(stopWatchName, __FILE__, __FUNCTION__, __LINE__);
+#define PROFILER_TIMER_GET(stopWatchName)    Profiler::TimerGetTime(stopWatchName, __FILE__, __FUNCTION__, __LINE__);
+#define PROFILER_TIMER_GET_IF(condition, stopWatchName) { if (condition) {Profiler::TimerGetTime(stopWatchName, __FILE__, __FUNCTION__, __LINE__);} }
 
 
 class Profiler
@@ -27,7 +42,7 @@ public:
 
 private:
 	static void initLogger();
-	
+
 	static Logger*  _logger;
 	const char*     _file;
 	const char*     _func;
@@ -35,3 +50,4 @@ private:
 	unsigned int    _blockId;
 	clock_t         _startTime;
 };
+

--- a/libsrc/db/DBManager.cpp
+++ b/libsrc/db/DBManager.cpp
@@ -8,6 +8,10 @@
 #include <QUuid>
 #include <QDir>
 
+#ifdef _WIN32
+	#include <stdexcept>
+#endif
+
 // not in header because of linking
 static QString _rootPath;
 static QThreadStorage<QSqlDatabase> _databasePool;

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -195,7 +195,7 @@ void V4L2Grabber::getV4Ldevices()
 				continue;
 			}
 
-			if (cap.device_caps & V4L2_CAP_META_CAPTURE || !(cap.capabilities & V4L2_CAP_META_CAPTURE)) // this device has bit 23 set (and bit 1 reset), so it doesn't have capture.
+			if (cap.device_caps & V4L2_CAP_META_CAPTURE) // this device has bit 23 set (and bit 1 reset), so it doesn't have capture.
 			{
 				close(fd);
 				continue;
@@ -232,16 +232,8 @@ void V4L2Grabber::getV4Ldevices()
 					break;
 					case V4L2_FRMSIZE_TYPE_CONTINUOUS:
 					case V4L2_FRMSIZE_TYPE_STEPWISE:
-					{
-						for(unsigned int y = frmsizeenum.stepwise.min_height; y <= frmsizeenum.stepwise.max_height; y += frmsizeenum.stepwise.step_height)
-						{
-							for(unsigned int x = frmsizeenum.stepwise.min_width; x <= frmsizeenum.stepwise.max_width; x += frmsizeenum.stepwise.step_width)
-							{
-								properties.resolutions << QString::number(x) + "x" + QString::number(y);
-								enumFrameIntervals(properties.framerates, fd, fmt.fmt.pix.pixelformat, x, y);
-							}
-						}
-					}
+						// We do not take care of V4L2_FRMSIZE_TYPE_CONTINUOUS or V4L2_FRMSIZE_TYPE_STEPWISE
+						break;
 				}
 				frmsizeenum.index++;
 			}

--- a/libsrc/grabber/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/v4l2/V4L2Grabber.cpp
@@ -195,7 +195,7 @@ void V4L2Grabber::getV4Ldevices()
 				continue;
 			}
 
-			if (cap.device_caps & V4L2_CAP_META_CAPTURE) // this device has bit 23 set (and bit 1 reset), so it doesn't have capture.
+			if (cap.device_caps & V4L2_CAP_META_CAPTURE || !(cap.capabilities & V4L2_CAP_META_CAPTURE)) // this device has bit 23 set (and bit 1 reset), so it doesn't have capture.
 			{
 				close(fd);
 				continue;

--- a/libsrc/python/PythonInit.cpp
+++ b/libsrc/python/PythonInit.cpp
@@ -16,6 +16,7 @@
 #include <effectengine/EffectModule.h>
 
 #ifdef _WIN32
+	#include <stdexcept>
 	#define STRINGIFY2(x) #x
 	#define STRINGIFY(x) STRINGIFY2(x)
 #endif

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -192,6 +192,7 @@ int main(int argc, char** argv)
 	BooleanOption & versionOption       = parser.add<BooleanOption> (0x0, "version", "Show version information");
 	Option        & userDataOption      = parser.add<Option>        ('u', "userdata", "Overwrite user data path, defaults to home directory of current user (%1)", QDir::homePath() + "/.hyperion");
 	BooleanOption & resetPassword       = parser.add<BooleanOption> (0x0, "resetPassword", "Lost your password? Reset it with this option back to 'hyperion'");
+	BooleanOption & deleteDB            = parser.add<BooleanOption> (0x0, "deleteDatabase", "Start all over? This Option will delete the database");
 	BooleanOption & silentOption        = parser.add<BooleanOption> ('s', "silent", "do not print any outputs");
 	BooleanOption & verboseOption       = parser.add<BooleanOption> ('v', "verbose", "Increase verbosity");
 	BooleanOption & debugOption         = parser.add<BooleanOption> ('d', "debug", "Show debug messages");
@@ -297,6 +298,20 @@ int main(int argc, char** argv)
 				Error(log,"Failed to reset password!");
 				delete table;
 				exit(1);
+			}
+		}
+
+		// delete database before start
+		if(parser.isSet(deleteDB))
+		{
+			QString dbFile = mDir.absolutePath() + "/db/hyperion.db";
+			if (QFile::exists(dbFile))
+			{
+				if (!QFile::remove(dbFile))
+				{
+					Info(log,"Failed to delete Database!");
+					exit(1);
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- An option to reset (delete) the database for the commandline has been added
- Enumerate only V4L2 frame sizes & intervals for framesize type DISCRETE (fix BCM2835 ISP)
- Fix systemd registration in debian for RPi4
- Update dependency rpi_ws281x to latest upstream
- Fix missing define in Profiler & added header notes

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
