### PR TITLE
Fix Qt screenhot crash

### DIFF
--- a/include/utils/ImageData.h
+++ b/include/utils/ImageData.h
@@ -136,7 +136,9 @@ public:
 
 	void toRgb(ImageData<ColorRgb>& image)
 	{
-		image.resize(_width, _height);
+		if (image.width() != _width || image.height() != _height)
+			image.resize(_width, _height);
+
 		const unsigned imageSize = _width * _height;
 
 		for (unsigned idx = 0; idx < imageSize; idx++)

--- a/libsrc/grabber/qt/QtGrabber.cpp
+++ b/libsrc/grabber/qt/QtGrabber.cpp
@@ -101,6 +101,7 @@ int QtGrabber::grabFrame(Image<ColorRgb> & image)
 	QPixmap originalPixmap = _screen->grabWindow(0, _src_x, _src_y, _src_x_max, _src_y_max);
 	QPixmap resizedPixmap = originalPixmap.scaled(_width,_height);
 	QImage imageFrame = resizedPixmap.toImage().convertToFormat( QImage::Format_RGB888);
+	image.resize(imageFrame.width(), imageFrame.height());
 
 	for (int y=0; y<imageFrame.height(); ++y)
 		for (int x=0; x<imageFrame.width(); ++x)

--- a/libsrc/utils/ImageResampler.cpp
+++ b/libsrc/utils/ImageResampler.cpp
@@ -60,7 +60,9 @@ void ImageResampler::processImage(const uint8_t * data, int width, int height, i
 	// calculate the output size
 	int outputWidth = (width - _cropLeft - cropRight - (_horizontalDecimation >> 1) + _horizontalDecimation - 1) / _horizontalDecimation;
 	int outputHeight = (height - _cropTop - cropBottom - (_verticalDecimation >> 1) + _verticalDecimation - 1) / _verticalDecimation;
-	outputImage.resize(outputWidth, outputHeight);
+
+	if (outputImage.width() != outputWidth || outputImage.height() != outputHeight)
+		outputImage.resize(outputWidth, outputHeight);
 
 	for (int yDest = 0, ySource = _cropTop + (_verticalDecimation >> 1); yDest < outputHeight; ySource += _verticalDecimation, ++yDest)
 	{


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

resize() is forgotten for image before using

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
