### PR TITLE
Show thread names in GDB for better debugging

### DIFF
--- a/libsrc/hyperion/HyperionIManager.cpp
+++ b/libsrc/hyperion/HyperionIManager.cpp
@@ -74,6 +74,7 @@ bool HyperionIManager::startInstance(const quint8& inst, const bool& block)
 		if(!_runningInstances.contains(inst) && !_startQueue.contains(inst))
 		{
 			QThread* hyperionThread = new QThread();
+			hyperionThread->setObjectName("HyperionIManagerThread");
 			Hyperion* hyperion = new Hyperion(inst);
 			hyperion->moveToThread(hyperionThread);
 			// setup thread management

--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -47,6 +47,7 @@ void LedDeviceWrapper::createLedDevice(const QJsonObject& config)
 
 	// create thread and device
 	QThread* thread = new QThread(this);
+	thread->setObjectName("LedDeviceWrapperThread");
 	_ledDevice = LedDeviceFactory::construct(config);
 	_ledDevice->moveToThread(thread);
 	// setup thread management

--- a/src/hyperion-aml/AmlogicWrapper.cpp
+++ b/src/hyperion-aml/AmlogicWrapper.cpp
@@ -9,6 +9,8 @@ AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeig
 	_thread(this),
 	_grabber(grabWidth, grabHeight)
 {
+	_thread.setObjectName("AmlogicWrapperThread");
+
 	// Connect capturing to the timeout signal of the timer
 	connect(&_thread, SIGNAL (started()), this, SLOT(capture()));
 }

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -219,6 +219,7 @@ void HyperionDaemon::startNetworkServices()
 	// Create FlatBuffer server in thread
 	_flatBufferServer = new FlatBufferServer(getSetting(settings::FLATBUFSERVER));
 	QThread *fbThread = new QThread(this);
+	fbThread->setObjectName("FlatBufferServerThread");
 	_flatBufferServer->moveToThread(fbThread);
 	connect(fbThread, &QThread::started, _flatBufferServer, &FlatBufferServer::initServer);
 	connect(fbThread, &QThread::finished, _flatBufferServer, &QObject::deleteLater);
@@ -229,6 +230,7 @@ void HyperionDaemon::startNetworkServices()
 	// Create Proto server in thread
 	_protoServer = new ProtoServer(getSetting(settings::PROTOSERVER));
 	QThread *pThread = new QThread(this);
+	pThread->setObjectName("ProtoServerThread");
 	_protoServer->moveToThread(pThread);
 	connect(pThread, &QThread::started, _protoServer, &ProtoServer::initServer);
 	connect(pThread, &QThread::finished, _protoServer, &QObject::deleteLater);
@@ -239,6 +241,7 @@ void HyperionDaemon::startNetworkServices()
 	// Create Webserver in thread
 	_webserver = new WebServer(getSetting(settings::WEBSERVER), false);
 	QThread *wsThread = new QThread(this);
+	wsThread->setObjectName("WebServerThread");
 	_webserver->moveToThread(wsThread);
 	connect(wsThread, &QThread::started, _webserver, &WebServer::initServer);
 	connect(wsThread, &QThread::finished, _webserver, &QObject::deleteLater);
@@ -249,6 +252,7 @@ void HyperionDaemon::startNetworkServices()
 	// Create SSL Webserver in thread
 	_sslWebserver = new WebServer(getSetting(settings::WEBSERVER), true);
 	QThread *sslWsThread = new QThread(this);
+	sslWsThread->setObjectName("SSLWebServerThread");
 	_sslWebserver->moveToThread(sslWsThread);
 	connect(sslWsThread, &QThread::started, _sslWebserver, &WebServer::initServer);
 	connect(sslWsThread, &QThread::finished, _sslWebserver, &QObject::deleteLater);
@@ -259,6 +263,7 @@ void HyperionDaemon::startNetworkServices()
 	// Create SSDP server in thread
 	_ssdp = new SSDPHandler(_webserver, getSetting(settings::FLATBUFSERVER).object()["port"].toInt(), getSetting(settings::JSONSERVER).object()["port"].toInt(), getSetting(settings::GENERAL).object()["name"].toString());
 	QThread *ssdpThread = new QThread(this);
+	ssdpThread->setObjectName("SSDPThread");
 	_ssdp->moveToThread(ssdpThread);
 	connect(ssdpThread, &QThread::started, _ssdp, &SSDPHandler::initServer);
 	connect(ssdpThread, &QThread::finished, _ssdp, &QObject::deleteLater);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Before :

    (gdb) info threads 
    Id   Target Id         Frame 
    * 1    Thread 0x7ffff7fc8400 (LWP 8738) "hyperiond" 0x00007ffff3c22bf9 in __GI___poll (fds=0x55555611f8d0, nfds=7, timeout=62) at ../sysdeps/unix/sysv/linux/poll.c:29
      2    Thread 0x7fffea135700 (LWP 8743) "QXcbEventReader" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffea134ca8, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      3    Thread 0x7fffdf001700 (LWP 8744) "QDBusConnection" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd8019170, nfds=4, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      4    Thread 0x7fffde2e7700 (LWP 8745) "hyperiond" 0x00007ffff3c22bf9 in __GI___poll (fds=0x55555600a970, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      5    Thread 0x7fffdd981700 (LWP 8746) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd0009f80, nfds=1, timeout=20) at ../sysdeps/unix/sysv/linux/poll.c:29
      6    Thread 0x7fffdd180700 (LWP 8747) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd4004bb0, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      7    Thread 0x7fffdc97f700 (LWP 8748) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc80056b0, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      8    Thread 0x7fffcffff700 (LWP 8749) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc4029350, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      9    Thread 0x7fffcf7fe700 (LWP 8750) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffbc00c7b0, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      10   Thread 0x7fffceb32700 (LWP 8751) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc000b600, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      11   Thread 0x7fffce331700 (LWP 8752) "QThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffb40071c0, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      12   Thread 0x7fffcd8a3700 (LWP 8753) "Effect" 0x00007ffff3c2503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7fffcd8a2860) at ../sysdeps/unix/sysv/linux/select.c:41
      13   Thread 0x7fffcd0a2700 (LWP 8754) "Effect" 0x00007ffff3c2503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7fffcd0a1860) at ../sysdeps/unix/sysv/linux/select.c:41
      14   Thread 0x7fffb3f7f700 (LWP 8755) "Qt bearer threa" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffa8004e10, nfds=1, timeout=10000) at ../sysdeps/unix/sysv/linux/poll.c:29

After :

    (gdb) info threads 
    Id   Target Id         Frame 
    * 1    Thread 0x7ffff7fc8400 (LWP 9673) "hyperiond" 0x00007ffff3c22bf9 in __GI___poll (fds=0x5555560c80f0, nfds=7, timeout=84) at ../sysdeps/unix/sysv/linux/poll.c:29
      2    Thread 0x7fffea135700 (LWP 9678) "QXcbEventReader" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffea134ca8, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      3    Thread 0x7fffdf001700 (LWP 9679) "QDBusConnection" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd8018dc0, nfds=4, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      4    Thread 0x7fffde2e7700 (LWP 9680) "hyperiond" 0x00007ffff3c22bf9 in __GI___poll (fds=0x55555600b490, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      5    Thread 0x7fffdd981700 (LWP 9681) "HyperionIManage" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd0009f80, nfds=1, timeout=39) at ../sysdeps/unix/sysv/linux/poll.c:29
      6    Thread 0x7fffdd180700 (LWP 9682) "FlatBufferServe" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd4004b40, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      7    Thread 0x7fffdc97f700 (LWP 9683) "ProtoServerThre" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc80056b0, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      8    Thread 0x7fffcffff700 (LWP 9684) "WebServerThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc4005a70, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:2
      9    Thread 0x7fffcf7fe700 (LWP 9685) "LedDeviceWrappe" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffb8006da0, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      10   Thread 0x7fffceffd700 (LWP 9686) "SSLWebServerThr" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffc0029100, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      11   Thread 0x7fffce7fc700 (LWP 9687) "SSDPThread" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffb000c1e0, nfds=2, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      12   Thread 0x7fffcdb30700 (LWP 9688) "EffectThread" 0x00007ffff3c2503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7fffcdb2f860) at ../sysdeps/unix/sysv/linux/select.c:41
      13   Thread 0x7fffcd32f700 (LWP 9689) "EffectThread" 0x00007ffff3c2503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7fffcd32e860) at ../sysdeps/unix/sysv/linux/select.c:41
      14   Thread 0x7fffaffff700 (LWP 9690) "Qt bearer threa" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffa8004e10, nfds=1, timeout=10363) at ../sysdeps/unix/sysv/linux/poll.c:29


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:
Improve debugging experience

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
