### PR TITLE
Fix OpenSSL dependencies for Windows

### DIFF
--- a/.azure.yml
+++ b/.azure.yml
@@ -87,6 +87,7 @@ jobs:
       python -m pip install aqtinstall
       python -m aqt install -O c:\Qt 5.15.0 windows desktop win64_msvc2019_64
     displayName: 'Install Qt 5.15.0'
+
   # build process
   - bash: ./.ci/ci_build.sh
     env:

--- a/CompileHowto.md
+++ b/CompileHowto.md
@@ -82,6 +82,7 @@ We assume a 64bit Windows 7 or higher. Install the following
   - Open a console window and execute `pip install aqtinstall`.
   - Now we can download Qt to _C:\Qt_ `mkdir c:\Qt && aqt install -O c:\Qt 5.15.0 windows desktop win64_msvc2019_64`
 - [CMake (Windows win64-x64 Installer)](https://cmake.org/download/) (Check: Add to PATH)
+- [Win64 OpenSSL v1.1.1g](https://slproweb.com/products/Win32OpenSSL.html) ([direct link](https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe))
 - [Visual Studio 2019 Build Tools](https://go.microsoft.com/fwlink/?linkid=840931) ([direct link](https://aka.ms/vs/16/release/vs_buildtools.exe))
   - Select C++ Buildtools
   - On the right, just select `MSVC v142 VS 2019 C++ x64/x86-Buildtools` and latest `Windows 10 SDK`. Everything else is not needed.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -178,6 +178,7 @@ macro(DeployWindows TARGET)
 
 	if(EXISTS ${TARGET_FILE})
 		find_package(Qt5Core REQUIRED)
+		find_package(OpenSSL REQUIRED)
 
 		# Find the windeployqt binaries
 		get_target_property(QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
@@ -225,6 +226,36 @@ macro(DeployWindows TARGET)
 
 			list(REMOVE_AT DEPENDENCIES 0 1)
 		endwhile()
+
+		# Copy OpenSSL Libs
+		if (OPENSSL_FOUND)
+			string(REGEX MATCHALL "[0-9]+" openssl_versions "${OPENSSL_VERSION}")
+			list(GET openssl_versions 0 openssl_version_major)
+			list(GET openssl_versions 1 openssl_version_minor)
+
+			set(library_suffix "-${openssl_version_major}_${openssl_version_minor}")
+			if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+			  string(APPEND library_suffix "-x64")
+			endif()
+
+			find_file(OPENSSL_SSL
+				NAMES "libssl${library_suffix}.dll"
+				PATHS ${OPENSSL_INCLUDE_DIR}/.. ${OPENSSL_INCLUDE_DIR}/../bin
+				NO_DEFAULT_PATH
+			)
+
+			find_file(OPENSSL_CRYPTO
+				NAMES "libcrypto${library_suffix}.dll"
+				PATHS ${OPENSSL_INCLUDE_DIR}/.. ${OPENSSL_INCLUDE_DIR}/../bin
+				NO_DEFAULT_PATH
+			)
+
+			install(
+				FILES ${OPENSSL_SSL} ${OPENSSL_CRYPTO}
+				DESTINATION "bin"
+				COMPONENT "Hyperion"
+			)
+		endif(OPENSSL_FOUND)
 
 		# Create a qt.conf file in 'bin' to override hard-coded search paths in Qt plugins
 		file(WRITE "${CMAKE_BINARY_DIR}/qt.conf" "[Paths]\nPlugins=../lib/\n")


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

As explained in Issue #737, the OpenSSL dependencies for Windows are still missing.
Many thanks to @m-seker  for the hint.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
