### PR TITLE
Fix 'Restart' RPC command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Make logs look a bit more cleaner
 - Decrease compile time (#886)
 - Fix some data synchronization error (#890)
+- Fix RPC restart of Hyperion (#894)
 
 ### Removed
 

--- a/include/commandline/Parser.h
+++ b/include/commandline/Parser.h
@@ -71,6 +71,28 @@ public:
 		return *option;
 	}
 
+	template<class OptionT>
+	OptionT &addHidden(
+		const char shortOption,
+		const QString longOption,
+		const QString description,
+		const QString default_ = QString())
+	{
+		OptionT * option = new OptionT(
+			_getNames(shortOption, longOption),
+			_getDescription(description, default_),
+			longOption,
+			default_);
+		#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+		option->setFlags(QCommandLineOption::HiddenFromHelp);
+		#else
+		option->setHidden(true);
+		#endif
+
+		addOption(option);
+		return *option;
+	}
+
 	Parser(QString description=QString())
 	{
 		if(description.size())setApplicationDescription(description);

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -868,12 +868,16 @@ void JsonAPI::handleConfigCommand(const QJsonObject &message, const QString &com
 	{
 		if (_adminAuthorized)
 		{
-			_hyperion->freeObjects(true);
+			Debug(_log, "Restarting due to RPC command");
+
 			Process::restartHyperion();
-			sendErrorReply("failed to restart hyperion", full_command, tan);
+
+			sendSuccessReply(command + "-" + subcommand, tan);
 		}
 		else
+		{
 			sendErrorReply("No Authorization", command, tan);
+		}
 	}
 	else
 	{

--- a/libsrc/utils/Process.cpp
+++ b/libsrc/utils/Process.cpp
@@ -18,6 +18,7 @@ QByteArray command_exec(QString /*cmd*/, QByteArray /*data*/)
 #include <utils/Logger.h>
 
 #include <QCoreApplication>
+#include <QProcess>
 #include <QStringList>
 
 #include <unistd.h>
@@ -31,26 +32,20 @@ namespace Process {
 void restartHyperion(bool asNewProcess)
 {
 	Logger* log = Logger::getInstance("Process");
+	Info(log, "Restarting hyperion ...");
+
 	std::cout << std::endl
 		<< "      *******************************************" << std::endl
 		<< "      *      hyperion will restart now          *" << std::endl
 		<< "      *******************************************" << std::endl << std::endl;
 
+	auto arguments = QCoreApplication::arguments();
+	if (!arguments.contains("--wait-hyperion"))
+		arguments << "--wait-hyperion";
 
-	QStringList qargs = QCoreApplication::arguments();
-	int size = qargs.size();
-	char *args[size+1];
-	args[size] = nullptr;
-	for(int i=0; i<size; i++)
-	{
-		int str_size = qargs[i].toLocal8Bit().size();
-		args[i] = new char[str_size+1];
-		strncpy(args[i], qargs[i].toLocal8Bit().constData(),str_size);
-		args[i][str_size] = '\0';
-	}
+	QProcess::startDetached(QCoreApplication::applicationFilePath(), arguments);
 
-	execv(args[0],args);
-	Error(log, "error while restarting hyperion");
+	QCoreApplication::quit();
 }
 
 QByteArray command_exec(QString cmd, QByteArray data)

--- a/src/hyperiond/detectProcess.h
+++ b/src/hyperiond/detectProcess.h
@@ -61,7 +61,7 @@ QStringList getProcessIdsByProcessName(const char *processName)
 			continue;
 		}
 
-		QFile cmdline("/proc/" + pid + "/cmdline");
+		QFile cmdline("/proc/" + pid + "/comm");
 		if (!cmdline.open(QFile::ReadOnly | QFile::Text))
 		{
 			/* Can not open cmdline file */


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
**restart** RPC fails because ````execve```` doesn't return and blocks the process. Hence we don't return a response to the caller. Also, ````hyperion->freeObjects()```` is called on a totally wrong thread, which causes a crash.

This PR introduces a different path for restarting Hyperion. It starts a new instance of Hyperion in a detached state with a special internal command line argument (**--wait-hyperion**). New instance sees that **--wait-hyperion** argument is set and waits until previous Hyperion exits. Old instance gracefully quits application. Then new instance continues with normal execution.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [x] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
