### PR TITLE
use QSerialPortInfo to detect presence of a serial port (fix #836)

### DIFF
--- a/libsrc/leddevice/dev_serial/ProviderRs232.cpp
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.cpp
@@ -201,7 +201,9 @@ bool ProviderRs232::tryOpen(const int delayAfterConnect_ms)
 	if ( ! _rs232Port.isOpen() )
 	{
 		_frameDropCounter = 0;
-		if (QFile::exists(_deviceName))
+
+		QSerialPortInfo serialPortInfo(_deviceName);
+		if (! serialPortInfo.isNull())
 		{
 			if ( _preOpenDelayTimeOut > QDateTime::currentMSecsSinceEpoch() )
 			{

--- a/libsrc/leddevice/dev_serial/ProviderRs232.cpp
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.cpp
@@ -225,6 +225,8 @@ bool ProviderRs232::tryOpen(const int delayAfterConnect_ms)
 		}
 		else
 		{
+			QString errortext = QString("Invalid serial device name: [%1]!").arg(_deviceName);
+			this->setInError(errortext);
 			_preOpenDelayTimeOut = QDateTime::currentMSecsSinceEpoch() + _preOpenDelay;
 			return false;
 		}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

* ProviderRs232: checking for existence of device file does not work on windows.
* instead: construct QSerialPortInfo from device name and check, if it is not null.

  When constructing QSerialPortInfo from device name, this constructor finds the
  relevant serial port among the available ones according to the port name name,
  and constructs the serial port info instance for that port.
  (https://doc.qt.io/qt-5/qserialportinfo.html#QSerialPortInfo-2)

Fixes: #836 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
