### PR TITLE
Fix logger

### DIFF
--- a/assets/webconfig/js/content_logging.js
+++ b/assets/webconfig/js/content_logging.js
@@ -4,7 +4,6 @@
 	requestLoggingStart();
 
 $(document).ready(function() {
-	
 	var messages;
 	var loguplmess = "";
 	var reportUrl = 'https://report.hyperion-project.org/#';

--- a/include/hyperion/AuthManager.h
+++ b/include/hyperion/AuthManager.h
@@ -5,6 +5,7 @@
 
 //qt
 #include <QMap>
+#include <QVector>
 
 class AuthTable;
 class MetaTable;

--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -3,29 +3,33 @@
 // QT includes
 #include <QObject>
 #include <QString>
+#include <QMap>
+#include <QAtomicInteger>
+#include <QList>
+#include <QMutex>
 
 // stl includes
 #include <stdio.h>
 #include <stdarg.h>
-#include <map>
-#include <QVector>
 #ifdef _WIN32
 #include <stdexcept>
 #endif
 
 #include <utils/global_defines.h>
 
+#define LOG_MESSAGE(severity, logger, ...)   (logger)->Message(severity, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+
 // standard log messages
-#define Debug(logger, ...)   (logger)->Message(Logger::DEBUG  , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define Info(logger, ...)    (logger)->Message(Logger::INFO   , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define Warning(logger, ...) (logger)->Message(Logger::WARNING, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define Error(logger, ...)   (logger)->Message(Logger::ERRORR  , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define Debug(logger, ...)   LOG_MESSAGE(Logger::DEBUG  , logger, __VA_ARGS__)
+#define Info(logger, ...)    LOG_MESSAGE(Logger::INFO   , logger, __VA_ARGS__)
+#define Warning(logger, ...) LOG_MESSAGE(Logger::WARNING, logger, __VA_ARGS__)
+#define Error(logger, ...)   LOG_MESSAGE(Logger::ERRORR , logger, __VA_ARGS__)
 
 // conditional log messages
-#define DebugIf(condition, logger, ...)   if (condition) (logger)->Message(Logger::DEBUG   , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define InfoIf(condition, logger, ...)    if (condition) (logger)->Message(Logger::INFO    , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define WarningIf(condition, logger, ...) if (condition) (logger)->Message(Logger::WARNING , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define ErrorIf(condition, logger, ...)   if (condition) (logger)->Message(Logger::ERRORR   , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define DebugIf(condition, logger, ...)   if (condition) Debug(logger,   __VA_ARGS__)
+#define InfoIf(condition, logger, ...)    if (condition) Info(logger,    __VA_ARGS__)
+#define WarningIf(condition, logger, ...) if (condition) Warning(logger, __VA_ARGS__)
+#define ErrorIf(condition, logger, ...)   if (condition) Error(logger,   __VA_ARGS__)
 
 // ================================================================
 
@@ -35,54 +39,60 @@ class Logger : public QObject
 
 public:
 	enum LogLevel {
-		UNSET,
-		DEBUG,
-		INFO,
-		WARNING,
-		ERRORR,
-		OFF
+		UNSET    = 0,
+		DEBUG    = 1,
+		INFO     = 2,
+		WARNING  = 3,
+		ERRORR   = 4,
+		OFF      = 5
 	};
 
-	typedef struct
+	struct T_LOG_MESSAGE
 	{
 		QString      appName;
 		QString      loggerName;
 		QString      function;
 		unsigned int line;
 		QString      fileName;
-		time_t       utime;
+		uint64_t     utime;
 		QString      message;
 		LogLevel     level;
 		QString      levelString;
-	} T_LOG_MESSAGE;
+	};
 
-	static Logger*  getInstance(QString name="", LogLevel minLevel=Logger::INFO);
-	static void     deleteInstance(QString name="");
-	static void     setLogLevel(LogLevel level, QString name="");
-	static LogLevel getLogLevel(QString name="");
+	static Logger*  getInstance(const QString & name = "", LogLevel minLevel=Logger::INFO);
+	static void     deleteInstance(const QString & name = "");
+	static void     setLogLevel(LogLevel level, const QString & name = "");
+	static LogLevel getLogLevel(const QString & name = "");
 
 	void     Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...);
-	void     setMinLevel(LogLevel level) { _minLevel = level; }
-	LogLevel getMinLevel() { return _minLevel; }
+	void     setMinLevel(LogLevel level) { _minLevel = static_cast<int>(level); }
+	LogLevel getMinLevel() { return static_cast<LogLevel>(int(_minLevel)); }
+	QString  getName() const { return _name; }
+	QString  getAppName() const { return _appname; }
 
 signals:
 	void newLogMessage(Logger::T_LOG_MESSAGE);
 
 protected:
-	Logger( QString name="", LogLevel minLevel=INFO);
+	Logger(const QString & name="", LogLevel minLevel = INFO);
 	~Logger();
 
 private:
-	static std::map<QString,Logger*> *LoggerMap;
-	static LogLevel GLOBAL_MIN_LOG_LEVEL;
+	void write(const Logger::T_LOG_MESSAGE & message) const;
 
-	QString  _name;
-	QString  _appname;
-	LogLevel _minLevel;
-	bool     _syslogEnabled;
-	unsigned _loggerId;
+	static QMutex                MapLock;
+	static QMap<QString,Logger*> LoggerMap;
+	static QAtomicInteger<int>   GLOBAL_MIN_LOG_LEVEL;
+
+	const QString                _name;
+	const QString                _appname;
+	const bool                   _syslogEnabled;
+	const unsigned               _loggerId;
+
+	/* Only non-const member, hence the atomic */
+	QAtomicInteger<int> _minLevel;
 };
-
 
 class LoggerManager : public QObject
 {
@@ -90,7 +100,7 @@ class LoggerManager : public QObject
 
 public:
 	static LoggerManager* getInstance();
-	QVector<Logger::T_LOG_MESSAGE>* getLogMessageBuffer() { return &_logMessageBuffer; }
+	const QList<Logger::T_LOG_MESSAGE>* getLogMessageBuffer() const { return &_logMessageBuffer; }
 
 public slots:
 	void handleNewLogMessage(const Logger::T_LOG_MESSAGE&);
@@ -101,8 +111,7 @@ signals:
 protected:
 	LoggerManager();
 
-	static LoggerManager*          _instance;
-	QVector<Logger::T_LOG_MESSAGE> _logMessageBuffer;
+	QList<Logger::T_LOG_MESSAGE>   _logMessageBuffer;
 	const int                      _loggerMaxMsgBufferSize;
 };
 

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -1548,7 +1548,7 @@ void JsonAPI::incommingLogMessage(const Logger::T_LOG_MESSAGE &msg)
 	if (!_streaming_logging_activated)
 	{
 		_streaming_logging_activated = true;
-		QVector<Logger::T_LOG_MESSAGE> *logBuffer = LoggerManager::getInstance()->getLogMessageBuffer();
+		const QList<Logger::T_LOG_MESSAGE> *logBuffer = LoggerManager::getInstance()->getLogMessageBuffer();
 		for (int i = 0; i < logBuffer->length(); i++)
 		{
 			message["appName"] = logBuffer->at(i).appName;

--- a/libsrc/flatbufserver/FlatBufferConnection.cpp
+++ b/libsrc/flatbufserver/FlatBufferConnection.cpp
@@ -12,7 +12,7 @@ FlatBufferConnection::FlatBufferConnection(const QString& origin, const QString 
 	, _origin(origin)
 	, _priority(priority)
 	, _prevSocketState(QAbstractSocket::UnconnectedState)
-	, _log(Logger::getInstance("FLATBUFCONNECTION"))
+	, _log(Logger::getInstance("FLATBUFCONN"))
 	, _registered(false)
 {
 	QStringList parts = address.split(":");

--- a/libsrc/hyperion/ComponentRegister.cpp
+++ b/libsrc/hyperion/ComponentRegister.cpp
@@ -7,7 +7,7 @@ using namespace hyperion;
 
 ComponentRegister::ComponentRegister(Hyperion* hyperion)
 	: _hyperion(hyperion)
-	, _log(Logger::getInstance("ComponentRegister"))
+	, _log(Logger::getInstance("COMPONENTREG"))
 {
 	// init all comps to false
 	QVector<hyperion::Components> vect;

--- a/libsrc/hyperion/Grabber.cpp
+++ b/libsrc/hyperion/Grabber.cpp
@@ -14,7 +14,7 @@ Grabber::Grabber(QString grabberName, int width, int height, int cropLeft, int c
 	, _cropTop(0)
 	, _cropBottom(0)
 	, _enabled(true)
-	, _log(Logger::getInstance(grabberName))
+	, _log(Logger::getInstance(grabberName.toUpper()))
 {
 	Grabber::setVideoMode(VideoMode::VIDEO_2D);
 	Grabber::setCropping(cropLeft, cropRight, cropTop, cropBottom);

--- a/libsrc/hyperion/SettingsManager.cpp
+++ b/libsrc/hyperion/SettingsManager.cpp
@@ -16,7 +16,7 @@ QJsonObject SettingsManager::schemaJson;
 
 SettingsManager::SettingsManager(const quint8& instance, QObject* parent)
 	: QObject(parent)
-	, _log(Logger::getInstance("SettingsManager"))
+	, _log(Logger::getInstance("SETTINGSMGR"))
 	, _sTable(new SettingsTable(instance, this))
 {
 	// get schema

--- a/libsrc/utils/Logger.cpp
+++ b/libsrc/utils/Logger.cpp
@@ -11,99 +11,33 @@
 #include <Shlwapi.h>
 #pragma comment(lib, "Shlwapi.lib")
 #endif
+#include <QDateTime>
 #include <QFileInfo>
+#include <QMutexLocker>
+#include <QThreadStorage>
 #include <time.h>
 
-static const char * LogLevelStrings[]   = { "", "DEBUG", "INFO", "WARNING", "ERROR" };
+QMutex                 Logger::MapLock              { QMutex::Recursive };
+QMap<QString,Logger*>  Logger::LoggerMap            { };
+QAtomicInteger<int>    Logger::GLOBAL_MIN_LOG_LEVEL { static_cast<int>(Logger::UNSET)};
+
+namespace
+{
+const char * LogLevelStrings[]   = { "", "DEBUG", "INFO", "WARNING", "ERROR" };
 #ifndef _WIN32
-static const int    LogLevelSysLog[]    = { LOG_DEBUG, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR };
+const int    LogLevelSysLog[]    = { LOG_DEBUG, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR };
 #endif
-static unsigned int loggerCount         = 0;
-static unsigned int loggerId            = 0;
 
-std::map<QString,Logger*> *Logger::LoggerMap = nullptr;
-Logger::LogLevel Logger::GLOBAL_MIN_LOG_LEVEL = Logger::UNSET;
-LoggerManager* LoggerManager::_instance = nullptr;
-int _repeatCount = 0;
-Logger::T_LOG_MESSAGE _repeatMessage;
-const int _maxRepeatCountSize = 200;
+const size_t MAX_IDENTIFICATION_LENGTH = 22;
 
-Logger* Logger::getInstance(QString name, Logger::LogLevel minLevel)
-{
-	qRegisterMetaType<Logger::T_LOG_MESSAGE>();
-	Logger* log = nullptr;
-	if (LoggerMap == nullptr)
-	{
-		LoggerMap = new std::map<QString,Logger*>;
-	}
+QAtomicInteger<unsigned int> LoggerCount = 0;
+QAtomicInteger<unsigned int> LoggerId    = 0;
 
-	if (LoggerMap->find(name) == LoggerMap->end())
-	{
-		log = new Logger(name,minLevel);
-		LoggerMap->insert(std::pair<QString,Logger*>(name,log)); // compat version, replace it with following line if we have 100% c++11
-		//LoggerMap->emplace(name,log);  // not compat with older linux distro's e.g. wheezy
-		connect(log, &Logger::newLogMessage, LoggerManager::getInstance(), &LoggerManager::handleNewLogMessage);
-	}
-	else
-	{
-		log = LoggerMap->at(name);
-	}
+const int MaxRepeatCountSize = 200;
+QThreadStorage<int> RepeatCount;
+QThreadStorage<Logger::T_LOG_MESSAGE> RepeatMessage;
 
-	return log;
-}
-
-void Logger::deleteInstance(QString name)
-{
-	if (LoggerMap == nullptr)
-		return;
-
-	if (name.isEmpty())
-	{
-		std::map<QString,Logger*>::iterator it;
-		for (it = LoggerMap->begin(); it != LoggerMap->end(); it++)
-		{
-			delete it->second;
-		}
-		LoggerMap->clear();
-	}
-	else if (LoggerMap->find(name) != LoggerMap->end())
-	{
-		delete LoggerMap->at(name);
-		LoggerMap->erase(name);
-	}
-
-}
-
-void Logger::setLogLevel(LogLevel level,QString name)
-{
-	if (name.isEmpty())
-	{
-		GLOBAL_MIN_LOG_LEVEL = level;
-	}
-	else
-	{
-		Logger* log = Logger::getInstance(name,level);
-		log->setMinLevel(level);
-	}
-}
-
-Logger::LogLevel Logger::getLogLevel(QString name)
-{
-	if (name.isEmpty())
-	{
-		return GLOBAL_MIN_LOG_LEVEL;
-	}
-
-	Logger* log = Logger::getInstance(name);
-	return log->getMinLevel();
-}
-
-Logger::Logger (QString name, LogLevel minLevel)
-	: QObject()
-	, _name(name)
-	, _minLevel(minLevel)
-	, _syslogEnabled(true)
-	, _loggerId(loggerId++)
+QString getApplicationName()
 {
 #ifdef __GLIBC__
     const char* _appname_char = program_invocation_short_name;
@@ -121,32 +55,132 @@ Logger::Logger (QString name, LogLevel minLevel)
 	else
 		_appname_char = "unknown";
 #endif
-	_appname = QString(_appname_char).toLower();
+	return QString(_appname_char).toLower();
 
-	loggerCount++;
+}
+} // namespace
 
-	if (_syslogEnabled && loggerCount == 1)
+Logger* Logger::getInstance(const QString & name, Logger::LogLevel minLevel)
+{
+	QMutexLocker lock(&MapLock);
+
+	Logger* log = LoggerMap.value(name, nullptr);
+	if (log == nullptr)
 	{
-		#ifndef _WIN32
-		openlog (_appname_char, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL0);
-		#endif
+		log = new Logger(name, minLevel);
+		LoggerMap.insert(name, log); // compat version, replace it with following line if we have 100% c++11
+		//LoggerMap.emplace(name, log);  // not compat with older linux distro's e.g. wheezy
+		connect(log, &Logger::newLogMessage, LoggerManager::getInstance(), &LoggerManager::handleNewLogMessage);
+	}
+
+	return log;
+}
+
+void Logger::deleteInstance(const QString & name)
+{
+	QMutexLocker lock(&MapLock);
+
+	if (name.isEmpty())
+	{
+		for (auto logger : LoggerMap)
+			delete logger;
+
+		LoggerMap.clear();
+	}
+	else
+	{
+		delete LoggerMap.value(name, nullptr);
+		LoggerMap.remove(name);
+	}
+}
+
+void Logger::setLogLevel(LogLevel level, const QString & name)
+{
+	if (name.isEmpty())
+	{
+		GLOBAL_MIN_LOG_LEVEL = static_cast<int>(level);
+	}
+	else
+	{
+		Logger* log = Logger::getInstance(name, level);
+		log->setMinLevel(level);
+	}
+}
+
+Logger::LogLevel Logger::getLogLevel(const QString & name)
+{
+	if (name.isEmpty())
+	{
+		return static_cast<Logger::LogLevel>(int(GLOBAL_MIN_LOG_LEVEL));
+	}
+
+	Logger* log = Logger::getInstance(name);
+	return log->getMinLevel();
+}
+
+Logger::Logger (const QString & name, LogLevel minLevel)
+	: QObject()
+	, _name(name)
+	, _appname(getApplicationName())
+	, _syslogEnabled(true)
+	, _loggerId(LoggerId++)
+	, _minLevel(static_cast<int>(minLevel))
+{
+	qRegisterMetaType<Logger::T_LOG_MESSAGE>();
+
+	int count = LoggerCount.fetchAndAddOrdered(1);
+
+	if (_syslogEnabled && count == 1)
+	{
+#ifndef _WIN32
+		openlog (_appname.toLocal8Bit(), LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL0);
+#endif
 	}
 }
 
 Logger::~Logger()
 {
 	//Debug(this, "logger '%s' destroyed", QSTRING_CSTR(_name) );
-	loggerCount--;
+
+	int count = LoggerCount.fetchAndSubOrdered(1);
 #ifndef _WIN32
-	if (loggerCount == 0)
+	if (_syslogEnabled && count == 0)
 		closelog();
 #endif
 }
 
+void Logger::write(const Logger::T_LOG_MESSAGE & message) const
+{
+	QString location;
+	if (message.level == Logger::DEBUG)
+	{
+		location = QString("%1:%2:%3() | ")
+			.arg(message.fileName)
+			.arg(message.line)
+			.arg(message.function);
+	}
+
+	QString name = message.appName + " " + message.loggerName;
+	name.resize(MAX_IDENTIFICATION_LENGTH, ' ');
+
+	const QDateTime timestamp = QDateTime::fromMSecsSinceEpoch(message.utime);
+
+	std::cout << QString("%1 %2 : <%3> %4%5")
+			.arg(timestamp.toString("yyyy-MM-ddThh:mm:ss.zzz"))
+			.arg(name)
+			.arg(LogLevelStrings[message.level])
+			.arg(location)
+			.arg(message.message)
+		.toStdString()
+	<< std::endl;
+}
+
 void Logger::Message(LogLevel level, const char* sourceFile, const char* func, unsigned int line, const char* fmt, ...)
 {
-	if ( (GLOBAL_MIN_LOG_LEVEL == Logger::UNSET && level < _minLevel) // no global level, use level from logger
-	  || (GLOBAL_MIN_LOG_LEVEL > Logger::UNSET && level < GLOBAL_MIN_LOG_LEVEL) ) // global level set, use global level
+	Logger::LogLevel globalLevel = static_cast<Logger::LogLevel>(int(GLOBAL_MIN_LOG_LEVEL));
+
+	if ( (globalLevel == Logger::UNSET && level < _minLevel) // no global level, use level from logger
+	  || (globalLevel > Logger::UNSET && level < globalLevel) ) // global level set, use global level
 		return;
 
 	const size_t max_msg_length = 1024;
@@ -156,38 +190,35 @@ void Logger::Message(LogLevel level, const char* sourceFile, const char* func, u
 	vsnprintf (msg, max_msg_length, fmt, args);
 	va_end (args);
 
-	auto repeatedSummary = [=]
+	const auto repeatedSummary = [&]
 	{
-		Logger::T_LOG_MESSAGE repMsg = _repeatMessage;
-		repMsg.message = "Previous line repeats " + QString::number(_repeatCount) + " times";
+		Logger::T_LOG_MESSAGE repMsg = RepeatMessage.localData();
+		repMsg.message = "Previous line repeats " + QString::number(RepeatCount.localData()) + " times";
+		repMsg.utime   = QDateTime::currentMSecsSinceEpoch();
 
-		emit newLogMessage(repMsg);
-
-		std::cout << QString("[" + repMsg.appName + " " + repMsg.loggerName + "] <" + LogLevelStrings[repMsg.level] + "> " + repMsg.message).toStdString() << std::endl;
-
+		write(repMsg);
 #ifndef _WIN32
 		if ( _syslogEnabled && repMsg.level >= Logger::WARNING )
-			syslog (LogLevelSysLog[repMsg.level], "Previous line repeats %d times", _repeatCount);
+			syslog (LogLevelSysLog[repMsg.level], "Previous line repeats %d times", RepeatCount.localData());
 #endif
 
-		_repeatCount = 0;
+		RepeatCount.setLocalData(0);
 	};
 
-	if (_repeatMessage.loggerName == _name
-		&& _repeatMessage.function == QString(func)
-		&& _repeatMessage.line == line
-		&& _repeatMessage.message == QString(msg))
+	if (RepeatMessage.localData().loggerName == _name  &&
+		RepeatMessage.localData().function == func &&
+		RepeatMessage.localData().message == msg   &&
+		RepeatMessage.localData().line == line)
 	{
-		if (_repeatCount >= _maxRepeatCountSize)
+		if (RepeatCount.localData() >= MaxRepeatCountSize)
 			repeatedSummary();
 		else
-			_repeatCount++;
-
-		return;
+			RepeatCount.setLocalData(RepeatCount.localData() + 1);
 	}
 	else
 	{
-		if (_repeatCount) repeatedSummary();
+		if (RepeatCount.localData())
+			repeatedSummary();
 
 		Logger::T_LOG_MESSAGE logMsg;
 
@@ -196,25 +227,17 @@ void Logger::Message(LogLevel level, const char* sourceFile, const char* func, u
 		logMsg.function    = QString(func);
 		logMsg.line        = line;
 		logMsg.fileName    = FileUtils::getBaseName(sourceFile);
-		time(&(logMsg.utime));
+		logMsg.utime       = QDateTime::currentMSecsSinceEpoch();
 		logMsg.message     = QString(msg);
 		logMsg.level       = level;
 		logMsg.levelString = LogLevelStrings[level];
 
-		emit newLogMessage(logMsg);
-
-		QString location;
-		if ( level == Logger::DEBUG )
-		{
-			location = "<" + logMsg.fileName + ":" + QString::number(line)+":"+ logMsg.function + "()> ";
-		}
-
-		std::cout << QString("[" + _appname + " " + _name + "] <" + LogLevelStrings[level] + "> " + location + msg).toStdString() << std::endl;
+		write(logMsg);
 #ifndef _WIN32
 		if ( _syslogEnabled && level >= Logger::WARNING )
 			syslog (LogLevelSysLog[level], "%s", msg);
 #endif
-		_repeatMessage = logMsg;
+		RepeatMessage.setLocalData(logMsg);
 	}
 }
 
@@ -222,14 +245,15 @@ LoggerManager::LoggerManager()
 	: QObject()
 	, _loggerMaxMsgBufferSize(200)
 {
+	_logMessageBuffer.reserve(_loggerMaxMsgBufferSize);
 }
 
-void LoggerManager::handleNewLogMessage(const Logger::T_LOG_MESSAGE &msg)
+void LoggerManager::handleNewLogMessage(const Logger::T_LOG_MESSAGE & msg)
 {
-	_logMessageBuffer.append(msg);
+	_logMessageBuffer.push_back(msg);
 	if (_logMessageBuffer.length() > _loggerMaxMsgBufferSize)
 	{
-		_logMessageBuffer.erase(_logMessageBuffer.begin());
+		_logMessageBuffer.pop_front();
 	}
 
 	emit newLogMessage(msg);
@@ -237,7 +261,6 @@ void LoggerManager::handleNewLogMessage(const Logger::T_LOG_MESSAGE &msg)
 
 LoggerManager* LoggerManager::getInstance()
 {
-	if (_instance == nullptr)
-		_instance = new LoggerManager();
-	return _instance;
+	static LoggerManager instance;
+	return &instance;
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Fixes #723 and #874 

Changes :
- Make logger thread safe.
- Include timestamp in logs.
- Make logs look a bit more cleaner.

Example :

```
2020-07-18T23:10:08.975 hyperiond LEDDEVICE    : <DEBUG> ProviderSpi.cpp:46:init() | _baudRate_Hz [3000000], _latchTime_ms [0]
2020-07-18T23:10:08.975 hyperiond LEDDEVICE    : <DEBUG> ProviderSpi.cpp:47:init() | _spiDataInvert [0], _spiMode [0]
2020-07-18T23:10:08.975 hyperiond LEDDEVICE    : <DEBUG> LedDeviceSk6812SPI.cpp:45:init() | whiteAlgorithm : subtract_minimum
2020-07-18T23:10:08.975 hyperiond LEDDEVICE    : <ERROR> Device disabled, device 'sk6812spi' signals error: 'Failed to open device (/dev/spidev0.0). Error message: No such file or directory'
2020-07-18T23:10:08.981 hyperiond EFFECTENGINE : <INFO> Run effect "Rainbow swirl fast" on channel 0
2020-07-18T23:10:08.981 hyperiond EFFECTENGINE : <DEBUG> EffectEngine.cpp:187:runEffectScript() | Start the effect: name [Rainbow swirl fast], smoothCfg [2]
2020-07-18T23:10:08.981 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:158:registerInput() | Register new input 'System/EFFECT' with priority 0 as inactive
2020-07-18T23:10:08.981 hyperiond HYPERION     : <INFO> Initial foreground effect 'Rainbow swirl fast' started
2020-07-18T23:10:08.982 hyperiond EFFECTENGINE : <INFO> Run effect "Warm mood blobs" on channel 254
2020-07-18T23:10:08.982 hyperiond EFFECTENGINE : <DEBUG> EffectEngine.cpp:187:runEffectScript() | Start the effect: name [Warm mood blobs], smoothCfg [2]
2020-07-18T23:10:08.982 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:158:registerInput() | Register new input 'System/EFFECT' with priority 254 as inactive
2020-07-18T23:10:08.982 hyperiond HYPERION     : <INFO> Inital background effect 'Warm mood blobs' started
2020-07-18T23:10:08.982 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:158:registerInput() | Register new input 'System/GRABBER' with priority 250 as inactive
2020-07-18T23:10:08.982 hyperiond COMPONENTREG : <DEBUG> ComponentRegister.cpp:36:setNewComponentState() | Framegrabber: enabled
2020-07-18T23:10:08.982 hyperiond BOBLIGHT     : <DEBUG> BoblightServer.cpp:28:BoblightServer() | Instance created
2020-07-18T23:10:08.985 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:91:handleSettingsUpdate() | Apply Webserver settings
2020-07-18T23:10:08.985 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:109:handleSettingsUpdate() | Set document root to: :/webconfig
2020-07-18T23:10:08.986 hyperiond WEBSERVER    : <INFO> Started on port 8090 name 'Hyperion Webserver'
2020-07-18T23:10:08.986 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:91:handleSettingsUpdate() | Apply Webserver settings
2020-07-18T23:10:08.986 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:109:handleSettingsUpdate() | Set document root to: :/webconfig
2020-07-18T23:10:08.992 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:175:handleSettingsUpdate() | Setup SSL certificate
2020-07-18T23:10:08.993 hyperiond WEBSERVER    : <DEBUG> WebServer.cpp:191:handleSettingsUpdate() | Setup private SSL key
2020-07-18T23:10:08.993 hyperiond WEBSERVER    : <INFO> Started on port 8092 name 'Hyperion Webserver'
2020-07-18T23:10:09.073 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:238:setInputImage() | Priority 0 is now active
2020-07-18T23:10:09.073 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:333:setCurrentTime() | Set visible priority to 0
2020-07-18T23:10:09.087 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:198:setInput() | Priority 254 is now active
2020-07-18T23:10:09.141 hyperiond X11          : <DEBUG> GrabberWrapper.cpp:49:start() | Grabber start()
2020-07-18T23:10:09.141 hyperiond HYPERION     : <INFO> Hyperion instance 'First LED Hardware instance' has been started
2020-07-18T23:10:09.250 hyperiond X11GRABBER   : <INFO> Update of screen resolution: [0x0]  to [1920x1017]
2020-07-18T23:10:09.250 hyperiond X11GRABBER   : <INFO> Using XRender for grabbing
2020-07-18T23:10:09.250 hyperiond X11GRABBER   : <INFO> Update output image resolution: [0x0]  to [1920x1017]
2020-07-18T23:10:09.251 hyperiond X11GRABBER   : <INFO> Capture interface is now enabled
2020-07-18T23:10:09.321 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:238:setInputImage() | Priority 250 is now active
2020-07-18T23:10:12.138 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:298:setCurrentTime() | Timeout clear for priority 0
2020-07-18T23:10:12.390 hyperiond HYPERION     : <DEBUG> PriorityMuxer.cpp:333:setCurrentTime() | Set visible priority to 250

```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
