### PR TITLE
Fix leaking active events and a potential crash during quit

### DIFF
--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -45,6 +45,11 @@ EffectEngine::EffectEngine(Hyperion * hyperion)
 
 EffectEngine::~EffectEngine()
 {
+	for (Effect * effect : _activeEffects)
+	{
+		effect->wait();
+		delete effect;
+	}
 }
 
 QString EffectEngine::saveEffect(const QJsonObject& obj)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The effects created by ````EffectEngine```` are stored in a container as soon as they are created and started :

	int EffectEngine::runEffectScript(const QString &script, const QString &name, const QJsonObject &args, int priority, int timeout, const QString &origin, unsigned smoothCfg, const QString &imageData)
	{
		....
		// create the effect
		Effect *effect = new Effect(_hyperion, priority, timeout, script, name, args, imageData);
		connect(effect, &Effect::setInput, _hyperion, &Hyperion::setInput, Qt::QueuedConnection);
		connect(effect, &Effect::setInputImage, _hyperion, &Hyperion::setInputImage, Qt::QueuedConnection);
		connect(effect, &QThread::finished, this, &EffectEngine::effectFinished);
		connect(_hyperion, &Hyperion::finished, effect, &Effect::requestInterruption, Qt::DirectConnection);
		_activeEffects.push_back(effect);

		........
		effect->start();

		return 0;
	}

And they are deleted as soon as they finish:

	void EffectEngine::effectFinished()
	{
		Effect* effect = qobject_cast<Effect*>(sender());
		.........
		Info( _log, "effect finished");
		for (auto effectIt = _activeEffects.begin(); effectIt != _activeEffects.end(); ++effectIt)
		{
			if (*effectIt == effect)
			{
				_activeEffects.erase(effectIt);
				break;
			}
		}

		// cleanup the effect
		effect->deleteLater();
	}

The problem is, if we start the exit procedure when there are ````_activeEvents````, ````EffectEngine```` destructor does nothing about it and just returns. Since the ````EffectEngine```` gets destructed, ````EffectEngine::effectFinished()```` is never called for unfinished effects. This has 2 consequences:

1- Those active effects leak.
2-  Active effects are probably still running their own thread(````Effect::run()````) when ````EffectEngine```` gets destructed. Execution of the main thread will continue with ````PythonInit::~PythonInit()```` when there is another thread messing with Python.

Long story short, this is what happens before :

    Thread 1 "hyperiond" hit Breakpoint 1, PythonInit::~PythonInit (this=0x555555fdc860, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
    57	PythonInit::~PythonInit()
    (gdb) bt
    #0  PythonInit::~PythonInit (this=0x555555fdc860, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
    #1  0x0000555555763ec9 in HyperionDaemon::~HyperionDaemon (this=0x555555e67e00, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/src/hyperiond/hyperiond.cpp:148
    #2  0x0000555555763f22 in HyperionDaemon::~HyperionDaemon (this=0x555555e67e00, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/src/hyperiond/hyperiond.cpp:149
    #3  0x0000555555774427 in main (argc=4, argv=0x7fffffffdee8) at /home/murse/hyperion.ng/src/hyperiond/main.cpp:343
    (gdb) info threads 
      Id   Target Id         Frame 
    * 1    Thread 0x7ffff7fc8400 (LWP 30085) "hyperiond" PythonInit::~PythonInit (this=0x555555fdc860, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
      2    Thread 0x7fffea135700 (LWP 30087) "QXcbEventReader" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffea134ca8, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      3    Thread 0x7fffdf001700 (LWP 30088) "QDBusConnection" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd8018ed0, nfds=4, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      10   Thread 0x7fffceffd700 (LWP 30095) "Effect" 0x00007ffff785bb5b in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0
      12   Thread 0x7fffcdffb700 (LWP 30097) "Effect" 0x00007ffff3c2503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7fffcdffa860) at ../sysdeps/unix/sysv/linux/select.c:41
      14   Thread 0x7fffaf3e4700 (LWP 30099) "Qt bearer threa" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffa8004e10, nfds=1, timeout=9846) at ../sysdeps/unix/sysv/linux/poll.c:29

As you can see there are still ````Effect```` treads when we are about to execute ````PythonInit::~PythonInit()````. After proposed fix :

    Thread 1 "hyperiond" hit Breakpoint 1, PythonInit::~PythonInit (this=0x555555fdd8e0, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
    57	PythonInit::~PythonInit()
    (gdb) bt
    #0  PythonInit::~PythonInit (this=0x555555fdd8e0, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
    #1  0x0000555555763ec9 in HyperionDaemon::~HyperionDaemon (this=0x555555ea0180, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/src/hyperiond/hyperiond.cpp:148
    #2  0x0000555555763f22 in HyperionDaemon::~HyperionDaemon (this=0x555555ea0180, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/src/hyperiond/hyperiond.cpp:149
    #3  0x0000555555774427 in main (argc=4, argv=0x7fffffffdee8) at /home/murse/hyperion.ng/src/hyperiond/main.cpp:343
    (gdb) info threads
      Id   Target Id         Frame 
    * 1    Thread 0x7ffff7fc8400 (LWP 29160) "hyperiond" PythonInit::~PythonInit (this=0x555555fdd8e0, __in_chrg=<optimized out>) at /home/murse/hyperion.ng/libsrc/python/PythonInit.cpp:57
      2    Thread 0x7fffea135700 (LWP 29162) "QXcbEventReader" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffea134ca8, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      3    Thread 0x7fffdf001700 (LWP 29163) "QDBusConnection" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffd8018e10, nfds=4, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
      4   Thread 0x7fffc73f9700 (LWP 29174) "Qt bearer threa" 0x00007ffff3c22bf9 in __GI___poll (fds=0x7fffac004e10, nfds=1, timeout=9542) at ../sysdeps/unix/sysv/linux/poll.c:29


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
