### PR TITLE
set zlib back to system ignore list/revert pr #871 ....

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -27,6 +27,10 @@ macro(DeployUnix TARGET)
 			"libz"
 		)
 
+		if(ENABLE_DISPMANX)
+			list(APPEND SYSTEM_LIBS_SKIP "libcec")
+		endif()
+
 		if (APPLE)
 			set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
 		endif(APPLE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -24,6 +24,7 @@ macro(DeployUnix TARGET)
 			"libusb-1"
 			"libutil"
 			"libX11"
+			"libz"
 		)
 
 		if (APPLE)
@@ -153,35 +154,14 @@ macro(DeployUnix TARGET)
 
 		endif()
 
-		# Pack Python modules to pythonXX.zip or copy to 'share/hyperion/lib/python'
+		# Copy Python modules to 'share/hyperion/lib/python'
 		if (PYTHON_MODULES_DIR)
-			# Since version 3.3.2 CMake has the functionality to generate a zip file built-in.
-			if (NOT CMAKE_VERSION VERSION_LESS "3.3.2")
 
-				file(GLOB PYTHON_MODULE_FILES RELATIVE "${PYTHON_MODULES_DIR}" "${PYTHON_MODULES_DIR}/*")
-				set(PYTHON_ZIP "python${PYTHON_VERSION_MAJOR_MINOR}.zip")
-
-				execute_process(
-					COMMAND "${CMAKE_COMMAND}" "-E" "tar" "cf" "${CMAKE_BINARY_DIR}/${PYTHON_ZIP}" "--format=zip" ${PYTHON_MODULE_FILES}
-					WORKING_DIRECTORY "${PYTHON_MODULES_DIR}"
-					OUTPUT_QUIET
-				)
-
-				install(
-					FILES "${CMAKE_BINARY_DIR}/${PYTHON_ZIP}"
-					DESTINATION "share/hyperion/bin"
-					COMPONENT "Hyperion"
-				)
-
-			else()
-
-				install(
-					DIRECTORY ${PYTHON_MODULES_DIR}/
-					DESTINATION "share/hyperion/lib/python"
-					COMPONENT "Hyperion"
-				)
-
-			endif()
+			install(
+				DIRECTORY ${PYTHON_MODULES_DIR}/
+				DESTINATION "share/hyperion/lib/python"
+				COMPONENT "Hyperion"
+			)
 
 		endif(PYTHON_MODULES_DIR)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- The library "libz" is no longer included in the finished packages
- PR #871  has been undone because of [errors with the QT plugin](https://github.com/hyperion-project/hyperion.ng/issues/903#issuecomment-663840462).
- The libcec library is no longer included in the finished RPi packages

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
