### PR TITLE
feat(win): Add binary meta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,16 +296,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 	endif()
 endif()
 
-# Windows specific
-if(WIN32)
-	# Path to .rc icon file for add_executable() calls
-	SET ( WIN_RC_ICON_FILE ${CMAKE_SOURCE_DIR}/cmake/nsis/icon.rc)
-	# Force gui app
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
-endif()
-
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -v")
-
 # Use GNU gold linker if available
 if (NOT WIN32)
 	include (${CMAKE_CURRENT_SOURCE_DIR}/cmake/LDGold.cmake)

--- a/cmake/nsis/icon.rc
+++ b/cmake/nsis/icon.rc
@@ -1,1 +1,0 @@
-IDI_ICON1 ICON DISCARDABLE "installer.ico"

--- a/cmake/win/win.rc.in
+++ b/cmake/win/win.rc.in
@@ -1,0 +1,34 @@
+IDI_ICON1 ICON DISCARDABLE "${WIN_RC_ICON_PATH}"
+1 VERSIONINFO
+ FILEVERSION ${HYPERION_VERSION_MAJOR},${HYPERION_VERSION_MINOR},${HYPERION_VERSION_PATCH},0
+ PRODUCTVERSION ${HYPERION_VERSION_MAJOR},${HYPERION_VERSION_MINOR},${HYPERION_VERSION_PATCH},0
+ FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x4L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "hyperion-project"
+            VALUE "Comments", "www.hyperion-project.org"
+            VALUE "FileDescription", "Hyperion Ambient Lighting"
+            VALUE "FileVersion", "${HYPERION_VERSION}"
+            VALUE "InternalName", "Hyperion"
+            VALUE "LegalCopyright", "MIT"
+            VALUE "OriginalFilename", "${BINARY_NAME}"
+            VALUE "ProductName", "Hyperion Ambient Lighting"
+            VALUE "ProductVersion", "${HYPERION_VERSION}"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/cmake/win/win_rc.cmake
+++ b/cmake/win/win_rc.cmake
@@ -1,0 +1,15 @@
+# process a .rc file for windows
+# Provides (BINARY_NAME)_WIN_RC_PATH with path to generated file
+function(generate_win_rc_file BINARY_NAME)
+	# target path to store generated files
+	set(TARGET_PATH ${CMAKE_BINARY_DIR}/win_rc_file/${BINARY_NAME})
+	# assets
+	string(REPLACE "/" "\\\\" WIN_RC_ICON_PATH ${CMAKE_SOURCE_DIR}/cmake/nsis/installer.ico)
+	# configure the rc file
+	configure_file(
+		${CMAKE_SOURCE_DIR}/cmake/win/win.rc.in
+		${TARGET_PATH}/win.rc
+	)
+    # provide var for parent scope
+  	set(${BINARY_NAME}_WIN_RC_PATH ${TARGET_PATH}/win.rc PARENT_SCOPE)
+endfunction()

--- a/src/hyperion-qt/CMakeLists.txt
+++ b/src/hyperion-qt/CMakeLists.txt
@@ -17,10 +17,16 @@ set(Hyperion_QT_SOURCES
 	hyperion-qt.cpp
 )
 
+# generate windows .rc file for this binary
+if (WIN32)
+	include(${CMAKE_SOURCE_DIR}/cmake/win/win_rc.cmake)
+	generate_win_rc_file(${PROJECT_NAME})
+endif()
+
 add_executable(${PROJECT_NAME}
 	${Hyperion_QT_HEADERS}
 	${Hyperion_QT_SOURCES}
-	${WIN_RC_ICON_FILE}
+	${${PROJECT_NAME}_WIN_RC_PATH}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/hyperion-remote/CMakeLists.txt
+++ b/src/hyperion-remote/CMakeLists.txt
@@ -17,10 +17,16 @@ set(hyperion-remote_SOURCES
 	hyperion-remote.cpp
 	JsonConnection.cpp)
 
+# generate windows .rc file for this binary
+if (WIN32)
+	include(${CMAKE_SOURCE_DIR}/cmake/win/win_rc.cmake)
+	generate_win_rc_file(${PROJECT_NAME})
+endif()
+
 add_executable(${PROJECT_NAME}
 	${hyperion-remote_HEADERS}
 	${hyperion-remote_SOURCES}
-	${WIN_RC_ICON_FILE}
+	${${PROJECT_NAME}_WIN_RC_PATH}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 
 find_package(Qt5Widgets REQUIRED)
 
+# generate windows .rc file for this binary
+if (WIN32)
+	include(${CMAKE_SOURCE_DIR}/cmake/win/win_rc.cmake)
+	generate_win_rc_file(hyperiond)
+endif()
+
 add_executable(hyperiond
 	console.h
 	hyperiond.h
@@ -15,8 +21,13 @@ add_executable(hyperiond
 	hyperiond.cpp
 	systray.cpp
 	main.cpp
-	${WIN_RC_ICON_FILE}
+	${hyperiond_WIN_RC_PATH}
 )
+
+# promote hyperiond as GUI app
+if (WIN32)
+	target_link_options(hyperiond PUBLIC /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup)
+endif()
 
 target_link_libraries(hyperiond
 	commandline


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
- Add more meta to all binaries
- Just `hyperiond` is now promoted to be a gui app, `hyperion-remote` and `hyperion-qt` run now properly again in terminal scope (no window and proper output)
- Note: It's not possible to omit the language field
The file view
![dialog](https://user-images.githubusercontent.com/15967679/89125542-7b522d00-d4df-11ea-9a21-361cf096d4f2.PNG)

The "Autostart-App" page of Windows 10. Previous it was just "hyperiond"
![start-up](https://user-images.githubusercontent.com/15967679/89125581-c9ffc700-d4df-11ea-9270-0c530ade32ff.PNG)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
