### PR TITLE
Suppress default password warning

### DIFF
--- a/assets/webconfig/i18n/de.json
+++ b/assets/webconfig/i18n/de.json
@@ -84,6 +84,7 @@
 	"dashboard_message_global_setting": "Die Einstellungen auf dieser Seite sind instanzunabhängig. Änderungen werden global übernommen.",
 	"dashboard_message_default_password_t": "WebUi Standardpasswort gesetzt",
 	"dashboard_message_default_password": "Das Standardpasswort der WebUi ist gesetzt. Wir empfehlen dringend, dieses zu ändern.",
+	"dashboard_message_do_not_show_again": "Diese Meldung nicht mehr anzeigen",
 	"dashboard_active_instance": "Ausgewählte Instanz",
 	"main_menu_dashboard_token": "Dashboard",
 	"main_menu_configuration_token": "Konfiguration",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -84,6 +84,7 @@
 	"dashboard_message_global_setting": "The settings on this page are not depending on a specific instance. Changes will be stored globally for all instances.",
 	"dashboard_message_default_password_t": "WebUi default password is set",
 	"dashboard_message_default_password": "The default password for the WebUi is set. We strongly recommend to change this.",
+	"dashboard_message_do_not_show_again": "Do not show this message again",
 	"dashboard_active_instance": "Selected instance",
 	"main_menu_dashboard_token" : "Dashboard",
 	"main_menu_configuration_token" : "Configuration",

--- a/assets/webconfig/js/content_index.js
+++ b/assets/webconfig/js/content_index.js
@@ -123,8 +123,13 @@ $(document).ready(function () {
 		$("#main-nav").removeAttr('style')
 		$("#top-navbar").removeAttr('style')
 
-		if (window.defaultPasswordIsSet === true)
-			showNotification('warning', $.i18n('dashboard_message_default_password'), $.i18n('dashboard_message_default_password_t'), '<a style="cursor:pointer" onClick="changePassword()"> ' + $.i18n('InfoDialog_changePassword_title') + '</a>')
+		if (window.defaultPasswordIsSet === true && getStorage("suppressDefaultPwWarning") !== "true" )
+		{
+			var supprPwWarnCheckbox = '<div class="text-right">'+$.i18n('dashboard_message_do_not_show_again')
+					+ ' <input id="chk_suppressDefaultPw" type="checkbox" onChange="suppressDefaultPwWarning()"> </div>'
+			showNotification('warning', $.i18n('dashboard_message_default_password'), $.i18n('dashboard_message_default_password_t'), '<a style="cursor:pointer" onClick="changePassword()">'
+					+ $.i18n('InfoDialog_changePassword_title') + '</a>' + supprPwWarnCheckbox)
+		}
 		else
 			//if logged on and pw != default show option to lock ui
 			$("#btn_lock_ui").removeAttr('style')
@@ -278,6 +283,14 @@ $(document).ready(function () {
 	});
 
 });
+
+function suppressDefaultPwWarning(){
+
+  if (document.getElementById('chk_suppressDefaultPw').checked) 
+	setStorage("suppressDefaultPwWarning", "true");
+  else 
+	setStorage("suppressDefaultPwWarning", "false");
+}
 
 $(function () {
 	var sidebar = $('#side-menu');  // cache sidebar to a variable for performance

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8498,9 +8498,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 when@~3.6.x:
   version "3.6.4"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Allow the user to suppress default password warning,
in case they are happy to run hyperion without password access.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Before**

![image](https://user-images.githubusercontent.com/48840279/84566089-c87f1180-ad6e-11ea-8f74-1f8115ea53bd.png)

**After**
![image](https://user-images.githubusercontent.com/48840279/84566069-94a3ec00-ad6e-11ea-8b00-8c3670aef736.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
