### PR TITLE
Pass primitive types by value

### DIFF
--- a/include/api/API.h
+++ b/include/api/API.h
@@ -46,14 +46,14 @@ public:
     /// @param localConnection Is this a local network connection? Use utils/NetOrigin to check that
     /// @param parent          Parent QObject
     ///
-    API(Logger *log, const bool &localConnection, QObject *parent);
+    API(Logger *log, bool localConnection, QObject *parent);
 
 protected:
     ///
     /// @brief Initialize the API
     /// This call is REQUIRED!
     ///
-    void init(void);
+    void init();
 
     ///
     /// @brief Set a single color
@@ -62,7 +62,7 @@ protected:
     /// @param[in] timeout_ms The time the leds are set to the given color [ms]
     /// @param[in] origin   The setter
     ///
-    void setColor(const int &priority, const std::vector<uint8_t> &ledColors, const int &timeout_ms = -1, const QString &origin = "API", const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setColor(int priority, const std::vector<uint8_t> &ledColors, int timeout_ms = -1, const QString &origin = "API", hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set a image
@@ -72,7 +72,7 @@ protected:
     /// @param      callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     /// @return True on success
     ///
-    bool setImage(ImageCmdData &data, hyperion::Components comp, QString &replyMsg, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    bool setImage(ImageCmdData &data, hyperion::Components comp, QString &replyMsg, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Clear a priority in the Muxer, if -1 all priorities are cleared
@@ -81,7 +81,7 @@ protected:
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     /// @return  True on success
     ///
-    bool clearPriority(const int &priority, QString &replyMsg, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    bool clearPriority(int priority, QString &replyMsg, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set a new component state
@@ -91,21 +91,21 @@ protected:
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     /// @ return True on success
     ///
-    bool setComponentState(const QString &comp, bool &compState, QString &replyMsg, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    bool setComponentState(const QString &comp, bool &compState, QString &replyMsg, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set a ledToImageMapping type
     /// @param type       mapping type string
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     ///
-    void setLedMappingType(const int &type, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setLedMappingType(int type, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set the 2D/3D modes type
     /// @param mode       The VideoMode
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     ///
-    void setVideoMode(const VideoMode &mode, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setVideoMode(VideoMode mode, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set an effect
@@ -113,21 +113,21 @@ protected:
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     /// REQUIRED dat fields: effectName, priority, duration, origin
     ///
-    void setEffect(const EffectCmdData &dat, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setEffect(const EffectCmdData &dat, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set source auto select enabled or disabled
     /// @param sate       The new state
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     ///
-    void setSourceAutoSelect(const bool state, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setSourceAutoSelect(bool state, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Set the visible priority to given priority
     /// @param priority   The priority to set
     /// @param callerComp The HYPERION COMPONENT that calls this function! e.g. PROT/FLATBUF
     ///
-    void setVisiblePriority(const int &priority, const hyperion::Components &callerComp = hyperion::COMP_INVALID);
+    void setVisiblePriority(int priority, hyperion::Components callerComp = hyperion::COMP_INVALID);
 
     ///
     /// @brief Register a input or update the meta data of a previous register call
@@ -138,21 +138,21 @@ protected:
     /// @param[in] owner       Specific owner string, might be empty
     /// @param[in] callerComp  The component that call this (e.g. PROTO/FLAT)
     ///
-    void registerInput(const int &priority, const hyperion::Components &component, const QString &origin, const QString &owner, const hyperion::Components &callerComp);
+    void registerInput(int priority, hyperion::Components component, const QString &origin, const QString &owner, hyperion::Components callerComp);
 
     ///
     /// @brief Revoke a registerInput() call by priority. We maintain all registered priorities in this scope
     /// ATTENTION: This is MANDATORY if you change (priority change) or stop(clear/timeout) DURING lifetime. If this class destructs it's not needed
     /// @param priority  The priority to unregister
     ///
-    void unregisterInput(const int &priority);
+    void unregisterInput(int priority);
 
     ///
     /// @brief Handle the instance switching
     /// @param inst  The requested instance
     /// @return True on success else false
     ///
-    bool setHyperionInstance(const quint8 &inst);
+    bool setHyperionInstance(quint8 inst);
 
     ///
     /// @brief Get all contrable components and their state
@@ -169,19 +169,19 @@ protected:
     /// @brief Get all instances data
     /// @return The instance data
     ///
-    QVector<QVariantMap> getAllInstanceData(void);
+    QVector<QVariantMap> getAllInstanceData();
 
     ///
     /// @brief Start instance
     /// @param index  The instance index
     ///
-    void startInstance(const quint8 &index);
+    void startInstance(quint8 index);
 
     ///
     /// @brief Stop instance
     /// @param index  The instance index
     ///
-    void stopInstance(const quint8 &index);
+    void stopInstance(quint8 index);
 
     //////////////////////////////////
     /// AUTH / ADMINISTRATION METHODS
@@ -193,7 +193,7 @@ protected:
     /// @param replyMsg The reply Msg
     /// @return False with reply
     ///
-    bool deleteInstance(const quint8 &index, QString &replyMsg);
+    bool deleteInstance(quint8 index, QString &replyMsg);
 
     ///
     /// @brief Create instance. Requires ADMIN ACCESS
@@ -208,7 +208,7 @@ protected:
     /// @param name  With given name
     /// @return False with reply
     ///
-    QString setInstanceName(const quint8 &index, const QString &name);
+    QString setInstanceName(quint8 index, const QString &name);
 
     ///
     /// @brief Delete an effect. Requires ADMIN ACCESS
@@ -292,7 +292,7 @@ protected:
     /// @param id     The id fo the request
     /// @param accept True when it should be accepted, else false
     /// @return True on success
-    bool handlePendingTokenRequest(const QString &id, const bool accept);
+    bool handlePendingTokenRequest(const QString &id, bool accept);
 
     ///
     /// @brief Get the current List of Tokens. Requires ADMIN ACCESS
@@ -379,7 +379,7 @@ signals:
     /// @param  comment The comment that was part of the request
     /// @param  id      The id that was part of the request
     ///
-    void onTokenResponse(const bool &success, const QString &token, const QString &comment, const QString &id);
+    void onTokenResponse(bool success, const QString &token, const QString &comment, const QString &id);
 
 private slots:
     ///
@@ -396,7 +396,7 @@ private slots:
     /// @param  comment The comment that was part of the request
     /// @param  id      The id that was part of the request
     ///
-    void checkTokenResponse(const bool &success, QObject *caller, const QString &token, const QString &comment, const QString &id);
+    void checkTokenResponse(bool success, QObject *caller, const QString &token, const QString &comment, const QString &id);
 
 private:
     void stopDataConnectionss();

--- a/include/api/JsonAPI.h
+++ b/include/api/JsonAPI.h
@@ -30,7 +30,7 @@ public:
 	/// @param localConnection True when the sender has origin home network
 	/// @param noListener  if true, this instance won't listen for hyperion push events
 	///
-	JsonAPI(QString peerAddress, Logger *log, const bool &localConnection, QObject *parent, bool noListener = false);
+	JsonAPI(QString peerAddress, Logger *log, bool localConnection, QObject *parent, bool noListener = false);
 
 	///
 	/// Handle an incoming JSON message
@@ -42,7 +42,7 @@ public:
 	///
 	/// @brief Initialization steps
 	///
-	void initialize(void);
+	void initialize();
 
 public slots:
 	///
@@ -77,7 +77,7 @@ private slots:
 	/// @param  comment The comment that was part of the request
 	/// @param  id      The id that was part of the request
 	///
-	void handleTokenResponse(const bool &success, const QString &token, const QString &comment, const QString &id);
+	void handleTokenResponse(bool success, const QString &token, const QString &comment, const QString &id);
 
 	///
 	/// @brief Handle whenever the state of a instance (HyperionIManager) changes according to enum instanceState
@@ -85,7 +85,7 @@ private slots:
 	/// @param instance      The index of instance
 	/// @param name          The name of the instance, just available with H_CREATED
 	///
-	void handleInstanceStateChange(const InstanceState &state, const quint8 &instance, const QString &name = QString());
+	void handleInstanceStateChange(InstanceState state, quint8 instance, const QString &name = QString());
 
 signals:
 	///
@@ -131,151 +131,151 @@ private:
 	/// @param forced  indicate if it was a forced switch by system
 	/// @return true on success. false if not found
 	///
-	bool handleInstanceSwitch(const quint8 &instance = 0, const bool &forced = false);
+	bool handleInstanceSwitch(quint8 instance = 0, bool forced = false);
 
 	///
 	/// Handle an incoming JSON Color message
 	///
 	/// @param message the incoming message
 	///
-	void handleColorCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleColorCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Image message
 	///
 	/// @param message the incoming message
 	///
-	void handleImageCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleImageCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Effect message
 	///
 	/// @param message the incoming message
 	///
-	void handleEffectCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleEffectCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Effect message (Write JSON Effect)
 	///
 	/// @param message the incoming message
 	///
-	void handleCreateEffectCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleCreateEffectCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Effect message (Delete JSON Effect)
 	///
 	/// @param message the incoming message
 	///
-	void handleDeleteEffectCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleDeleteEffectCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON System info message
 	///
 	/// @param message the incoming message
 	///
-	void handleSysInfoCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleSysInfoCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Server info message
 	///
 	/// @param message the incoming message
 	///
-	void handleServerInfoCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleServerInfoCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Clear message
 	///
 	/// @param message the incoming message
 	///
-	void handleClearCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleClearCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Clearall message
 	///
 	/// @param message the incoming message
 	///
-	void handleClearallCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleClearallCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Adjustment message
 	///
 	/// @param message the incoming message
 	///
-	void handleAdjustmentCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleAdjustmentCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON SourceSelect message
 	///
 	/// @param message the incoming message
 	///
-	void handleSourceSelectCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleSourceSelectCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON GetConfig message and check subcommand
 	///
 	/// @param message the incoming message
 	///
-	void handleConfigCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleConfigCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON GetSchema message from handleConfigCommand()
 	///
 	/// @param message the incoming message
 	///
-	void handleSchemaGetCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleSchemaGetCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON SetConfig message from handleConfigCommand()
 	///
 	/// @param message the incoming message
 	///
-	void handleConfigSetCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleConfigSetCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON Component State message
 	///
 	/// @param message the incoming message
 	///
-	void handleComponentStateCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleComponentStateCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON Led Colors message
 	///
 	/// @param message the incoming message
 	///
-	void handleLedColorsCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleLedColorsCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON Logging message
 	///
 	/// @param message the incoming message
 	///
-	void handleLoggingCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleLoggingCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON Processing message
 	///
 	/// @param message the incoming message
 	///
-	void handleProcessingCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleProcessingCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON VideoMode message
 	///
 	/// @param message the incoming message
 	///
-	void handleVideoModeCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleVideoModeCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON plugin message
 	///
 	/// @param message the incoming message
 	///
-	void handleAuthorizeCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleAuthorizeCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON instance message
 	///
 	/// @param message the incoming message
 	///
-	void handleInstanceCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleInstanceCommand(const QJsonObject &message, const QString &command, int tan);
 
 	/// Handle an incoming JSON Led Device message
 	///
 	/// @param message the incoming message
 	///
-	void handleLedDeviceCommand(const QJsonObject &message, const QString &command, const int tan);
+	void handleLedDeviceCommand(const QJsonObject &message, const QString &command, int tan);
 
 	///
 	/// Handle an incoming JSON message of unknown type
@@ -285,22 +285,22 @@ private:
 	///
 	/// Send a standard reply indicating success
 	///
-	void sendSuccessReply(const QString &command = "", const int tan = 0);
+	void sendSuccessReply(const QString &command = "", int tan = 0);
 
 	///
 	/// Send a standard reply indicating success with data
 	///
-	void sendSuccessDataReply(const QJsonDocument &doc, const QString &command = "", const int &tan = 0);
+	void sendSuccessDataReply(const QJsonDocument &doc, const QString &command = "", int tan = 0);
 
 	///
 	/// Send an error message back to the client
 	///
 	/// @param error String describing the error
 	///
-	void sendErrorReply(const QString &error, const QString &command = "", const int tan = 0);
+	void sendErrorReply(const QString &error, const QString &command = "", int tan = 0);
 
 	///
 	/// @brief Kill all signal/slot connections to stop possible data emitter
 	///
-	void stopDataConnections(void);
+	void stopDataConnections();
 };

--- a/include/api/JsonCB.h
+++ b/include/api/JsonCB.h
@@ -35,7 +35,7 @@ public:
 	/// @param unsubscribe  Revert subscription
 	/// @return      True on success, false if not found
 	///
-	bool subscribeFor(const QString& cmd, const bool & unsubscribe = false);
+	bool subscribeFor(const QString& cmd, bool unsubscribe = false);
 
 	///
 	/// @brief Get all possible commands to subscribe for
@@ -52,7 +52,7 @@ public:
 	///
 	/// @brief Reset subscriptions, disconnect all signals
 	///
-	void resetSubscriptions(void);
+	void resetSubscriptions();
 
 	///
 	/// @brief Re-apply all current subs to a new Hyperion instance, the connections to the old instance will be dropped
@@ -70,7 +70,7 @@ private slots:
 	///
 	/// @brief handle component state changes
 	///
-	void handleComponentState(const hyperion::Components comp, const bool state);
+	void handleComponentState(hyperion::Components comp, bool state);
 #ifdef ENABLE_AVAHI
 	///
 	/// @brief handle emits from bonjour wrapper
@@ -86,7 +86,7 @@ private slots:
 	///
 	/// @brief Handle imageToLedsMapping updates
 	///
-	void handleImageToLedsMappingChange(const int& mappingType);
+	void handleImageToLedsMappingChange(int mappingType);
 
 	///
 	/// @brief Handle the adjustment update
@@ -97,7 +97,7 @@ private slots:
 	/// @brief Handle video mode change
 	/// @param mode  The new videoMode
 	///
-	void handleVideoModeChange(const VideoMode& mode);
+	void handleVideoModeChange(VideoMode mode);
 
 	///
 	/// @brief Handle effect list change
@@ -109,14 +109,14 @@ private slots:
 	/// @param type   The settings type from enum
 	/// @param data   The data as QJsonDocument
 	///
-	void handleSettingsChange(const settings::type& type, const QJsonDocument& data);
+	void handleSettingsChange(settings::type type, const QJsonDocument& data);
 
 	///
 	/// @brief Handle led config specific updates (required for led color streaming with positional display)
 	/// @param type   The settings type from enum
 	/// @param data   The data as QJsonDocument
 	///
-	void handleLedsConfigChange(const settings::type& type, const QJsonDocument& data);
+	void handleLedsConfigChange(settings::type type, const QJsonDocument& data);
 
 	///
 	/// @brief Handle Hyperion instance manager change

--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -49,7 +49,7 @@ namespace hyperion
 		/// It's not possible to enable bb from this method, if the user requsted a disable!
 		/// @param disable  The new state
 		///
-		void setHardDisable(const bool& disable);
+		void setHardDisable(bool disable);
 
 		///
 		/// Processes the image. This performs detecion of black-border on the given image and
@@ -100,12 +100,12 @@ namespace hyperion
 		/// @param type   settingyType from enum
 		/// @param config configuration object
 		///
-		void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+		void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 		///
 		/// @brief Handle component state changes, it's not possible for BB to be enabled, when a hardDisable is active
 		///
-		void handleCompStateChangeRequest(const hyperion::Components component, bool enable);
+		void handleCompStateChangeRequest(hyperion::Components component, bool enable);
 
 	private:
 		/// Hyperion instance

--- a/include/boblightserver/BoblightServer.h
+++ b/include/boblightserver/BoblightServer.h
@@ -54,14 +54,14 @@ public slots:
 	///
 	void stop();
 
-	void compStateChangeRequest(const hyperion::Components component, bool enable);
+	void compStateChangeRequest(hyperion::Components component, bool enable);
 
 	///
 	/// @brief Handle settings update from Hyperion Settingsmanager emit or this constructor
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private slots:
 	///

--- a/include/bonjour/bonjourserviceregister.h
+++ b/include/bonjour/bonjourserviceregister.h
@@ -47,11 +47,11 @@ public:
     BonjourServiceRegister(QObject *parent = 0);
     ~BonjourServiceRegister();
 
-	void registerService(const QString& service, const int& port);
+	void registerService(const QString& service, int port);
     void registerService(const BonjourRecord &record, quint16 servicePort, std::vector<std::pair<std::string, std::string>> txt = std::vector<std::pair<std::string, std::string>>());
     inline BonjourRecord registeredRecord() const {return finalRecord; }
 
-	const quint16 & getPort() { return _port; };
+	quint16 getPort() const { return _port; };
 
 signals:
     void error(DNSServiceErrorType error);

--- a/include/db/InstanceTable.h
+++ b/include/db/InstanceTable.h
@@ -71,7 +71,7 @@ public:
 	/// @param  inst  The id that has been assigned
 	/// @return True on success else false
 	///
-	inline bool deleteInstance(const quint8& inst)
+	inline bool deleteInstance(quint8 inst)
 	{
 		VectorPair cond;
 		cond.append(CPair("instance",inst));
@@ -91,7 +91,7 @@ public:
 	/// @param  name  The new name of the instance
 	/// @return True on success else false (instance not found)
 	///
-	inline bool saveName(const quint8& inst, const QString& name)
+	inline bool saveName(quint8 inst, const QString& name)
 	{
 		VectorPair fcond;
 		fcond.append(CPair("friendly_name",name));
@@ -119,7 +119,7 @@ public:
 	/// @param justEnabled  return just enabled instances if true
 	/// @return The found instances
 	///
-	inline QVector<QVariantMap> getAllInstances(const bool& justEnabled = false)
+	inline QVector<QVariantMap> getAllInstances(bool justEnabled = false)
 	{
 		QVector<QVariantMap> results;
 		getRecords(results, QStringList(), QStringList() << "instance ASC");
@@ -143,7 +143,7 @@ public:
 	/// @param[in]  user   The user id
 	/// @return     true on success else false
 	///
-	inline bool instanceExist(const quint8& inst)
+	inline bool instanceExist(quint8 inst)
 	{
 		VectorPair cond;
 		cond.append(CPair("instance",inst));
@@ -155,7 +155,7 @@ public:
 	/// @param index  The index to search for
 	/// @return The name of this index, may return NOT FOUND if not found
 	///
-	inline const QString getNamebyIndex(const quint8 index)
+	inline const QString getNamebyIndex(quint8 index)
 	{
 		QVariantMap results;
 		VectorPair cond;
@@ -170,7 +170,7 @@ public:
 	/// @brief Update 'last_use' timestamp
 	/// @param inst  The instance to update
 	///
-	inline void setLastUse(const quint8& inst)
+	inline void setLastUse(quint8 inst)
 	{
 		VectorPair cond;
 		cond.append(CPair("instance", inst));
@@ -184,7 +184,7 @@ public:
 	/// @param inst     The instance to update
 	/// @param newState True when enabled else false
 	///
-	inline void setEnable(const quint8& inst, const bool& newState)
+	inline void setEnable(quint8 inst, bool newState)
 	{
 		VectorPair cond;
 		cond.append(CPair("instance", inst));
@@ -198,7 +198,7 @@ public:
 	/// @param inst  The instance to get
 	/// @return True when enabled else false
 	///
-	inline bool isEnabled(const quint8& inst)
+	inline bool isEnabled(quint8 inst)
 	{
 		VectorPair cond;
 		cond.append(CPair("instance", inst));

--- a/include/db/SettingsTable.h
+++ b/include/db/SettingsTable.h
@@ -15,7 +15,7 @@ class SettingsTable : public DBManager
 
 public:
 	/// construct wrapper with settings table
-	SettingsTable(const quint8& instance, QObject* parent = nullptr)
+	SettingsTable(quint8 instance, QObject* parent = nullptr)
 		: DBManager(parent)
 		, _hyperion_inst(instance)
 	{

--- a/include/effectengine/Effect.h
+++ b/include/effectengine/Effect.h
@@ -64,8 +64,8 @@ public:
 	QJsonObject getArgs() const { return _args; }
 
 signals:
-	void setInput(const int priority, const std::vector<ColorRgb> &ledColors, const int timeout_ms, const bool &clearEffect);
-	void setInputImage(const int priority, const Image<ColorRgb> &image, const int timeout_ms, const bool &clearEffect);
+	void setInput(int priority, const std::vector<ColorRgb> &ledColors, int timeout_ms, bool clearEffect);
+	void setInputImage(int priority, const Image<ColorRgb> &image, int timeout_ms, bool clearEffect);
 
 private:
 

--- a/include/effectengine/EffectFileHandler.h
+++ b/include/effectengine/EffectFileHandler.h
@@ -47,7 +47,7 @@ public slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 signals:
 	///

--- a/include/flatbufserver/FlatBufferConnection.h
+++ b/include/flatbufserver/FlatBufferConnection.h
@@ -35,7 +35,7 @@ public:
 	/// @param address The address of the Hyperion server (for example "192.168.0.32:19444)
 	/// @param skipReply  If true skip reply
 	///
-	FlatBufferConnection(const QString& origin, const QString & address, const int& priority, const bool& skipReply);
+	FlatBufferConnection(const QString& origin, const QString & address, int priority, bool skipReply);
 
 	///
 	/// @brief Destructor
@@ -43,7 +43,7 @@ public:
 	~FlatBufferConnection();
 
 	/// @brief Do not read reply messages from Hyperion if set to true
-	void setSkipReply(const bool& skip);
+	void setSkipReply(bool skip);
 
 	///
 	/// @brief Register a new priority with given origin
@@ -100,7 +100,7 @@ signals:
 	///
 	/// @brief emits when a new videoMode was requested from flatbuf client
 	///
-	void setVideoMode(const VideoMode videoMode);
+	void setVideoMode(VideoMode videoMode);
 
 private:
 

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -29,7 +29,7 @@ public slots:
 	/// @param type   The type from enum
 	/// @param config The configuration
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	void initServer();
 

--- a/include/grabber/AmlogicGrabber.h
+++ b/include/grabber/AmlogicGrabber.h
@@ -17,7 +17,7 @@ public:
 	/// @param[in] width  The width of the captured screenshot
 	/// @param[in] height The heigth of the captured screenshot
 	///
-	AmlogicGrabber(const unsigned width, const unsigned height);
+	AmlogicGrabber(unsigned width, unsigned height);
 	~AmlogicGrabber() override;
 
 	///

--- a/include/grabber/AmlogicWrapper.h
+++ b/include/grabber/AmlogicWrapper.h
@@ -18,7 +18,7 @@ public:
 	/// @param[in] grabWidth  The width of the grabbed image [pixels]
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	///
-	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight);
+	AmlogicWrapper(unsigned grabWidth, unsigned grabHeight);
 
 public slots:
 	///

--- a/include/grabber/DispmanxFrameGrabber.h
+++ b/include/grabber/DispmanxFrameGrabber.h
@@ -26,7 +26,7 @@ public:
 	/// @param[in] width  The width of the captured screenshot
 	/// @param[in] height The heigth of the captured screenshot
 	///
-	DispmanxFrameGrabber(const unsigned width, const unsigned height);
+	DispmanxFrameGrabber(unsigned width, unsigned height);
 	~DispmanxFrameGrabber() override;
 
 
@@ -50,7 +50,7 @@ private:
 	///
 	/// @param vc_flags  The snapshot grabbing mask
 	///
-	void setFlags(const int vc_flags);
+	void setFlags(int vc_flags);
 
 	///
 	/// @brief free _vc_resource and captureBuffer

--- a/include/grabber/DispmanxWrapper.h
+++ b/include/grabber/DispmanxWrapper.h
@@ -20,7 +20,7 @@ public:
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	/// @param[in] updateRate_Hz  The image grab rate [Hz]
 	///
-	DispmanxWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	DispmanxWrapper(unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz);
 
 public slots:
 	///

--- a/include/grabber/FramebufferFrameGrabber.h
+++ b/include/grabber/FramebufferFrameGrabber.h
@@ -17,7 +17,7 @@ public:
 	/// @param[in] width  The width of the captured screenshot
 	/// @param[in] height The heigth of the captured screenshot
 	///
-	FramebufferFrameGrabber(const QString & device, const unsigned width, const unsigned height);
+	FramebufferFrameGrabber(const QString & device, unsigned width, unsigned height);
 
 	///
 	/// Captures a single snapshot of the display and writes the data to the given image. The

--- a/include/grabber/FramebufferWrapper.h
+++ b/include/grabber/FramebufferWrapper.h
@@ -20,7 +20,7 @@ public:
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	/// @param[in] updateRate_Hz  The image grab rate [Hz]
 	///
-	FramebufferWrapper(const QString & device, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	FramebufferWrapper(const QString & device, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz);
 
 public slots:
 	///

--- a/include/grabber/OsxFrameGrabber.h
+++ b/include/grabber/OsxFrameGrabber.h
@@ -24,7 +24,7 @@ public:
 	/// @param[in] width  The width of the captured screenshot
 	/// @param[in] height The heigth of the captured screenshot
 	///
-	OsxFrameGrabber(const unsigned display, const unsigned width, const unsigned height);
+	OsxFrameGrabber(unsigned display, unsigned width, unsigned height);
 	~OsxFrameGrabber() override;
 
 	///

--- a/include/grabber/OsxWrapper.h
+++ b/include/grabber/OsxWrapper.h
@@ -20,7 +20,7 @@ public:
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	/// @param[in] updateRate_Hz  The image grab rate [Hz]
 	///
-	OsxWrapper(const unsigned display, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	OsxWrapper(unsigned display, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz);
 
 public slots:
 	///

--- a/include/grabber/QtGrabber.h
+++ b/include/grabber/QtGrabber.h
@@ -75,7 +75,7 @@ private:
 	///
 	/// @brief Is called whenever we need new screen dimension calculations based on window geometry
 	///
-	int updateScreenDimensions(const bool& force);
+	int updateScreenDimensions(bool force);
 
 	///
 	/// @brief free the _screen pointer

--- a/include/grabber/QtWrapper.h
+++ b/include/grabber/QtWrapper.h
@@ -19,7 +19,7 @@ public:
 	/// @param[in] pixelDecimation   Decimation factor for image [pixels]
 	/// @param[in] updateRate_Hz     The image grab rate [Hz]
 	///
-	QtWrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, int display, const unsigned updateRate_Hz);
+	QtWrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, int display, unsigned updateRate_Hz);
 
 public slots:
 	///

--- a/include/grabber/V4L2Wrapper.h
+++ b/include/grabber/V4L2Wrapper.h
@@ -32,7 +32,7 @@ public slots:
 	void setCecDetectionEnable(bool enable);
 	void setDeviceVideoStandard(QString device, VideoStandard videoStandard);
 	void handleCecEvent(CECEvent event);
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config) override;
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config) override;
 
 private slots:
 	void newFrame(const Image<ColorRgb> & image);

--- a/include/grabber/X11Wrapper.h
+++ b/include/grabber/X11Wrapper.h
@@ -24,7 +24,7 @@ public:
 	/// @param[in] grabHeight  The height of the grabbed images [pixels]
 	/// @param[in] updateRate_Hz  The image grab rate [Hz]
 	///
-	X11Wrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, const unsigned updateRate_Hz);
+	X11Wrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, unsigned updateRate_Hz);
 
 	///
 	/// Destructor of this framebuffer frame grabber. Releases any claimed resources.

--- a/include/hyperion/AuthManager.h
+++ b/include/hyperion/AuthManager.h
@@ -38,25 +38,25 @@ public:
 	/// @brief Get the unique id (imported from removed class 'Stats')
 	/// @return The unique id
 	///
-	const QString &getID() { return _uuid; };
+	const QString &getID() const { return _uuid; };
 
 	///
 	/// @brief Check authorization is required according to the user setting
 	/// @return       True if authorization required else false
 	///
-	const bool &isAuthRequired() { return _authRequired; };
+	bool isAuthRequired() const { return _authRequired; };
 
 	///
 	/// @brief Check if authorization is required for local network connections
 	/// @return       True if authorization required else false
 	///
-	const bool &isLocalAuthRequired() { return _localAuthRequired; };
+	bool isLocalAuthRequired() const { return _localAuthRequired; };
 
 	///
 	/// @brief Check if authorization is required for local network connections for admin access
 	/// @return       True if authorization required else false
 	///
-	const bool &isLocalAdminAuthRequired() { return _localAdminAuthRequired; };
+	bool isLocalAdminAuthRequired() const { return _localAdminAuthRequired; };
 
 	///
 	/// @brief Reset Hyperion user
@@ -158,7 +158,7 @@ public slots:
 	/// @param id      The id of the request
 	/// @param accept  The accept or deny the request
 	///
-	void handlePendingTokenRequest(const QString &id, const bool &accept);
+	void handlePendingTokenRequest(const QString &id, bool accept);
 
 	///
 	/// @brief Get pending requests
@@ -183,7 +183,7 @@ public slots:
 	/// @param type   settings type from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type &type, const QJsonDocument &config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument &config);
 
 signals:
 	///
@@ -201,7 +201,7 @@ signals:
 	/// @param  comment The comment that was part of the request
 	/// @param  id      The id that was part of the request
 	///
-	void tokenResponse(const bool &success, QObject *caller, const QString &token, const QString &comment, const QString &id);
+	void tokenResponse(bool success, QObject *caller, const QString &token, const QString &comment, const QString &id);
 
 	///
 	/// @brief Emits whenever the token list changes
@@ -214,7 +214,7 @@ private:
 	/// @brief Increment counter for token/user auth
 	/// @param user If true we increment USER auth instead of token
 	///
-	void setAuthBlock(const bool &user = false);
+	void setAuthBlock(bool user = false);
 
 	/// Database interface for auth table
 	AuthTable *_authTable;

--- a/include/hyperion/BGEffectHandler.h
+++ b/include/hyperion/BGEffectHandler.h
@@ -29,7 +29,7 @@ private slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 	{
 		if(type == settings::BGEFFECT)
 		{

--- a/include/hyperion/CaptureCont.h
+++ b/include/hyperion/CaptureCont.h
@@ -18,8 +18,8 @@ class CaptureCont : public QObject
 public:
 	CaptureCont(Hyperion* hyperion);
 
-	void setSystemCaptureEnable(const bool& enable);
-	void setV4LCaptureEnable(const bool& enable);
+	void setSystemCaptureEnable(bool enable);
+	void setV4LCaptureEnable(bool enable);
 
 private slots:
 	///
@@ -27,14 +27,14 @@ private slots:
 	/// @param component  The component from enum
 	/// @param enable     The new state
 	///
-	void handleCompStateChangeRequest(const hyperion::Components component, bool enable);
+	void handleCompStateChangeRequest(hyperion::Components component, bool enable);
 
 	///
 	/// @brief Handle settings update from Hyperion Settingsmanager emit or this constructor
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	///
 	/// @brief forward system image

--- a/include/hyperion/ComponentRegister.h
+++ b/include/hyperion/ComponentRegister.h
@@ -27,7 +27,7 @@ public:
 	/// @param  comp   The component from enum
 	/// @return        True if component is running else false. Not found is -1
 	///
-	int isComponentEnabled(const hyperion::Components& comp) const;
+	int isComponentEnabled(hyperion::Components comp) const;
 
 	/// contains all components and their state
 	std::map<hyperion::Components, bool> getRegister() const { return _componentStates; };
@@ -38,7 +38,7 @@ signals:
 	///	@param comp   The component
 	///	@param state  The new state of the component
 	///
-	void updatedComponentState(const hyperion::Components comp, const bool state);
+	void updatedComponentState(hyperion::Components comp, bool state);
 
 public slots:
 	///
@@ -46,13 +46,13 @@ public slots:
 	///	@param comp   The component
 	///	@param state  The new state of the component
 	///
-	void setNewComponentState(const hyperion::Components comp, const bool activated);
+	void setNewComponentState(hyperion::Components comp, bool activated);
 
 private slots:
 	///
 	/// @brief Handle COMP_ALL changes from Hyperion->compStateChangeRequest
 	///
-	void handleCompStateChangeRequest(const hyperion::Components comps, const bool activated);
+	void handleCompStateChangeRequest(hyperion::Components comps, bool activated);
 
 private:
 	///  Hyperion instance

--- a/include/hyperion/GrabberWrapper.h
+++ b/include/hyperion/GrabberWrapper.h
@@ -29,7 +29,7 @@ class GrabberWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	GrabberWrapper(QString grabberName, Grabber * ggrabber, unsigned width, unsigned height, const unsigned updateRate_Hz = 0);
+	GrabberWrapper(QString grabberName, Grabber * ggrabber, unsigned width, unsigned height, unsigned updateRate_Hz = 0);
 
 	virtual ~GrabberWrapper();
 
@@ -122,7 +122,7 @@ public slots:
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///
-	virtual void setVideoMode(const VideoMode& videoMode);
+	virtual void setVideoMode(VideoMode videoMode);
 
 	///
 	/// Set the crop values
@@ -138,7 +138,7 @@ public slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	virtual void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	virtual void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 signals:
 	///
@@ -149,7 +149,7 @@ signals:
 private slots:
 	/// @brief Handle a source request event from Hyperion.
 	/// Will start and stop grabber based on active listeners count
-	void handleSourceRequest(const hyperion::Components& component, const int hyperionInd, const bool listen);
+	void handleSourceRequest(hyperion::Components component, int hyperionInd, bool listen);
 
 	///
 	/// @brief Update Update capture rate

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -120,7 +120,7 @@ public slots:
 	/// @param[in] owner       Specific owner string, might be empty
 	/// @param[in] smooth_cfg  The smooth id to use
 	///
-	void registerInput(const int priority, const hyperion::Components& component, const QString& origin = "System", const QString& owner = "", unsigned smooth_cfg = 0);
+	void registerInput(int priority, hyperion::Components component, const QString& origin = "System", const QString& owner = "", unsigned smooth_cfg = 0);
 
 	///
 	/// @brief   Update the current color of a priority (prev registered with registerInput())
@@ -131,7 +131,7 @@ public slots:
 	/// @param  clearEffect  Should be true when NOT called from an effect
 	/// @return              True on success, false when priority is not found
 	///
-	bool setInput(const int priority, const std::vector<ColorRgb>& ledColors, const int timeout_ms = -1, const bool& clearEffect = true);
+	bool setInput(int priority, const std::vector<ColorRgb>& ledColors, int timeout_ms = -1, bool clearEffect = true);
 
 	///
 	/// @brief   Update the current image of a priority (prev registered with registerInput())
@@ -142,7 +142,7 @@ public slots:
 	/// @param  clearEffect  Should be true when NOT called from an effect
 	/// @return              True on success, false when priority is not found
 	///
-	bool setInputImage(const int priority, const Image<ColorRgb>& image, const int64_t timeout_ms = -1, const bool& clearEffect = true);
+	bool setInputImage(int priority, const Image<ColorRgb>& image, int64_t timeout_ms = -1, bool clearEffect = true);
 
 	///
 	/// Writes a single color to all the leds for the given time and priority
@@ -155,14 +155,14 @@ public slots:
 	/// @param[in] origin   The setter
 	/// @param     clearEffect  Should be true when NOT called from an effect
 	///
-	void setColor(const int priority, const std::vector<ColorRgb> &ledColors, const int timeout_ms = -1, const QString& origin = "System" ,bool clearEffects = true);
+	void setColor(int priority, const std::vector<ColorRgb> &ledColors, int timeout_ms = -1, const QString& origin = "System" ,bool clearEffects = true);
 
 	///
 	/// @brief Set the given priority to inactive
 	/// @param priority  The priority
 	/// @return True on success false if not found
 	///
-	bool setInputInactive(const quint8& priority);
+	bool setInputInactive(quint8 priority);
 
 	///
 	/// Returns the list with unique adjustment identifiers
@@ -187,7 +187,7 @@ public slots:
 	/// @param[in] forceClearAll Force the clear
 	/// @return              True on success else false (not found)
 	///
-	bool clear(const int priority, bool forceClearAll=false);
+	bool clear(int priority, bool forceClearAll=false);
 
 	/// #############
 	// EFFECTENGINE
@@ -255,14 +255,14 @@ public slots:
 	/// @brief enable/disable automatic/priorized source selection
 	/// @param state The new state
 	///
-	void setSourceAutoSelect(const bool state);
+	void setSourceAutoSelect(bool state);
 
 	///
 	/// @brief set current input source to visible
 	/// @param priority the priority channel which should be vidible
 	/// @return true if success, false on error
 	///
-	bool setVisiblePriority(const int& priority);
+	bool setVisiblePriority(int priority);
 
 	/// gets current state of automatic/priorized source selection
 	/// @return the state
@@ -280,7 +280,7 @@ public slots:
 	///
 	/// @return bool
 	///
-	bool isCurrentPriority(const int priority) const;
+	bool isCurrentPriority(int priority) const;
 
 	///
 	/// Returns a list of all registered priorities
@@ -296,7 +296,7 @@ public slots:
 	///
 	/// @return The information of the given, a not found priority will return lowest priority as fallback
 	///
-	InputInfo getPriorityInfo(const int priority) const;
+	InputInfo getPriorityInfo(int priority) const;
 
 	/// #############
 	/// SETTINGSMANAGER
@@ -305,7 +305,7 @@ public slots:
 	/// @param type  The settingsType from enum
 	/// @return      Data Document
 	///
-	QJsonDocument getSetting(const settings::type& type) const;
+	QJsonDocument getSetting(settings::type type) const;
 
 	/// gets the current json config object from SettingsManager
 	/// @return json config
@@ -317,7 +317,7 @@ public slots:
 	/// @param correct If true will correct json against schema before save
 	/// @return        True on success else false
 	///
-	bool saveSettings(QJsonObject config, const bool& correct = false);
+	bool saveSettings(QJsonObject config, bool correct = false);
 
 	/// ############
 	/// COMPONENTREGISTER
@@ -332,7 +332,7 @@ public slots:
 	/// @param[in] component The component from enum
 	/// @param[in] state The state of the component [true | false]
 	///
-	void setNewComponentState(const hyperion::Components& component, const bool& state);
+	void setNewComponentState(hyperion::Components component, bool state);
 
 	///
 	/// @brief Get a list of all contrable components and their current state
@@ -345,16 +345,16 @@ public slots:
 	/// @param The component to test
 	/// @return Component state
 	///
-	int isComponentEnabled(const hyperion::Components& comp);
+	int isComponentEnabled(hyperion::Components comp);
 
 	/// sets the methode how image is maped to leds at ImageProcessor
-	void setLedMappingType(const int& mappingType);
+	void setLedMappingType(int mappingType);
 
 	///
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///
-	void setVideoMode(const VideoMode& mode);
+	void setVideoMode(VideoMode mode);
 
 	///
 	/// @brief Init after thread start
@@ -383,13 +383,13 @@ signals:
 	/// @param component  The component from enum
 	/// @param enabled    The new state of the component
 	///
-	void compStateChangeRequest(const hyperion::Components component, bool enabled);
+	void compStateChangeRequest(hyperion::Components component, bool enabled);
 
 	///
 	/// @brief Emits whenever the imageToLedsMapping has changed
 	/// @param mappingType The new mapping type
 	///
-	void imageToLedsMappingChanged(const int& mappingType);
+	void imageToLedsMappingChanged(int mappingType);
 
 	///
 	/// @brief Emits whenever the visible priority delivers a image which is applied in update()
@@ -410,19 +410,19 @@ signals:
 	///
 	/// @brief Is emitted from clients who request a videoMode change
 	///
-	void videoMode(const VideoMode& mode);
+	void videoMode(VideoMode mode);
 
 	///
 	/// @brief A new videoMode was requested (called from Daemon!)
 	///
-	void newVideoMode(const VideoMode& mode);
+	void newVideoMode(VideoMode mode);
 
 	///
 	/// @brief Emits whenever a config part changed. SIGNAL PIPE helper for SettingsManager -> HyperionDaemon
 	/// @param type   The settings type from enum
 	/// @param data   The data as QJsonDocument
 	///
-	void settingsChanged(const settings::type& type, const QJsonDocument& data);
+	void settingsChanged(settings::type type, const QJsonDocument& data);
 
 	///
 	/// @brief Emits whenever the adjustments have been updated
@@ -459,19 +459,19 @@ private slots:
 	///	@brief Handle whenever the visible component changed
 	///	@param comp      The new component
 	///
-	void handleVisibleComponentChanged(const hyperion::Components& comp);
+	void handleVisibleComponentChanged(hyperion::Components comp);
 
 	///
 	///	@brief Apply settings updates for LEDS and COLOR
 	///	@param type   The type from enum
 	///	@param config The configuration
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	///
 	/// @brief Apply new videoMode from Daemon to _currVideoMode
 	///
-	void handleNewVideoMode(const VideoMode& mode) { _currVideoMode = mode; }
+	void handleNewVideoMode(VideoMode mode) { _currVideoMode = mode; }
 
 private:
 	friend class HyperionDaemon;
@@ -481,7 +481,7 @@ private:
 	/// @brief Constructs the Hyperion instance, just accessible for HyperionIManager
 	/// @param  instance  The instance index
 	///
-	Hyperion(const quint8& instance);
+	Hyperion(quint8 instance);
 
 	/// instance index
 	const quint8 _instIndex;

--- a/include/hyperion/HyperionIManager.h
+++ b/include/hyperion/HyperionIManager.h
@@ -38,14 +38,14 @@ public slots:
 	/// @param inst  The instance to check
 	/// @return  True when running else false
 	///
-	bool IsInstanceRunning(const quint8& inst) { return _runningInstances.contains(inst); }
+	bool IsInstanceRunning(quint8 inst) { return _runningInstances.contains(inst); }
 
 	///
 	/// @brief Get a Hyperion instance by index
 	/// @param intance  the index
 	/// @return Hyperion instance, if index is not found returns instance 0
 	///
-	Hyperion* getHyperionInstance(const quint8& instance = 0);
+	Hyperion* getHyperionInstance(quint8 instance = 0);
 
 	///
 	/// @brief Get instance data of all instaces in db + running state
@@ -58,20 +58,20 @@ public slots:
 	/// @param block     If true return when thread has been started
 	/// @return Return true on success, false if not found in db
 	///
-	bool startInstance(const quint8& inst, const bool& block = false);
+	bool startInstance(quint8 inst, bool block = false);
 
 	///
 	/// @brief Stop a Hyperion instance
 	/// @param instance  Instance index
 	/// @return Return true on success, false if not found in db
 	///
-	bool stopInstance(const quint8& inst);
+	bool stopInstance(quint8 inst);
 
 	///
 	/// @brief Toggle the state of all Hyperion instances
 	/// @param pause If true all instances toggle to pause, else to resume
 	///
-	void toggleStateAllInstances(const bool& pause = false);
+	void toggleStateAllInstances(bool pause = false);
 
 	///
 	/// @brief Create a new Hyperion instance entry in db
@@ -79,14 +79,14 @@ public slots:
 	/// @param start     If true it will be started after creation (async)
 	/// @return Return true on success false if name is already in use or a db error occurred
 	///
-	bool createInstance(const QString& name, const bool& start = false);
+	bool createInstance(const QString& name, bool start = false);
 
 	///
 	/// @brief Delete Hyperion instance entry in db. Cleanup also all associated table data for this instance
 	/// @param inst  The instance index
 	/// @return Return true on success, false if not found or not allowed
 	///
-	bool deleteInstance(const quint8& inst);
+	bool deleteInstance(quint8 inst);
 
 	///
 	/// @brief Assign a new name to the given instance
@@ -94,7 +94,7 @@ public slots:
 	/// @param name  The instance name index
 	/// @return Return true on success, false if not found
 	///
-	bool saveName(const quint8& inst, const QString& name);
+	bool saveName(quint8 inst, const QString& name);
 
 signals:
 	///
@@ -103,7 +103,7 @@ signals:
 	/// @param instance      The index of instance
 	/// @param name          The name of the instance, just available with H_CREATED
 	///
-	void instanceStateChanged(const InstanceState& state, const quint8& instance, const QString& name = QString());
+	void instanceStateChanged(InstanceState state, quint8 instance, const QString& name = QString());
 
 	///
 	/// @brief Emits whenever something changes, the lazy version of instanceStateChanged (- H_ON_STOP) + saveName() emit
@@ -118,7 +118,7 @@ signals:
 	///
 	/// @brief PIPE videoMode back to Hyperion
 	///
-	void newVideoMode(const VideoMode& mode);
+	void newVideoMode(VideoMode mode);
 
 	///////////////////////////////////////
 	/// FROM HYPERION TO HYPERIONDAEMON ///
@@ -127,17 +127,17 @@ signals:
 	///
 	/// @brief PIPE settings events from Hyperion
 	///
-	void settingsChanged(const settings::type& type, const QJsonDocument& data);
+	void settingsChanged(settings::type type, const QJsonDocument& data);
 
 	///
 	/// @brief PIPE videoMode request changes from Hyperion to HyperionDaemon
 	///
-	void requestVideoMode(const VideoMode& mode);
+	void requestVideoMode(VideoMode mode);
 
 	///
 	/// @brief PIPE component state changes from Hyperion to HyperionDaemon
 	///
-	void compStateChangeRequest(const hyperion::Components component, bool enable);
+	void compStateChangeRequest(hyperion::Components component, bool enable);
 
 private slots:
 	///
@@ -172,7 +172,7 @@ private:
 	/// @brief check if a instance is allowed for management. Instance 0 represents the root instance
 	/// @apram inst The instance to check
 	///
-	bool isInstAllowed(const quint8& inst) { return (inst > 0); }
+	bool isInstAllowed(quint8 inst) { return (inst > 0); }
 
 private:
 	Logger* _log;

--- a/include/hyperion/ImageProcessor.h
+++ b/include/hyperion/ImageProcessor.h
@@ -46,7 +46,7 @@ public:
 	/// @param[in] width   The new width of the buffer-image
 	/// @param[in] height  The new height of the buffer-image
 	///
-	void setSize(const unsigned width, const unsigned height);
+	void setSize(unsigned width, unsigned height);
 
 	///
 	/// @brief Update the led string (eg on settings change)
@@ -57,10 +57,10 @@ public:
 	bool blackBorderDetectorEnabled();
 
 	/// Returns the current _userMappingType, this may not be the current applied type!
-	const int & getUserLedMappingType() { return _userMappingType; };
+	int getUserLedMappingType() { return _userMappingType; };
 
 	/// Returns the current _mappingType
-	const int & ledMappingType() { return _mappingType; };
+	int ledMappingType() { return _mappingType; };
 
 	static int mappingTypeToInt(QString mappingType);
 	static QString mappingTypeToStr(int mappingType);
@@ -215,7 +215,7 @@ private:
 	}
 
 private slots:
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private:
 	Logger * _log;

--- a/include/hyperion/MessageForwarder.h
+++ b/include/hyperion/MessageForwarder.h
@@ -45,20 +45,20 @@ private slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type &type, const QJsonDocument &config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument &config);
 
 	///
 	/// @brief Handle component state change MessageForwarder
 	/// @param component  The component from enum
 	/// @param enable     The new state
 	///
-	void handleCompStateChangeRequest(const hyperion::Components component, bool enable);
+	void handleCompStateChangeRequest(hyperion::Components component, bool enable);
 
 	///
 	/// @brief Handle priority updates from Priority Muxer
 	/// @param  priority  The new visible priority
 	///
-	void handlePriorityChanges(const quint8 &priority);
+	void handlePriorityChanges(quint8 priority);
 
 	///
 	/// @brief Forward message to all json slaves

--- a/include/hyperion/MultiColorAdjustment.h
+++ b/include/hyperion/MultiColorAdjustment.h
@@ -16,7 +16,7 @@
 class MultiColorAdjustment
 {
 public:
-	MultiColorAdjustment(const unsigned ledCnt);
+	MultiColorAdjustment(unsigned ledCnt);
 	~MultiColorAdjustment();
 
 	/**

--- a/include/hyperion/PriorityMuxer.h
+++ b/include/hyperion/PriorityMuxer.h
@@ -74,14 +74,14 @@ public:
 	/// @brief Start/Stop the PriorityMuxer update timer; On disabled no priority and timeout updates will be performend
 	/// @param  enable  The new state
 	///
-	void setEnable(const bool& enable);
+	void setEnable(bool enable);
 
 	/// @brief Enable or disable auto source selection
 	/// @param   enable   True if it should be enabled else false
 	/// @param   update   True to update _currentPriority - INTERNAL usage.
 	/// @return           True if changed has been applied, false if the state is unchanged
 	///
-	bool setSourceAutoSelectEnabled(const bool& enabel, const bool& update = true);
+	bool setSourceAutoSelectEnabled(bool enabel, bool update = true);
 
 	///
 	/// @brief Get the state of source auto selection
@@ -94,13 +94,13 @@ public:
 	/// @param   priority  The
 	/// @return            True on success, false if priority not found
 	///
-	bool setPriority(const uint8_t priority);
+	bool setPriority(uint8_t priority);
 
 	///
 	/// @brief Update all ledColos with min length of >= 1 to fit the new led length
 	/// @param[in] ledCount   The count of leds
 	///
-	void updateLedColorsLength(const int& ledCount);
+	void updateLedColorsLength(int ledCount);
 
 	///
 	/// Returns the current priority
@@ -114,7 +114,7 @@ public:
 	/// @param priority The priority channel
 	/// @return True if the priority channel exists else false
 	///
-	bool hasPriority(const int priority) const;
+	bool hasPriority(int priority) const;
 
 	///
 	/// Returns the number of active priorities
@@ -131,7 +131,7 @@ public:
 	///
 	/// @return The information for the specified priority channel
 	///
-	const InputInfo getInputInfo(const int priority) const;
+	InputInfo getInputInfo(int priority) const;
 
 	///
 	/// @brief  Register a new input by priority, the priority is not active (timeout -100 isn't muxer recognized) until you start to update the data with setInput()
@@ -142,7 +142,7 @@ public:
 	/// @param[in] owner       Speicifc owner string, might be empty
 	/// @param[in] smooth_cfg  The smooth id to use
 	///
-	void registerInput(const int priority, const hyperion::Components& component, const QString& origin = "System", const QString& owner = "", unsigned smooth_cfg = SMOOTHING_MODE_DEFAULT);
+	void registerInput(int priority, hyperion::Components component, const QString& origin = "System", const QString& owner = "", unsigned smooth_cfg = SMOOTHING_MODE_DEFAULT);
 
 	///
 	/// @brief   Update the current color of a priority (prev registered with registerInput())
@@ -151,7 +151,7 @@ public:
 	/// @param  timeout_ms  The new timeout (defaults to -1 endless)
 	/// @return             True on success, false when priority is not found
 	///
-	bool setInput(const int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms = -1);
+	bool setInput(int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms = -1);
 
 	///
 	/// @brief   Update the current image of a priority (prev registered with registerInput())
@@ -160,14 +160,14 @@ public:
 	/// @param  timeout_ms  The new timeout (defaults to -1 endless)
 	/// @return             True on success, false when priority is not found
 	///
-	bool setInputImage(const int priority, const Image<ColorRgb>& image, int64_t timeout_ms = -1);
+	bool setInputImage(int priority, const Image<ColorRgb>& image, int64_t timeout_ms = -1);
 
 	///
 	/// @brief Set the given priority to inactive
 	/// @param priority  The priority
 	/// @return True on success false if not found
 	///
-	bool setInputInactive(const quint8& priority);
+	bool setInputInactive(quint8 priority);
 
 	///
 	/// Clears the specified priority channel and update _currentPriority on success
@@ -175,7 +175,7 @@ public:
 	/// @param[in] priority  The priority of the channel to clear
 	/// @return              True if priority has been cleared else false (not found)
 	///
-	bool clearInput(const uint8_t priority);
+	bool clearInput(uint8_t priority);
 
 	///
 	/// Clears all priority channels
@@ -185,7 +185,7 @@ public:
 	///
 	/// @brief Queue a manual push where muxer doesn't recognize them (e.g. continous single color pushes)
 	///
-	void queuePush(void){ emit timeRunner(); };
+	void queuePush(){ emit timeRunner(); };
 
 signals:
 	///
@@ -198,38 +198,38 @@ signals:
 	/// @param priority  The priority which has changed
 	/// @param state     If true it was added else it was removed!
 	///
-	void priorityChanged(const quint8& priority, const bool& state);
+	void priorityChanged(quint8 priority, bool state);
 
 	///
 	/// @brief Emits whenever the visible priority has changed
 	/// @param  priority  The new visible priority
 	///
-	void visiblePriorityChanged(const quint8& priority);
+	void visiblePriorityChanged(quint8 priority);
 
 	///
 	/// @brief Emits whenever the current visible component changed
 	/// @param comp  The new component
 	///
-	void visibleComponentChanged(const hyperion::Components& comp);
+	void visibleComponentChanged(hyperion::Components comp);
 
 	///
 	/// @brief Emits whenever a priority changes active state
 	/// @param  priority  The priority who changed the active state
 	/// @param  state     The new state, state true = active else false
 	///
-	void activeStateChanged(const quint8& priority, const bool& state);
+	void activeStateChanged(quint8 priority, bool state);
 
 	///
 	/// @brief Emits whenever the auto selection state has been changed
 	/// @param  state  The new state of auto selection; True enabled else false
 	///
-	void autoSelectChanged(const bool& state);
+	void autoSelectChanged(bool state);
 
 	///
 	/// @brief Emits whenever something changes which influences the priorities listing
 	///        Emits also in 1s interval when a COLOR or EFFECT is running with a timeout > -1
 	///
-	void prioritiesChanged(void);
+	void prioritiesChanged();
 
 	///
 	/// internal used signal to resolve treading issues with timer
@@ -246,14 +246,14 @@ private slots:
 	/// Updates the current time. Channels with a configured time out will be checked and cleared if
 	/// required.
 	///
-	void setCurrentTime(void);
+	void setCurrentTime();
 
 private:
 	///
 	/// @brief Get the component of the given priority
 	/// @return The component
 	///
-	hyperion::Components getComponentOfPriority(const int& priority);
+	hyperion::Components getComponentOfPriority(int priority);
 
 	/// Logger instance
 	Logger* _log;

--- a/include/hyperion/SettingsManager.h
+++ b/include/hyperion/SettingsManager.h
@@ -21,7 +21,7 @@ public:
 	/// @params  instance   Instance index of HyperionInstanceManager
 	/// @params  parent    The parent hyperion instance
 	///
-	SettingsManager(const quint8& instance, QObject* parent = nullptr);
+	SettingsManager(quint8 instance, QObject* parent = nullptr);
 
 	///
 	/// @brief Save a complete json config
@@ -29,20 +29,20 @@ public:
 	/// @param correct If true will correct json against schema before save
 	/// @return True on success else false
 	///
-	bool saveSettings(QJsonObject config, const bool& correct = false);
+	bool saveSettings(QJsonObject config, bool correct = false);
 
 	///
 	/// @brief get a single setting json from config
 	/// @param type   The settings::type from enum
 	/// @return The requested json data as QJsonDocument
 	///
-	const QJsonDocument getSetting(const settings::type& type);
+	QJsonDocument getSetting(settings::type type) const;
 
 	///
 	/// @brief get the full settings object of this instance (with global settings)
 	/// @return The requested json
 	///
-	const QJsonObject & getSettings() { return _qconfig; };
+	const QJsonObject & getSettings() const { return _qconfig; };
 
 signals:
 	///
@@ -50,7 +50,7 @@ signals:
 	/// @param type The settings type from enum
 	/// @param data The data as QJsonDocument
 	///
-	void settingsChanged(const settings::type& type, const QJsonDocument& data);
+	void settingsChanged(settings::type type, const QJsonDocument& data);
 
 private:
 	///

--- a/include/jsonserver/JsonServer.h
+++ b/include/jsonserver/JsonServer.h
@@ -46,7 +46,7 @@ private slots:
 	///
 	/// Slot which is called when a client closes a connection
 	///
-	void closedConnection(void);
+	void closedConnection();
 
 public slots:
 	///
@@ -54,7 +54,7 @@ public slots:
 	/// @param type   settings type from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private:
 	/// The TCP server object

--- a/include/leddevice/LedDeviceWrapper.h
+++ b/include/leddevice/LedDeviceWrapper.h
@@ -78,7 +78,7 @@ public slots:
 	/// @param component  The comp from enum
 	/// @param state      The new state
 	///
-	void handleComponentState(const hyperion::Components component, const bool state);
+	void handleComponentState(hyperion::Components component, bool state);
 
 signals:
 	///

--- a/include/protoserver/ProtoServer.h
+++ b/include/protoserver/ProtoServer.h
@@ -30,7 +30,7 @@ public slots:
 	/// @param type   The type from enum
 	/// @param config The configuration
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	void initServer();
 

--- a/include/ssdp/SSDPDiscover.h
+++ b/include/ssdp/SSDPDiscover.h
@@ -58,7 +58,7 @@ public:
 	/// @param timeout_ms  The timeout in ms
 	/// @return The address+port of web-server or empty if timed out
 	///
-	const QString getFirstService(const searchType &type = searchType::STY_WEBSERVER,const QString &st = "urn:hyperion-project.org:device:basic:1", const int &timeout_ms = 3000);
+	const QString getFirstService(const searchType &type = searchType::STY_WEBSERVER,const QString &st = "urn:hyperion-project.org:device:basic:1", int timeout_ms = 3000);
 
 	///
 	/// @brief Discover services via ssdp.

--- a/include/ssdp/SSDPHandler.h
+++ b/include/ssdp/SSDPHandler.h
@@ -19,7 +19,7 @@ class QNetworkConfigurationManager;
 class SSDPHandler : public SSDPServer{
 	Q_OBJECT
 public:
-	SSDPHandler(WebServer* webserver, const quint16& flatBufPort, const quint16& jsonServerPort, const QString &name,  QObject * parent = nullptr);
+	SSDPHandler(WebServer* webserver, quint16 flatBufPort, quint16 jsonServerPort, const QString &name,  QObject * parent = nullptr);
 	~SSDPHandler();
 
 	///
@@ -37,14 +37,14 @@ public slots:
 	/// @brief get state changes from webserver
 	/// @param newState true for started and false for stopped
 	///
-	void handleWebServerStateChange(const bool newState);
+	void handleWebServerStateChange(bool newState);
 
 	///
 	/// @brief Handle settings update from Hyperion Settingsmanager emit
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private:
 	///
@@ -72,7 +72,7 @@ private:
 	/// @brief Send alive/byebye message based on _deviceList
 	/// @param alive When true send alive, else byebye
 	///
-	void sendAnnounceList(const bool alive);
+	void sendAnnounceList(bool alive);
 
 private slots:
 	///
@@ -82,7 +82,7 @@ private slots:
 	/// @param address The ip of the caller
 	/// @param port    The port of the caller
 	///
-	void handleMSearchRequest(const QString& target, const QString& mx, const QString address, const quint16 & port);
+	void handleMSearchRequest(const QString& target, const QString& mx, const QString address, quint16 port);
 
 	///
 	/// @brief Handle changes in the network configuration

--- a/include/ssdp/SSDPServer.h
+++ b/include/ssdp/SSDPServer.h
@@ -41,7 +41,7 @@ public:
 	/// @param senderIp   Ip address of the sender
 	/// @param senderPort The port of the sender
 	///
-	void sendMSearchResponse(const QString& st, const QString& senderIp, const quint16& senderPort);
+	void sendMSearchResponse(const QString& st, const QString& senderIp, quint16 senderPort);
 
 	///
 	/// @brief Send ByeBye notification (on SSDP stop) (repeated 3 times)
@@ -76,7 +76,7 @@ public:
 	///
 	/// @brief set new flatbuffer server port
 	///
-	void setFlatBufPort(const quint16& port) { _fbsPort = QString::number(port); };
+	void setFlatBufPort(quint16 port) { _fbsPort = QString::number(port); };
 
 	///
 	/// @brief Get current flatbuffer server port
@@ -86,7 +86,7 @@ public:
 	///
 	/// @brief set new jsonserver server port
 	///
-	void setJsonServerPort(const quint16& port) { _jssPort = QString::number(port); };
+	void setJsonServerPort(quint16 port) { _jssPort = QString::number(port); };
 
 	///
 	/// @brief get new jsonserver server port
@@ -112,7 +112,7 @@ signals:
 	/// @param address The ip of the caller
 	/// @param port    The port of the caller
 	///
-	void msearchRequestReceived(const QString& target, const QString& mx, const QString address, const quint16 & port);
+	void msearchRequestReceived(const QString& target, const QString& mx, const QString address, quint16 port);
 
 private:
 	Logger* _log;

--- a/include/utils/GlobalSignals.h
+++ b/include/utils/GlobalSignals.h
@@ -54,7 +54,7 @@ signals:
 	/// @param[in] owner       Specific owner string, might be empty
 	/// @param[in] smooth_cfg  The smooth id to use
 	///
-	void registerGlobalInput(const int priority, const hyperion::Components& component, const QString& origin = "External", const QString& owner = "", unsigned smooth_cfg = 0);
+	void registerGlobalInput(int priority, hyperion::Components component, const QString& origin = "External", const QString& owner = "", unsigned smooth_cfg = 0);
 
 	///
 	/// @brief PIPE the clear command for the global priority channel over HyperionDaemon to Hyperion class
@@ -70,7 +70,7 @@ signals:
 	/// @param[in] timeout_ms  The timeout in milliseconds
 	/// @param     clearEffect Should be true when NOT called from an effect
 	///
-	void setGlobalImage(const int priority, const Image<ColorRgb>& image, const int timeout_ms, const bool& clearEffect = true);
+	void setGlobalImage(int priority, const Image<ColorRgb>& image, int timeout_ms, bool clearEffect = true);
 
 	///
 	/// @brief PIPE external color message over HyperionDaemon to Hyperion class
@@ -80,7 +80,7 @@ signals:
 	/// @param[in] origin      The setter
 	/// @param     clearEffect Should be true when NOT called from an effect
 	///
-	void setGlobalColor(const int priority, const std::vector<ColorRgb> &ledColor, const int timeout_ms, const QString& origin = "External" ,bool clearEffects = true);
+	void setGlobalColor(int priority, const std::vector<ColorRgb> &ledColor, int timeout_ms, const QString& origin = "External" ,bool clearEffects = true);
 
 	///////////////////////////////////////
 	//////////// FROM HYPERION ////////////
@@ -98,6 +98,6 @@ signals:
 	/// @param hyperionInd The Hyperion instance index as identifier
 	/// @param listen  True when listening, else false
 	///
-	void requestSource(const hyperion::Components& component, const int hyperionInd, const bool listen);
+	void requestSource(hyperion::Components component, int hyperionInd, bool listen);
 
 };

--- a/include/utils/Image.h
+++ b/include/utils/Image.h
@@ -15,7 +15,7 @@ public:
 	{
 	}
 
-	Image(const unsigned width, const unsigned height) :
+	Image(unsigned width, unsigned height) :
 		Image(width, height, Pixel_T())
 
 	{
@@ -28,7 +28,7 @@ public:
 	/// @param height The height of the image
 	/// @param background The color of the image
 	///
-	Image(const unsigned width, const unsigned height, const Pixel_T background) :
+	Image(unsigned width, unsigned height, const Pixel_T background) :
 		_d_ptr(new ImageData<Pixel_T>(width, height, background))
 	{
 	}
@@ -93,12 +93,12 @@ public:
 		return _d_ptr->height();
 	}
 
-	uint8_t red(const unsigned pixel) const
+	uint8_t red(unsigned pixel) const
 	{
 		return _d_ptr->red(pixel);
 	}
 
-	uint8_t green(const unsigned pixel) const
+	uint8_t green(unsigned pixel) const
 	{
 		return _d_ptr->green(pixel);
 	}
@@ -111,7 +111,7 @@ public:
 	///
 	/// @return const reference to specified pixel
 	///
-	uint8_t blue(const unsigned pixel) const
+	uint8_t blue(unsigned pixel) const
 	{
 		return _d_ptr->blue(pixel);
 	}
@@ -121,7 +121,7 @@ public:
 	///
 	/// @param x The x index
 	/// @param y The y index
-	const Pixel_T& operator()(const unsigned x, const unsigned y) const
+	const Pixel_T& operator()(unsigned x, unsigned y) const
 	{
 		return _d_ptr->operator()(x, y);
 	}
@@ -129,7 +129,7 @@ public:
 	///
 	/// @return reference to specified pixel
 	///
-	Pixel_T& operator()(const unsigned x, const unsigned y)
+	Pixel_T& operator()(unsigned x, unsigned y)
 	{
 		return _d_ptr->operator()(x, y);
 	}
@@ -137,7 +137,7 @@ public:
 	/// Resize the image
 	/// @param width The width of the image
 	/// @param height The height of the image
-	void resize(const unsigned width, const unsigned height)
+	void resize(unsigned width, unsigned height)
 	{
 		_d_ptr->resize(width, height);
 	}
@@ -198,7 +198,7 @@ private:
 	///
 	/// @return The index into the underlying data-vector
 	///
-	inline unsigned toIndex(const unsigned x, const unsigned y) const
+	inline unsigned toIndex(unsigned x, unsigned y) const
 	{
 		return _d_ptr->toIndex(x, y);
 	}

--- a/include/utils/ImageData.h
+++ b/include/utils/ImageData.h
@@ -24,7 +24,7 @@ class ImageData : public QSharedData
 public:
 	typedef Pixel_T pixel_type;
 
-	ImageData(const unsigned width, const unsigned height, const Pixel_T background) :
+	ImageData(unsigned width, unsigned height, const Pixel_T background) :
 		_width(width),
 		_height(height),
 		_pixels(new Pixel_T[width * height + 1])
@@ -84,32 +84,32 @@ public:
 		return _height;
 	}
 
-	uint8_t red(const unsigned pixel) const
+	uint8_t red(unsigned pixel) const
 	{
 		return (_pixels + pixel)->red;
 	}
 
-	uint8_t green(const unsigned pixel) const
+	uint8_t green(unsigned pixel) const
 	{
 		return (_pixels + pixel)->green;
 	}
 
-	uint8_t blue(const unsigned pixel) const
+	uint8_t blue(unsigned pixel) const
 	{
 		return (_pixels + pixel)->blue;
 	}
 
-	const Pixel_T& operator()(const unsigned x, const unsigned y) const
+	const Pixel_T& operator()(unsigned x, unsigned y) const
 	{
 		return _pixels[toIndex(x,y)];
 	}
 
-	Pixel_T& operator()(const unsigned x, const unsigned y)
+	Pixel_T& operator()(unsigned x, unsigned y)
 	{
 		return _pixels[toIndex(x,y)];
 	}
 
-	void resize(const unsigned width, const unsigned height)
+	void resize(unsigned width, unsigned height)
 	{
 		if (width == _width && height == _height)
 			return;
@@ -167,7 +167,7 @@ public:
 	}
 
 private:
-	inline unsigned toIndex(const unsigned x, const unsigned y) const
+	inline unsigned toIndex(unsigned x, unsigned y) const
 	{
 		return y * _width + x;
 	}

--- a/include/utils/NetOrigin.h
+++ b/include/utils/NetOrigin.h
@@ -42,7 +42,7 @@ private slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private:
 	Logger* _log;

--- a/include/utils/hyperion.h
+++ b/include/utils/hyperion.h
@@ -71,7 +71,7 @@ namespace hyperion {
 		return RgbTransform(gammaR, gammaG, gammaB, backlightThreshold, backlightColored, brightness, brightnessComp);
 	}
 
-	RgbChannelAdjustment createRgbChannelAdjustment(const QJsonObject& colorConfig, const QString& channelName, const int defaultR, const int defaultG, const int defaultB)
+	RgbChannelAdjustment createRgbChannelAdjustment(const QJsonObject& colorConfig, const QString& channelName, int defaultR, int defaultG, int defaultB)
 	{
 		const QJsonArray& channelConfig  = colorConfig[channelName].toArray();
 		return RgbChannelAdjustment(
@@ -101,7 +101,7 @@ namespace hyperion {
 		return adjustment;
 	}
 
-	MultiColorAdjustment * createLedColorsAdjustment(const unsigned ledCnt, const QJsonObject & colorConfig)
+	MultiColorAdjustment * createLedColorsAdjustment(unsigned ledCnt, const QJsonObject & colorConfig)
 	{
 		// Create the result, the transforms are added to this
 		MultiColorAdjustment * adjustment = new MultiColorAdjustment(ledCnt);

--- a/include/webserver/WebServer.h
+++ b/include/webserver/WebServer.h
@@ -32,7 +32,7 @@ class WebServer : public QObject {
 	Q_OBJECT
 
 public:
-	WebServer (const QJsonDocument& config, const bool& useSsl, QObject * parent = 0);
+	WebServer (const QJsonDocument& config, bool useSsl, QObject * parent = 0);
 
 	~WebServer () override;
 
@@ -44,12 +44,12 @@ signals:
 	/// @emits whenever server is started or stopped (to sync with SSDPHandler)
 	/// @param newState   True when started, false when stopped
 	///
-	void stateChange(const bool newState);
+	void stateChange(bool newState);
 
 	///
 	/// @brief Emits whenever the port changes (doesn't compare prev <> now)
 	///
-	void portChanged(const quint16& port);
+	void portChanged(quint16 port);
 
 public slots:
 	///
@@ -57,7 +57,7 @@ public slots:
 	///
 	void initServer();
 
-	void onServerStopped      (void);
+	void onServerStopped      ();
 	void onServerStarted      (quint16 port);
 	void onServerError        (QString msg);
 
@@ -66,7 +66,7 @@ public slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	///
 	/// @brief Set a new description, if empty the description is NotFound for clients

--- a/libsrc/api/API.cpp
+++ b/libsrc/api/API.cpp
@@ -33,7 +33,7 @@
 
 using namespace hyperion;
 
-API::API(Logger *log, const bool &localConnection, QObject *parent)
+API::API(Logger *log, bool localConnection, QObject *parent)
     : QObject(parent)
 {
 	qRegisterMetaType<int64_t>("int64_t");
@@ -59,7 +59,7 @@ API::API(Logger *log, const bool &localConnection, QObject *parent)
     connect(_authManager, &AuthManager::tokenResponse, this, &API::checkTokenResponse);
 }
 
-void API::init(void)
+void API::init()
 {
     bool apiAuthRequired = _authManager->isAuthRequired();
 
@@ -82,7 +82,7 @@ void API::init(void)
     }
 }
 
-void API::setColor(const int &priority, const std::vector<uint8_t> &ledColors, const int &timeout_ms, const QString &origin, const hyperion::Components &callerComp)
+void API::setColor(int priority, const std::vector<uint8_t> &ledColors, int timeout_ms, const QString &origin, hyperion::Components callerComp)
 {
     std::vector<ColorRgb> fledColors;
     if (ledColors.size() % 3 == 0)
@@ -95,7 +95,7 @@ void API::setColor(const int &priority, const std::vector<uint8_t> &ledColors, c
     }
 }
 
-bool API::setImage(ImageCmdData &data, hyperion::Components comp, QString &replyMsg, const hyperion::Components &callerComp)
+bool API::setImage(ImageCmdData &data, hyperion::Components comp, QString &replyMsg, hyperion::Components callerComp)
 {
     // truncate name length
     data.imgName.truncate(16);
@@ -174,7 +174,7 @@ bool API::setImage(ImageCmdData &data, hyperion::Components comp, QString &reply
     return true;
 }
 
-bool API::clearPriority(const int &priority, QString &replyMsg, const hyperion::Components &callerComp)
+bool API::clearPriority(int priority, QString &replyMsg, hyperion::Components callerComp)
 {
     if (priority < 0 || (priority > 0 && priority < 254))
     {
@@ -188,7 +188,7 @@ bool API::clearPriority(const int &priority, QString &replyMsg, const hyperion::
     return true;
 }
 
-bool API::setComponentState(const QString &comp, bool &compState, QString &replyMsg, const hyperion::Components &callerComp)
+bool API::setComponentState(const QString &comp, bool &compState, QString &replyMsg, hyperion::Components callerComp)
 {
     Components component = stringToComponent(comp);
 
@@ -201,17 +201,17 @@ bool API::setComponentState(const QString &comp, bool &compState, QString &reply
     return false;
 }
 
-void API::setLedMappingType(const int &type, const hyperion::Components &callerComp)
+void API::setLedMappingType(int type, hyperion::Components callerComp)
 {
     QMetaObject::invokeMethod(_hyperion, "setLedMappingType", Qt::QueuedConnection, Q_ARG(int, type));
 }
 
-void API::setVideoMode(const VideoMode &mode, const hyperion::Components &callerComp)
+void API::setVideoMode(VideoMode mode, hyperion::Components callerComp)
 {
     QMetaObject::invokeMethod(_hyperion, "setVideoMode", Qt::QueuedConnection, Q_ARG(VideoMode, mode));
 }
 
-void API::setEffect(const EffectCmdData &dat, const hyperion::Components &callerComp)
+void API::setEffect(const EffectCmdData &dat, hyperion::Components callerComp)
 {
     if (!dat.args.isEmpty())
     {
@@ -223,17 +223,17 @@ void API::setEffect(const EffectCmdData &dat, const hyperion::Components &caller
     }
 }
 
-void API::setSourceAutoSelect(const bool state, const hyperion::Components &callerComp)
+void API::setSourceAutoSelect(bool state, hyperion::Components callerComp)
 {
     QMetaObject::invokeMethod(_hyperion, "setSourceAutoSelect", Qt::QueuedConnection, Q_ARG(bool, state));
 }
 
-void API::setVisiblePriority(const int &priority, const hyperion::Components &callerComp)
+void API::setVisiblePriority(int priority, hyperion::Components callerComp)
 {
     QMetaObject::invokeMethod(_hyperion, "setVisiblePriority", Qt::QueuedConnection, Q_ARG(int, priority));
 }
 
-void API::registerInput(const int &priority, const hyperion::Components &component, const QString &origin, const QString &owner, const hyperion::Components &callerComp)
+void API::registerInput(int priority, hyperion::Components component, const QString &origin, const QString &owner, hyperion::Components callerComp)
 {
     if (_activeRegisters.count(priority))
         _activeRegisters.erase(priority);
@@ -243,13 +243,13 @@ void API::registerInput(const int &priority, const hyperion::Components &compone
     QMetaObject::invokeMethod(_hyperion, "registerInput", Qt::QueuedConnection, Q_ARG(int, priority), Q_ARG(hyperion::Components, component), Q_ARG(QString, origin), Q_ARG(QString, owner));
 }
 
-void API::unregisterInput(const int &priority)
+void API::unregisterInput(int priority)
 {
     if (_activeRegisters.count(priority))
         _activeRegisters.erase(priority);
 }
 
-bool API::setHyperionInstance(const quint8 &inst)
+bool API::setHyperionInstance(quint8 inst)
 {
     if (_currInstanceIndex == inst)
         return true;
@@ -278,19 +278,19 @@ bool API::isHyperionEnabled()
     return res > 0;
 }
 
-QVector<QVariantMap> API::getAllInstanceData(void)
+QVector<QVariantMap> API::getAllInstanceData()
 {
     QVector<QVariantMap> vec;
     QMetaObject::invokeMethod(_instanceManager, "getInstanceData", Qt::DirectConnection, Q_RETURN_ARG(QVector<QVariantMap>, vec));
     return vec;
 }
 
-void API::startInstance(const quint8 &index)
+void API::startInstance(quint8 index)
 {
     QMetaObject::invokeMethod(_instanceManager, "startInstance", Qt::QueuedConnection, Q_ARG(quint8, index));
 }
 
-void API::stopInstance(const quint8 &index)
+void API::stopInstance(quint8 index)
 {
     QMetaObject::invokeMethod(_instanceManager, "stopInstance", Qt::QueuedConnection, Q_ARG(quint8, index));
 }
@@ -302,7 +302,7 @@ void API::requestActiveRegister(QObject *callerInstance)
     //   QMetaObject::invokeMethod(ApiSync::getInstance(), "answerActiveRegister", Qt::QueuedConnection, Q_ARG(QObject *, callerInstance), Q_ARG(MapRegister, _activeRegisters));
 }
 
-bool API::deleteInstance(const quint8 &index, QString &replyMsg)
+bool API::deleteInstance(quint8 index, QString &replyMsg)
 {
     if (_adminAuthorized)
     {
@@ -327,7 +327,7 @@ QString API::createInstance(const QString &name)
     return NO_AUTH;
 }
 
-QString API::setInstanceName(const quint8 &index, const QString &name)
+QString API::setInstanceName(quint8 index, const QString &name)
 {
     if (_adminAuthorized)
     {
@@ -417,7 +417,7 @@ void API::cancelNewTokenRequest(const QString &comment, const QString &id)
     QMetaObject::invokeMethod(_authManager, "cancelNewTokenRequest", Qt::QueuedConnection, Q_ARG(QObject *, this), Q_ARG(QString, comment), Q_ARG(QString, id));
 }
 
-bool API::handlePendingTokenRequest(const QString &id, const bool accept)
+bool API::handlePendingTokenRequest(const QString &id, bool accept)
 {
     if (!_adminAuthorized)
         return false;
@@ -503,7 +503,7 @@ void API::logout()
     stopDataConnectionss();
 }
 
-void API::checkTokenResponse(const bool &success, QObject *caller, const QString &token, const QString &comment, const QString &id)
+void API::checkTokenResponse(bool success, QObject *caller, const QString &token, const QString &comment, const QString &id)
 {
     if (this == caller)
         emit onTokenResponse(success, token, comment, id);

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -47,7 +47,7 @@
 
 using namespace hyperion;
 
-JsonAPI::JsonAPI(QString peerAddress, Logger *log, const bool &localConnection, QObject *parent, bool noListener)
+JsonAPI::JsonAPI(QString peerAddress, Logger *log, bool localConnection, QObject *parent, bool noListener)
 	: API(log, localConnection, parent)
 /*	, _authManager(AuthManager::getInstance()) // moved to API
 	, _authorized(false)
@@ -79,7 +79,7 @@ JsonAPI::JsonAPI(QString peerAddress, Logger *log, const bool &localConnection, 
 	Q_INIT_RESOURCE(JSONRPC_schemas);
 }
 
-void JsonAPI::initialize(void)
+void JsonAPI::initialize()
 {
 	// init API, REQUIRED!
 	API::init();
@@ -100,7 +100,7 @@ void JsonAPI::initialize(void)
 	connect(this, &JsonAPI::forwardJsonMessage, _hyperion, &Hyperion::forwardJsonMessage);
 }
 
-bool JsonAPI::handleInstanceSwitch(const quint8 &inst, const bool &forced)
+bool JsonAPI::handleInstanceSwitch(quint8 inst, bool forced)
 {
 	if (API::setHyperionInstance(inst))
 	{
@@ -211,7 +211,7 @@ proceed:
 		handleNotImplemented();
 }
 
-void JsonAPI::handleColorCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleColorCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	emit forwardJsonMessage(message);
 	int priority = message["priority"].toInt();
@@ -230,7 +230,7 @@ void JsonAPI::handleColorCommand(const QJsonObject &message, const QString &comm
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleImageCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleImageCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	emit forwardJsonMessage(message);
 
@@ -254,7 +254,7 @@ void JsonAPI::handleImageCommand(const QJsonObject &message, const QString &comm
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleEffectCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleEffectCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	emit forwardJsonMessage(message);
 
@@ -272,19 +272,19 @@ void JsonAPI::handleEffectCommand(const QJsonObject &message, const QString &com
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleCreateEffectCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleCreateEffectCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QString resultMsg = API::saveEffect(message);
 	resultMsg.isEmpty() ? sendSuccessReply(command, tan) : sendErrorReply(resultMsg, command, tan);
 }
 
-void JsonAPI::handleDeleteEffectCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleDeleteEffectCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QString res = API::deleteEffect(message["name"].toString());
 	res.isEmpty() ? sendSuccessReply(command, tan) : sendErrorReply(res, command, tan);
 }
 
-void JsonAPI::handleSysInfoCommand(const QJsonObject &, const QString &command, const int tan)
+void JsonAPI::handleSysInfoCommand(const QJsonObject &, const QString &command, int tan)
 {
 	// create result
 	QJsonObject result;
@@ -319,7 +319,7 @@ void JsonAPI::handleSysInfoCommand(const QJsonObject &, const QString &command, 
 	emit callbackMessage(result);
 }
 
-void JsonAPI::handleServerInfoCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleServerInfoCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	QJsonObject info;
 
@@ -714,7 +714,7 @@ void JsonAPI::handleServerInfoCommand(const QJsonObject &message, const QString 
 	}
 }
 
-void JsonAPI::handleClearCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleClearCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	emit forwardJsonMessage(message);
 	int priority = message["priority"].toInt();
@@ -728,7 +728,7 @@ void JsonAPI::handleClearCommand(const QJsonObject &message, const QString &comm
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleClearallCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleClearallCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	emit forwardJsonMessage(message);
 	QString replyMsg;
@@ -736,7 +736,7 @@ void JsonAPI::handleClearallCommand(const QJsonObject &message, const QString &c
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleAdjustmentCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleAdjustmentCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QJsonObject &adjustment = message["adjustment"].toObject();
 
@@ -822,7 +822,7 @@ void JsonAPI::handleAdjustmentCommand(const QJsonObject &message, const QString 
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleSourceSelectCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleSourceSelectCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	if (message.contains("auto"))
 	{
@@ -840,7 +840,7 @@ void JsonAPI::handleSourceSelectCommand(const QJsonObject &message, const QStrin
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleConfigCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleConfigCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	QString subcommand = message["subcommand"].toString("");
 	QString full_command = command + "-" + subcommand;
@@ -884,7 +884,7 @@ void JsonAPI::handleConfigCommand(const QJsonObject &message, const QString &com
 	}
 }
 
-void JsonAPI::handleConfigSetCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleConfigSetCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	if (message.contains("config"))
 	{
@@ -899,7 +899,7 @@ void JsonAPI::handleConfigSetCommand(const QJsonObject &message, const QString &
 	}
 }
 
-void JsonAPI::handleSchemaGetCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleSchemaGetCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	// create result
 	QJsonObject schemaJson, alldevices, properties;
@@ -962,7 +962,7 @@ void JsonAPI::handleSchemaGetCommand(const QJsonObject &message, const QString &
 	sendSuccessDataReply(QJsonDocument(schemaJson), command, tan);
 }
 
-void JsonAPI::handleComponentStateCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleComponentStateCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QJsonObject &componentState = message["componentstate"].toObject();
 	QString comp = componentState["component"].toString("invalid");
@@ -977,7 +977,7 @@ void JsonAPI::handleComponentStateCommand(const QJsonObject &message, const QStr
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleLedColorsCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleLedColorsCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	// create result
 	QString subcommand = message["subcommand"].toString("");
@@ -1036,7 +1036,7 @@ void JsonAPI::handleLedColorsCommand(const QJsonObject &message, const QString &
 	sendSuccessReply(command + "-" + subcommand, tan);
 }
 
-void JsonAPI::handleLoggingCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleLoggingCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	// create result
 	QString subcommand = message["subcommand"].toString("");
@@ -1078,19 +1078,19 @@ void JsonAPI::handleLoggingCommand(const QJsonObject &message, const QString &co
 	}
 }
 
-void JsonAPI::handleProcessingCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleProcessingCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	API::setLedMappingType(ImageProcessor::mappingTypeToInt(message["mappingType"].toString("multicolor_mean")));
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleVideoModeCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleVideoModeCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	API::setVideoMode(parse3DMode(message["videoMode"].toString("2D")));
 	sendSuccessReply(command, tan);
 }
 
-void JsonAPI::handleAuthorizeCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleAuthorizeCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QString &subc = message["subcommand"].toString().trimmed();
 	const QString &id = message["id"].toString().trimmed();
@@ -1326,7 +1326,7 @@ void JsonAPI::handleAuthorizeCommand(const QJsonObject &message, const QString &
 	}
 }
 
-void JsonAPI::handleInstanceCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleInstanceCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	const QString &subc = message["subcommand"].toString();
 	const quint8 &inst = message["instance"].toInt();
@@ -1396,7 +1396,7 @@ void JsonAPI::handleInstanceCommand(const QJsonObject &message, const QString &c
 	}
 }
 
-void JsonAPI::handleLedDeviceCommand(const QJsonObject &message, const QString &command, const int tan)
+void JsonAPI::handleLedDeviceCommand(const QJsonObject &message, const QString &command, int tan)
 {
 	Debug(_log, "message: [%s]", QString(QJsonDocument(message).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 
@@ -1457,7 +1457,7 @@ void JsonAPI::handleNotImplemented()
 	sendErrorReply("Command not implemented");
 }
 
-void JsonAPI::sendSuccessReply(const QString &command, const int tan)
+void JsonAPI::sendSuccessReply(const QString &command, int tan)
 {
 	// create reply
 	QJsonObject reply;
@@ -1469,7 +1469,7 @@ void JsonAPI::sendSuccessReply(const QString &command, const int tan)
 	emit callbackMessage(reply);
 }
 
-void JsonAPI::sendSuccessDataReply(const QJsonDocument &doc, const QString &command, const int &tan)
+void JsonAPI::sendSuccessDataReply(const QJsonDocument &doc, const QString &command, int tan)
 {
 	QJsonObject reply;
 	reply["success"] = true;
@@ -1483,7 +1483,7 @@ void JsonAPI::sendSuccessDataReply(const QJsonDocument &doc, const QString &comm
 	emit callbackMessage(reply);
 }
 
-void JsonAPI::sendErrorReply(const QString &error, const QString &command, const int tan)
+void JsonAPI::sendErrorReply(const QString &error, const QString &command, int tan)
 {
 	// create reply
 	QJsonObject reply;
@@ -1581,7 +1581,7 @@ void JsonAPI::newPendingTokenRequest(const QString &id, const QString &comment)
 	sendSuccessDataReply(QJsonDocument(obj), "authorize-tokenRequest", 1);
 }
 
-void JsonAPI::handleTokenResponse(const bool &success, const QString &token, const QString &comment, const QString &id)
+void JsonAPI::handleTokenResponse(bool success, const QString &token, const QString &comment, const QString &id)
 {
 	const QString cmd = "authorize-requestToken";
 	QJsonObject result;
@@ -1595,7 +1595,7 @@ void JsonAPI::handleTokenResponse(const bool &success, const QString &token, con
 		sendErrorReply("Token request timeout or denied", cmd, 5);
 }
 
-void JsonAPI::handleInstanceStateChange(const InstanceState &state, const quint8 &instance, const QString &name)
+void JsonAPI::handleInstanceStateChange(InstanceState state, quint8 instance, const QString &name)
 {
 	switch (state)
 	{
@@ -1610,7 +1610,7 @@ void JsonAPI::handleInstanceStateChange(const InstanceState &state, const quint8
 	}
 }
 
-void JsonAPI::stopDataConnections(void)
+void JsonAPI::stopDataConnections()
 {
 	LoggerManager::getInstance()->disconnect();
 	_streaming_logging_activated = false;

--- a/libsrc/api/JsonCB.cpp
+++ b/libsrc/api/JsonCB.cpp
@@ -42,7 +42,7 @@ JsonCB::JsonCB(QObject* parent)
 	<< "adjustment-update" << "videomode-update" << "effects-update" << "settings-update" << "leds-update" << "instance-update" << "token-update";
 }
 
-bool JsonCB::subscribeFor(const QString& type, const bool & unsubscribe)
+bool JsonCB::subscribeFor(const QString& type, bool unsubscribe)
 {
 	if(!_availableCommands.contains(type))
 		return false;
@@ -189,7 +189,7 @@ void JsonCB::doCallback(const QString& cmd, const QVariant& data)
 	emit newCallback(obj);
 }
 
-void JsonCB::handleComponentState(const hyperion::Components comp, const bool state)
+void JsonCB::handleComponentState(hyperion::Components comp, bool state)
 {
 	QJsonObject data;
 	data["name"] = componentToIdString(comp);
@@ -279,7 +279,7 @@ void JsonCB::handlePriorityUpdate()
 	doCallback("priorities-update", QVariant(data));
 }
 
-void JsonCB::handleImageToLedsMappingChange(const int& mappingType)
+void JsonCB::handleImageToLedsMappingChange(int mappingType)
 {
 	QJsonObject data;
 	data["imageToLedMappingType"] = ImageProcessor::mappingTypeToStr(mappingType);
@@ -357,7 +357,7 @@ void JsonCB::handleAdjustmentChange()
 	doCallback("adjustment-update", QVariant(adjustmentArray));
 }
 
-void JsonCB::handleVideoModeChange(const VideoMode& mode)
+void JsonCB::handleVideoModeChange(VideoMode mode)
 {
 	QJsonObject data;
 	data["videomode"] = QString(videoMode2String(mode));
@@ -382,7 +382,7 @@ void JsonCB::handleEffectListChange()
 	doCallback("effects-update", QVariant(effects));
 }
 
-void JsonCB::handleSettingsChange(const settings::type& type, const QJsonDocument& data)
+void JsonCB::handleSettingsChange(settings::type type, const QJsonDocument& data)
 {
 	QJsonObject dat;
 	if(data.isObject())
@@ -393,7 +393,7 @@ void JsonCB::handleSettingsChange(const settings::type& type, const QJsonDocumen
 	doCallback("settings-update", QVariant(dat));
 }
 
-void JsonCB::handleLedsConfigChange(const settings::type& type, const QJsonDocument& data)
+void JsonCB::handleLedsConfigChange(settings::type type, const QJsonDocument& data)
 {
 	if(type == settings::LEDS)
 	{

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -40,7 +40,7 @@ BlackBorderProcessor::~BlackBorderProcessor()
 	delete _detector;
 }
 
-void BlackBorderProcessor::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void BlackBorderProcessor::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::BLACKBORDER)
 	{
@@ -69,7 +69,7 @@ void BlackBorderProcessor::handleSettingsUpdate(const settings::type& type, cons
 	}
 }
 
-void BlackBorderProcessor::handleCompStateChangeRequest(const hyperion::Components component, bool enable)
+void BlackBorderProcessor::handleCompStateChangeRequest(hyperion::Components component, bool enable)
 {
 	if(component == hyperion::COMP_BLACKBORDER)
 	{
@@ -89,7 +89,7 @@ void BlackBorderProcessor::handleCompStateChangeRequest(const hyperion::Componen
 	}
 }
 
-void BlackBorderProcessor::setHardDisable(const bool& disable) {
+void BlackBorderProcessor::setHardDisable(bool disable) {
 
 	if (disable)
 	{

--- a/libsrc/boblightserver/BoblightClientConnection.cpp
+++ b/libsrc/boblightserver/BoblightClientConnection.cpp
@@ -23,7 +23,7 @@
 // project includes
 #include "BoblightClientConnection.h"
 
-BoblightClientConnection::BoblightClientConnection(Hyperion* hyperion, QTcpSocket *socket, const int priority)
+BoblightClientConnection::BoblightClientConnection(Hyperion* hyperion, QTcpSocket *socket, int priority)
 	: QObject()
 	, _locale(QLocale::C)
 	, _socket(socket)

--- a/libsrc/boblightserver/BoblightClientConnection.h
+++ b/libsrc/boblightserver/BoblightClientConnection.h
@@ -25,7 +25,7 @@ public:
 	/// @param socket The Socket object for this connection
 	/// @param hyperion The Hyperion server
 	///
-	BoblightClientConnection(Hyperion* hyperion, QTcpSocket * socket, const int priority);
+	BoblightClientConnection(Hyperion* hyperion, QTcpSocket * socket, int priority);
 
 	///
 	/// Destructor

--- a/libsrc/boblightserver/BoblightServer.cpp
+++ b/libsrc/boblightserver/BoblightServer.cpp
@@ -72,7 +72,7 @@ bool BoblightServer::active()
 	return _server->isListening();
 }
 
-void BoblightServer::compStateChangeRequest(const hyperion::Components component, bool enable)
+void BoblightServer::compStateChangeRequest(hyperion::Components component, bool enable)
 {
 	if (component == COMP_BOBLIGHTSERVER)
 	{
@@ -114,7 +114,7 @@ void BoblightServer::closedConnection(BoblightClientConnection *connection)
 	connection->deleteLater();
 }
 
-void BoblightServer::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void BoblightServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::BOBLSERVER)
 	{

--- a/libsrc/bonjour/bonjourserviceregister.cpp
+++ b/libsrc/bonjour/bonjourserviceregister.cpp
@@ -51,7 +51,7 @@ BonjourServiceRegister::~BonjourServiceRegister()
 	}
 }
 
-void BonjourServiceRegister::registerService(const QString& service, const int& port)
+void BonjourServiceRegister::registerService(const QString& service, int port)
 {
 	_port = port;
 	// zeroconf $configname@$hostname:port

--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -48,7 +48,7 @@ EffectFileHandler::EffectFileHandler(const QString& rootPath, const QJsonDocumen
 	handleSettingsUpdate(settings::EFFECTS, effectConfig);
 }
 
-void EffectFileHandler::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void EffectFileHandler::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::EFFECTS)
 	{

--- a/libsrc/flatbufserver/FlatBufferClient.cpp
+++ b/libsrc/flatbufserver/FlatBufferClient.cpp
@@ -6,7 +6,7 @@
 #include <QTimer>
 #include <QRgb>
 
-FlatBufferClient::FlatBufferClient(QTcpSocket* socket, const int &timeout, QObject *parent)
+FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, QObject *parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("FLATBUFSERVER"))
 	, _socket(socket)
@@ -104,7 +104,7 @@ void FlatBufferClient::handleColorCommand(const hyperionnet::Color *colorReq)
 	sendSuccessReply();
 }
 
-void FlatBufferClient::registationRequired(const int priority)
+void FlatBufferClient::registationRequired(int priority)
 {
 	if (_priority == priority)
 	{

--- a/libsrc/flatbufserver/FlatBufferClient.h
+++ b/libsrc/flatbufserver/FlatBufferClient.h
@@ -30,28 +30,28 @@ public:
 	/// @param timeout  The timeout when a client is automatically disconnected and the priority unregistered
 	/// @param parent   The parent
 	///
-	explicit FlatBufferClient(QTcpSocket* socket, const int &timeout, QObject *parent = nullptr);
+	explicit FlatBufferClient(QTcpSocket* socket, int timeout, QObject *parent = nullptr);
 
 signals:
 	///
 	/// @brief forward register data to HyperionDaemon
 	///
-	void registerGlobalInput(const int priority, const hyperion::Components& component, const QString& origin = "FlatBuffer", const QString& owner = "", unsigned smooth_cfg = 0);
+	void registerGlobalInput(int priority, hyperion::Components component, const QString& origin = "FlatBuffer", const QString& owner = "", unsigned smooth_cfg = 0);
 
 	///
 	/// @brief Forward clear command to HyperionDaemon
 	///
-	void clearGlobalInput(const int priority, bool forceClearAll=false);
+	void clearGlobalInput(int priority, bool forceClearAll=false);
 
 	///
 	/// @brief forward prepared image to HyperionDaemon
 	///
-	const bool setGlobalInputImage(const int priority, const Image<ColorRgb>& image, const int timeout_ms, const bool& clearEffect = false);
+	bool setGlobalInputImage(int priority, const Image<ColorRgb>& image, int timeout_ms, bool clearEffect = false);
 
 	///
 	/// @brief Forward requested color
 	///
-	void setGlobalInputColor(const int priority, const std::vector<ColorRgb> &ledColor, const int timeout_ms, const QString& origin = "FlatBuffer" ,bool clearEffects = true);
+	void setGlobalInputColor(int priority, const std::vector<ColorRgb> &ledColor, int timeout_ms, const QString& origin = "FlatBuffer" ,bool clearEffects = true);
 
 	///
 	/// @brief Emits whenever the client disconnected
@@ -62,7 +62,7 @@ public slots:
 	///
 	/// @brief Requests a registration from the client
 	///
-	void registationRequired(const int priority);
+	void registationRequired(int priority);
 
 	///
 	/// @brief close the socket and call disconnected()

--- a/libsrc/flatbufserver/FlatBufferConnection.cpp
+++ b/libsrc/flatbufserver/FlatBufferConnection.cpp
@@ -11,7 +11,7 @@
 #include "hyperion_reply_generated.h"
 #include "hyperion_request_generated.h"
 
-FlatBufferConnection::FlatBufferConnection(const QString& origin, const QString & address, const int& priority, const bool& skipReply)
+FlatBufferConnection::FlatBufferConnection(const QString& origin, const QString & address, int priority, bool skipReply)
 	: _socket()
 	, _origin(origin)
 	, _priority(priority)
@@ -85,7 +85,7 @@ void FlatBufferConnection::readData()
 	}
 }
 
-void FlatBufferConnection::setSkipReply(const bool& skip)
+void FlatBufferConnection::setSkipReply(bool skip)
 {
 	if(skip)
 		disconnect(&_socket, &QTcpSocket::readyRead, 0, 0);

--- a/libsrc/flatbufserver/FlatBufferServer.cpp
+++ b/libsrc/flatbufserver/FlatBufferServer.cpp
@@ -35,7 +35,7 @@ void FlatBufferServer::initServer()
 	handleSettingsUpdate(settings::FLATBUFSERVER, _config);
 }
 
-void FlatBufferServer::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void FlatBufferServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::FLATBUFSERVER)
 	{

--- a/libsrc/grabber/amlogic/AmlogicGrabber.cpp
+++ b/libsrc/grabber/amlogic/AmlogicGrabber.cpp
@@ -20,7 +20,7 @@
 #define VIDEO_DEVICE   "/dev/amvideo"
 #define CAPTURE_DEVICE "/dev/amvideocap0"
 
-AmlogicGrabber::AmlogicGrabber(const unsigned width, const unsigned height)
+AmlogicGrabber::AmlogicGrabber(unsigned width, unsigned height)
 	: Grabber("AMLOGICGRABBER", qMax(160u, width), qMax(160u, height)) // Minimum required width or height is 160
 	, _captureDev(-1)
 	, _videoDev(-1)

--- a/libsrc/grabber/amlogic/AmlogicWrapper.cpp
+++ b/libsrc/grabber/amlogic/AmlogicWrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/AmlogicWrapper.h>
 
-AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight)
+AmlogicWrapper::AmlogicWrapper(unsigned grabWidth, unsigned grabHeight)
 	: GrabberWrapper("AmLogic", &_grabber, grabWidth, grabHeight)
 	, _grabber(grabWidth, grabHeight)
 {}

--- a/libsrc/grabber/dispmanx/DispmanxFrameGrabber.cpp
+++ b/libsrc/grabber/dispmanx/DispmanxFrameGrabber.cpp
@@ -6,7 +6,7 @@
 // Local includes
 #include "grabber/DispmanxFrameGrabber.h"
 
-DispmanxFrameGrabber::DispmanxFrameGrabber(const unsigned width, const unsigned height)
+DispmanxFrameGrabber::DispmanxFrameGrabber(unsigned width, unsigned height)
 	: Grabber("DISPMANXGRABBER", 0, 0)
 	, _vc_display(0)
 	, _vc_resource(0)
@@ -84,7 +84,7 @@ bool DispmanxFrameGrabber::setWidthHeight(int width, int height)
 	return false;
 }
 
-void DispmanxFrameGrabber::setFlags(const int vc_flags)
+void DispmanxFrameGrabber::setFlags(int vc_flags)
 {
 	_vc_flags = vc_flags;
 }

--- a/libsrc/grabber/dispmanx/DispmanxWrapper.cpp
+++ b/libsrc/grabber/dispmanx/DispmanxWrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/DispmanxWrapper.h>
 
-DispmanxWrapper::DispmanxWrapper(const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz)
+DispmanxWrapper::DispmanxWrapper(unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz)
 	: GrabberWrapper("Dispmanx", &_grabber, grabWidth, grabHeight, updateRate_Hz)
 	, _grabber(grabWidth, grabHeight)
 {

--- a/libsrc/grabber/framebuffer/FramebufferFrameGrabber.cpp
+++ b/libsrc/grabber/framebuffer/FramebufferFrameGrabber.cpp
@@ -13,7 +13,7 @@
 // Local includes
 #include <grabber/FramebufferFrameGrabber.h>
 
-FramebufferFrameGrabber::FramebufferFrameGrabber(const QString & device, const unsigned width, const unsigned height)
+FramebufferFrameGrabber::FramebufferFrameGrabber(const QString & device, unsigned width, unsigned height)
 	: Grabber("FRAMEBUFFERGRABBER", width, height)
 	, _fbDevice()
 {

--- a/libsrc/grabber/framebuffer/FramebufferWrapper.cpp
+++ b/libsrc/grabber/framebuffer/FramebufferWrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/FramebufferWrapper.h>
 
-FramebufferWrapper::FramebufferWrapper(const QString & device, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz)
+FramebufferWrapper::FramebufferWrapper(const QString & device, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz)
 	: GrabberWrapper("FrameBuffer", &_grabber, grabWidth, grabHeight, updateRate_Hz)
 	, _grabber(device, grabWidth, grabHeight)
 {}

--- a/libsrc/grabber/osx/OsxFrameGrabber.cpp
+++ b/libsrc/grabber/osx/OsxFrameGrabber.cpp
@@ -5,7 +5,7 @@
 // Local includes
 #include <grabber/OsxFrameGrabber.h>
 
-OsxFrameGrabber::OsxFrameGrabber(const unsigned display, const unsigned width, const unsigned height)
+OsxFrameGrabber::OsxFrameGrabber(unsigned display, unsigned width, unsigned height)
 	: Grabber("OSXGRABBER", width, height)
 	, _screenIndex(100)
 {

--- a/libsrc/grabber/osx/OsxWrapper.cpp
+++ b/libsrc/grabber/osx/OsxWrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/OsxWrapper.h>
 
-OsxWrapper::OsxWrapper(const unsigned display, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz)
+OsxWrapper::OsxWrapper(unsigned display, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz)
 	: GrabberWrapper("OSX FrameGrabber", &_grabber, grabWidth, grabHeight, updateRate_Hz)
 	, _grabber(display, grabWidth, grabHeight)
 {}

--- a/libsrc/grabber/qt/QtGrabber.cpp
+++ b/libsrc/grabber/qt/QtGrabber.cpp
@@ -116,7 +116,7 @@ int QtGrabber::grabFrame(Image<ColorRgb> & image)
 	return 0;
 }
 
-int QtGrabber::updateScreenDimensions(const bool& force)
+int QtGrabber::updateScreenDimensions(bool force)
 {
 	if(!_screen)
 		return -1;

--- a/libsrc/grabber/qt/QtWrapper.cpp
+++ b/libsrc/grabber/qt/QtWrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/QtWrapper.h>
 
-QtWrapper::QtWrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, int display, const unsigned updateRate_Hz)
+QtWrapper::QtWrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, int display, unsigned updateRate_Hz)
 	: GrabberWrapper("Qt", &_grabber, 0, 0, updateRate_Hz)
 	, _grabber(cropLeft, cropRight, cropTop, cropBottom, pixelDecimation, display)
 {}

--- a/libsrc/grabber/v4l2/V4L2Wrapper.cpp
+++ b/libsrc/grabber/v4l2/V4L2Wrapper.cpp
@@ -110,7 +110,7 @@ void V4L2Wrapper::handleCecEvent(CECEvent event)
 	_grabber.handleCecEvent(event);
 }
 
-void V4L2Wrapper::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void V4L2Wrapper::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::V4L2 && _grabberName.startsWith("V4L"))
 	{

--- a/libsrc/grabber/x11/X11Wrapper.cpp
+++ b/libsrc/grabber/x11/X11Wrapper.cpp
@@ -1,6 +1,6 @@
 #include <grabber/X11Wrapper.h>
 
-X11Wrapper::X11Wrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, const unsigned updateRate_Hz)
+X11Wrapper::X11Wrapper(int cropLeft, int cropRight, int cropTop, int cropBottom, int pixelDecimation, unsigned updateRate_Hz)
 	: GrabberWrapper("X11", &_grabber, 0, 0, updateRate_Hz)
 	, _grabber(cropLeft, cropRight, cropTop, cropBottom, pixelDecimation)
 	, _init(false)

--- a/libsrc/hyperion/AuthManager.cpp
+++ b/libsrc/hyperion/AuthManager.cpp
@@ -85,7 +85,7 @@ const QString AuthManager::getUserToken(const QString &usr)
 	return QString(_authTable->getUserToken(usr));
 }
 
-void AuthManager::setAuthBlock(const bool &user)
+void AuthManager::setAuthBlock(bool user)
 {
 	// current timestamp +10 minutes
 	if (user)
@@ -172,7 +172,7 @@ void AuthManager::cancelNewTokenRequest(QObject *caller, const QString &comment,
 	}
 }
 
-void AuthManager::handlePendingTokenRequest(const QString &id, const bool &accept)
+void AuthManager::handlePendingTokenRequest(const QString &id, bool accept)
 {
 	if (_pendingRequests.contains(id))
 	{
@@ -226,7 +226,7 @@ bool AuthManager::deleteToken(const QString &id)
 	return false;
 }
 
-void AuthManager::handleSettingsUpdate(const settings::type &type, const QJsonDocument &config)
+void AuthManager::handleSettingsUpdate(settings::type type, const QJsonDocument &config)
 {
 	if (type == settings::NETWORK)
 	{

--- a/libsrc/hyperion/CaptureCont.cpp
+++ b/libsrc/hyperion/CaptureCont.cpp
@@ -63,7 +63,7 @@ void CaptureCont::handleSystemImage(const QString& name, const Image<ColorRgb>& 
 	_hyperion->setInputImage(_systemCaptPrio, image);
 }
 
-void CaptureCont::setSystemCaptureEnable(const bool& enable)
+void CaptureCont::setSystemCaptureEnable(bool enable)
 {
 	if(_systemCaptEnabled != enable)
 	{
@@ -86,7 +86,7 @@ void CaptureCont::setSystemCaptureEnable(const bool& enable)
 	}
 }
 
-void CaptureCont::setV4LCaptureEnable(const bool& enable)
+void CaptureCont::setV4LCaptureEnable(bool enable)
 {
 	if(_v4lCaptEnabled != enable)
 	{
@@ -109,7 +109,7 @@ void CaptureCont::setV4LCaptureEnable(const bool& enable)
 	}
 }
 
-void CaptureCont::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void CaptureCont::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::INSTCAPTURE)
 	{
@@ -130,7 +130,7 @@ void CaptureCont::handleSettingsUpdate(const settings::type& type, const QJsonDo
 	}
 }
 
-void CaptureCont::handleCompStateChangeRequest(const hyperion::Components component, bool enable)
+void CaptureCont::handleCompStateChangeRequest(hyperion::Components component, bool enable)
 {
 	if(component == hyperion::COMP_GRABBER)
 	{

--- a/libsrc/hyperion/ComponentRegister.cpp
+++ b/libsrc/hyperion/ComponentRegister.cpp
@@ -24,12 +24,12 @@ ComponentRegister::~ComponentRegister()
 {
 }
 
-int ComponentRegister::isComponentEnabled(const hyperion::Components& comp) const
+int ComponentRegister::isComponentEnabled(hyperion::Components comp) const
 {
 	return (_componentStates.count(comp)) ? _componentStates.at(comp) : -1;
 }
 
-void ComponentRegister::setNewComponentState(const hyperion::Components comp, const bool activated)
+void ComponentRegister::setNewComponentState(hyperion::Components comp, bool activated)
 {
 	if(_componentStates[comp] != activated)
 	{
@@ -40,7 +40,7 @@ void ComponentRegister::setNewComponentState(const hyperion::Components comp, co
 	}
 }
 
-void ComponentRegister::handleCompStateChangeRequest(const hyperion::Components comps, const bool activated)
+void ComponentRegister::handleCompStateChangeRequest(hyperion::Components comps, bool activated)
 {
 	if(comps == COMP_ALL && !_inProgress)
 	{

--- a/libsrc/hyperion/GrabberWrapper.cpp
+++ b/libsrc/hyperion/GrabberWrapper.cpp
@@ -11,7 +11,7 @@
 
 GrabberWrapper* GrabberWrapper::instance = nullptr;
 
-GrabberWrapper::GrabberWrapper(QString grabberName, Grabber * ggrabber, unsigned width, unsigned height, const unsigned updateRate_Hz)
+GrabberWrapper::GrabberWrapper(QString grabberName, Grabber * ggrabber, unsigned width, unsigned height, unsigned updateRate_Hz)
 	: _grabberName(grabberName)
 	, _timer(new QTimer(this))
 	, _updateInterval_ms(1000/updateRate_Hz)
@@ -101,7 +101,7 @@ QStringList GrabberWrapper::availableGrabbers()
 	return grabbers;
 }
 
-void GrabberWrapper::setVideoMode(const VideoMode& mode)
+void GrabberWrapper::setVideoMode(VideoMode mode)
 {
 	if (_ggrabber != nullptr)
 	{
@@ -130,7 +130,7 @@ void GrabberWrapper::updateTimer(int interval)
 	}
 }
 
-void GrabberWrapper::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void GrabberWrapper::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::SYSTEMCAPTURE && !_grabberName.startsWith("V4L"))
 	{
@@ -161,7 +161,7 @@ void GrabberWrapper::handleSettingsUpdate(const settings::type& type, const QJso
 	}
 }
 
-void GrabberWrapper::handleSourceRequest(const hyperion::Components& component, const int hyperionInd, const bool listen)
+void GrabberWrapper::handleSourceRequest(hyperion::Components component, int hyperionInd, bool listen)
 {
 	if(component == hyperion::Components::COMP_GRABBER  && !_grabberName.startsWith("V4L"))
 	{

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -39,7 +39,7 @@
 // Boblight
 #include <boblightserver/BoblightServer.h>
 
-Hyperion::Hyperion(const quint8& instance)
+Hyperion::Hyperion(quint8 instance)
 	: QObject()
 	, _instIndex(instance)
 	, _settingsManager(new SettingsManager(instance, this))
@@ -166,7 +166,7 @@ void Hyperion::freeObjects()
 	delete _ledDeviceWrapper;
 }
 
-void Hyperion::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void Hyperion::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 //	std::cout << "Hyperion::handleSettingsUpdate" << std::endl;
 //	std::cout << config.toJson().toStdString() << std::endl;
@@ -250,12 +250,12 @@ void Hyperion::handleSettingsUpdate(const settings::type& type, const QJsonDocum
 	update();
 }
 
-QJsonDocument Hyperion::getSetting(const settings::type& type) const
+QJsonDocument Hyperion::getSetting(settings::type type) const
 {
 	return _settingsManager->getSetting(type);
 }
 
-bool Hyperion::saveSettings(QJsonObject config, const bool& correct)
+bool Hyperion::saveSettings(QJsonObject config, bool correct)
 {
 	return _settingsManager->saveSettings(config, correct);
 }
@@ -280,12 +280,12 @@ unsigned Hyperion::getLedCount() const
 	return _ledString.leds().size();
 }
 
-void Hyperion::setSourceAutoSelect(const bool state)
+void Hyperion::setSourceAutoSelect(bool state)
 {
 	_muxer.setSourceAutoSelectEnabled(state);
 }
 
-bool Hyperion::setVisiblePriority(const int& priority)
+bool Hyperion::setVisiblePriority(int priority)
 {
 	return _muxer.setPriority(priority);
 }
@@ -295,7 +295,7 @@ bool Hyperion::sourceAutoSelectEnabled()
 	return _muxer.isSourceAutoSelectEnabled();
 }
 
-void Hyperion::setNewComponentState(const hyperion::Components& component, const bool& state)
+void Hyperion::setNewComponentState(hyperion::Components component, bool state)
 {
 	_componentRegister.setNewComponentState(component, state);
 }
@@ -305,17 +305,17 @@ std::map<hyperion::Components, bool> Hyperion::getAllComponents() const
 	return _componentRegister.getRegister();
 }
 
-int Hyperion::isComponentEnabled(const hyperion::Components &comp)
+int Hyperion::isComponentEnabled(hyperion::Components comp)
 {
 	return _componentRegister.isComponentEnabled(comp);
 }
 
-void Hyperion::registerInput(const int priority, const hyperion::Components& component, const QString& origin, const QString& owner, unsigned smooth_cfg)
+void Hyperion::registerInput(int priority, hyperion::Components component, const QString& origin, const QString& owner, unsigned smooth_cfg)
 {
 	_muxer.registerInput(priority, component, origin, owner, smooth_cfg);
 }
 
-bool Hyperion::setInput(const int priority, const std::vector<ColorRgb>& ledColors, int timeout_ms, const bool& clearEffect)
+bool Hyperion::setInput(int priority, const std::vector<ColorRgb>& ledColors, int timeout_ms, bool clearEffect)
 {
 	if(_muxer.setInput(priority, ledColors, timeout_ms))
 	{
@@ -334,7 +334,7 @@ bool Hyperion::setInput(const int priority, const std::vector<ColorRgb>& ledColo
 	return false;
 }
 
-bool Hyperion::setInputImage(const int priority, const Image<ColorRgb>& image, int64_t timeout_ms, const bool& clearEffect)
+bool Hyperion::setInputImage(int priority, const Image<ColorRgb>& image, int64_t timeout_ms, bool clearEffect)
 {
 	if (!_muxer.hasPriority(priority))
 	{
@@ -359,12 +359,12 @@ bool Hyperion::setInputImage(const int priority, const Image<ColorRgb>& image, i
 	return false;
 }
 
-bool Hyperion::setInputInactive(const quint8& priority)
+bool Hyperion::setInputInactive(quint8 priority)
 {
 	return _muxer.setInputInactive(priority);
 }
 
-void Hyperion::setColor(const int priority, const std::vector<ColorRgb> &ledColors, const int timeout_ms, const QString &origin, bool clearEffects)
+void Hyperion::setColor(int priority, const std::vector<ColorRgb> &ledColors, int timeout_ms, const QString &origin, bool clearEffects)
 {
 	// clear effect if this call does not come from an effect
 	if (clearEffects)
@@ -412,7 +412,7 @@ void Hyperion::adjustmentsUpdated()
 	update();
 }
 
-bool Hyperion::clear(const int priority, bool forceClearAll)
+bool Hyperion::clear(int priority, bool forceClearAll)
 {
 	if (priority < 0)
 	{
@@ -439,7 +439,7 @@ int Hyperion::getCurrentPriority() const
 	return _muxer.getCurrentPriority();
 }
 
-bool Hyperion::isCurrentPriority(const int priority) const
+bool Hyperion::isCurrentPriority(int priority) const
 {
 	return getCurrentPriority() == priority;
 }
@@ -449,7 +449,7 @@ QList<int> Hyperion::getActivePriorities() const
 	return _muxer.getPriorities();
 }
 
-Hyperion::InputInfo Hyperion::getPriorityInfo(const int priority) const
+Hyperion::InputInfo Hyperion::getPriorityInfo(int priority) const
 {
 	return _muxer.getInputInfo(priority);
 }
@@ -494,7 +494,7 @@ int Hyperion::setEffect(const QString &effectName, const QJsonObject &args, int 
 	return _effectEngine->runEffect(effectName, args, priority, timeout, pythonScript, origin, 0, imageData);
 }
 
-void Hyperion::setLedMappingType(const int& mappingType)
+void Hyperion::setLedMappingType(int mappingType)
 {
 	if(mappingType != _imageProcessor->getUserLedMappingType())
 	{
@@ -508,7 +508,7 @@ int Hyperion::getLedMappingType() const
 	return _imageProcessor->getUserLedMappingType();
 }
 
-void Hyperion::setVideoMode(const VideoMode& mode)
+void Hyperion::setVideoMode(VideoMode mode)
 {
 	emit videoMode(mode);
 }
@@ -523,7 +523,7 @@ QString Hyperion::getActiveDeviceType() const
 	return _ledDeviceWrapper->getActiveDeviceType();
 }
 
-void Hyperion::handleVisibleComponentChanged(const hyperion::Components &comp)
+void Hyperion::handleVisibleComponentChanged(hyperion::Components comp)
 {
 	_imageProcessor->setBlackbarDetectDisable((comp == hyperion::COMP_EFFECT));
 	_imageProcessor->setHardLedMappingType((comp == hyperion::COMP_EFFECT) ? 0 : -1);

--- a/libsrc/hyperion/HyperionIManager.cpp
+++ b/libsrc/hyperion/HyperionIManager.cpp
@@ -19,7 +19,7 @@ HyperionIManager::HyperionIManager(const QString& rootPath, QObject* parent)
 	qRegisterMetaType<InstanceState>("InstanceState");
 }
 
-Hyperion* HyperionIManager::getHyperionInstance(const quint8& instance)
+Hyperion* HyperionIManager::getHyperionInstance(quint8 instance)
 {
 	if(_runningInstances.contains(instance))
 		return _runningInstances.value(instance);
@@ -57,7 +57,7 @@ void HyperionIManager::stopAll()
 	}
 }
 
-void HyperionIManager::toggleStateAllInstances(const bool& pause)
+void HyperionIManager::toggleStateAllInstances(bool pause)
 {
 	// copy the instances due to loop corruption, even with .erase() return next iter
 	QMap<quint8, Hyperion*> instCopy = _runningInstances;
@@ -67,7 +67,7 @@ void HyperionIManager::toggleStateAllInstances(const bool& pause)
 	}
 }
 
-bool HyperionIManager::startInstance(const quint8& inst, const bool& block)
+bool HyperionIManager::startInstance(quint8 inst, bool block)
 {
 	if(_instanceTable->instanceExist(inst))
 	{
@@ -113,7 +113,7 @@ bool HyperionIManager::startInstance(const quint8& inst, const bool& block)
 	return false;
 }
 
-bool HyperionIManager::stopInstance(const quint8& inst)
+bool HyperionIManager::stopInstance(quint8 inst)
 {
 	// inst 0 can't be stopped
 	if(!isInstAllowed(inst))
@@ -140,7 +140,7 @@ bool HyperionIManager::stopInstance(const quint8& inst)
 	return false;
 }
 
-bool HyperionIManager::createInstance(const QString& name, const bool& start)
+bool HyperionIManager::createInstance(const QString& name, bool start)
 {
 	quint8 inst;
 	if(_instanceTable->createInstance(name, inst))
@@ -156,7 +156,7 @@ bool HyperionIManager::createInstance(const QString& name, const bool& start)
 	return false;
 }
 
-bool HyperionIManager::deleteInstance(const quint8& inst)
+bool HyperionIManager::deleteInstance(quint8 inst)
 {
 	// inst 0 can't be deleted
 	if(!isInstAllowed(inst))
@@ -176,7 +176,7 @@ bool HyperionIManager::deleteInstance(const quint8& inst)
 	return false;
 }
 
-bool HyperionIManager::saveName(const quint8& inst, const QString& name)
+bool HyperionIManager::saveName(quint8 inst, const QString& name)
 {
 	if(_instanceTable->saveName(inst, name))
 	{
@@ -189,7 +189,7 @@ bool HyperionIManager::saveName(const quint8& inst, const QString& name)
 void HyperionIManager::handleFinished()
 {
 	Hyperion* hyperion = qobject_cast<Hyperion*>(sender());
-	const quint8 & instance = hyperion->getInstanceIndex();
+	quint8 instance = hyperion->getInstanceIndex();
 
 	Info(_log,"Hyperion instance '%s' has been stopped", QSTRING_CSTR(_instanceTable->getNamebyIndex(instance)));
 
@@ -203,7 +203,7 @@ void HyperionIManager::handleFinished()
 void HyperionIManager::handleStarted()
 {
 	Hyperion* hyperion = qobject_cast<Hyperion*>(sender());
-	const quint8 & instance = hyperion->getInstanceIndex();
+	quint8 instance = hyperion->getInstanceIndex();
 
 	Info(_log,"Hyperion instance '%s' has been started", QSTRING_CSTR(_instanceTable->getNamebyIndex(instance)));
 

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -48,7 +48,7 @@ ImageProcessor::~ImageProcessor()
 	delete _imageToLeds;
 }
 
-void ImageProcessor::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void ImageProcessor::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::COLOR)
 	{
@@ -61,7 +61,7 @@ void ImageProcessor::handleSettingsUpdate(const settings::type& type, const QJso
 	}
 }
 
-void ImageProcessor::setSize(const unsigned width, const unsigned height)
+void ImageProcessor::setSize(unsigned width, unsigned height)
 {
 	// Check if the existing buffer-image is already the correct dimensions
 	if (_imageToLeds && _imageToLeds->width() == width && _imageToLeds->height() == height)

--- a/libsrc/hyperion/ImageToLedsMap.cpp
+++ b/libsrc/hyperion/ImageToLedsMap.cpp
@@ -3,10 +3,10 @@
 using namespace hyperion;
 
 ImageToLedsMap::ImageToLedsMap(
-		const unsigned width,
-		const unsigned height,
-		const unsigned horizontalBorder,
-		const unsigned verticalBorder,
+		unsigned width,
+		unsigned height,
+		unsigned horizontalBorder,
+		unsigned verticalBorder,
 		const std::vector<Led>& leds)
 	: _width(width)
 	, _height(height)

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -43,7 +43,7 @@ LinearColorSmoothing::LinearColorSmoothing(const QJsonDocument& config, Hyperion
 	connect(_timer, &QTimer::timeout, this, &LinearColorSmoothing::updateLeds);
 }
 
-void LinearColorSmoothing::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void LinearColorSmoothing::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::SMOOTHING)
 	{
@@ -198,7 +198,7 @@ void LinearColorSmoothing::clearQueuedColors()
 	_targetValues.clear();
 }
 
-void LinearColorSmoothing::componentStateChange(const hyperion::Components component, const bool state)
+void LinearColorSmoothing::componentStateChange(hyperion::Components component, bool state)
 {
 	_writeToLedsEnable = state;
 	if(component == hyperion::COMP_LEDDEVICE)
@@ -254,7 +254,7 @@ unsigned LinearColorSmoothing::updateConfig(unsigned cfgID, int settlingTime_ms,
 	return updatedCfgID;
 }
 
-bool LinearColorSmoothing::selectConfig(unsigned cfg, const bool& force)
+bool LinearColorSmoothing::selectConfig(unsigned cfg, bool force)
 {
 	if (_currentConfigId == cfg && !force)
 	{

--- a/libsrc/hyperion/LinearColorSmoothing.h
+++ b/libsrc/hyperion/LinearColorSmoothing.h
@@ -74,7 +74,7 @@ public:
 	///
 	/// @return  On success return else false (and falls back to cfg 0)
 	///
-	bool selectConfig(unsigned cfg, const bool& force = false);
+	bool selectConfig(unsigned cfg, bool force = false);
 
 public slots:
 	///
@@ -82,7 +82,7 @@ public slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 private slots:
 	/// Timer callback which writes updated led values to the led device
@@ -93,7 +93,7 @@ private slots:
 	/// @param component   The component
 	/// @param state       The requested state
 	///
-	void componentStateChange(const hyperion::Components component, const bool state);
+	void componentStateChange(hyperion::Components component, bool state);
 
 private:
 

--- a/libsrc/hyperion/MessageForwarder.cpp
+++ b/libsrc/hyperion/MessageForwarder.cpp
@@ -43,7 +43,7 @@ MessageForwarder::~MessageForwarder()
 		delete _forwardClients.takeFirst();
 }
 
-void MessageForwarder::handleSettingsUpdate(const settings::type &type, const QJsonDocument &config)
+void MessageForwarder::handleSettingsUpdate(settings::type type, const QJsonDocument &config)
 {
 	if(type == settings::NETFORWARD)
 	{
@@ -95,7 +95,7 @@ void MessageForwarder::handleSettingsUpdate(const settings::type &type, const QJ
 	}
 }
 
-void MessageForwarder::handleCompStateChangeRequest(const hyperion::Components component, bool enable)
+void MessageForwarder::handleCompStateChangeRequest(hyperion::Components component, bool enable)
 {
 	if (component == hyperion::COMP_FORWARDER && _forwarder_enabled != enable)
 	{
@@ -106,7 +106,7 @@ void MessageForwarder::handleCompStateChangeRequest(const hyperion::Components c
 	}
 }
 
-void MessageForwarder::handlePriorityChanges(const quint8 &priority)
+void MessageForwarder::handlePriorityChanges(quint8 priority)
 {
 	const QJsonObject obj = _hyperion->getSetting(settings::NETFORWARD).object();
 	if (priority != 0 && _forwarder_enabled && obj["enable"].toBool())

--- a/libsrc/hyperion/MultiColorAdjustment.cpp
+++ b/libsrc/hyperion/MultiColorAdjustment.cpp
@@ -2,7 +2,7 @@
 #include <utils/Logger.h>
 #include <hyperion/MultiColorAdjustment.h>
 
-MultiColorAdjustment::MultiColorAdjustment(const unsigned ledCnt)
+MultiColorAdjustment::MultiColorAdjustment(unsigned ledCnt)
 	: _ledAdjustments(ledCnt, nullptr)
 	, _log(Logger::getInstance("ADJUSTMENT"))
 {
@@ -25,7 +25,7 @@ void MultiColorAdjustment::addAdjustment(ColorAdjustment * adjustment)
 	_adjustment.push_back(adjustment);
 }
 
-void MultiColorAdjustment::setAdjustmentForLed(const QString& id, const unsigned startLed, unsigned endLed)
+void MultiColorAdjustment::setAdjustmentForLed(const QString& id, unsigned startLed, unsigned endLed)
 {
 	// abort
 	if(startLed > endLed)

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -55,12 +55,12 @@ PriorityMuxer::~PriorityMuxer()
 {
 }
 
-void PriorityMuxer::setEnable(const bool& enable)
+void PriorityMuxer::setEnable(bool enable)
 {
 	enable ? _updateTimer->start() : _updateTimer->stop();
 }
 
-bool PriorityMuxer::setSourceAutoSelectEnabled(const bool& enable, const bool& update)
+bool PriorityMuxer::setSourceAutoSelectEnabled(bool enable, bool update)
 {
 	if(_sourceAutoSelectEnabled != enable)
 	{
@@ -84,7 +84,7 @@ bool PriorityMuxer::setSourceAutoSelectEnabled(const bool& enable, const bool& u
 	return false;
 }
 
-bool PriorityMuxer::setPriority(const uint8_t priority)
+bool PriorityMuxer::setPriority(uint8_t priority)
 {
 	if(_activeInputs.contains(priority))
 	{
@@ -96,7 +96,7 @@ bool PriorityMuxer::setPriority(const uint8_t priority)
 	return false;
 }
 
-void PriorityMuxer::updateLedColorsLength(const int& ledCount)
+void PriorityMuxer::updateLedColorsLength(int ledCount)
 {
 	for (auto infoIt = _activeInputs.begin(); infoIt != _activeInputs.end();)
 	{
@@ -113,12 +113,12 @@ QList<int> PriorityMuxer::getPriorities() const
 	return _activeInputs.keys();
 }
 
-bool PriorityMuxer::hasPriority(const int priority) const
+bool PriorityMuxer::hasPriority(int priority) const
 {
 	return (priority == PriorityMuxer::LOWEST_PRIORITY) ? true : _activeInputs.contains(priority);
 }
 
-const PriorityMuxer::InputInfo PriorityMuxer::getInputInfo(const int priority) const
+PriorityMuxer::InputInfo PriorityMuxer::getInputInfo(int priority) const
 {
 	auto elemIt = _activeInputs.find(priority);
 	if (elemIt == _activeInputs.end())
@@ -133,12 +133,12 @@ const PriorityMuxer::InputInfo PriorityMuxer::getInputInfo(const int priority) c
 	return elemIt.value();
 }
 
-hyperion::Components PriorityMuxer::getComponentOfPriority(const int &priority)
+hyperion::Components PriorityMuxer::getComponentOfPriority(int priority)
 {
 	return _activeInputs[priority].componentId;
 }
 
-void PriorityMuxer::registerInput(const int priority, const hyperion::Components& component, const QString& origin, const QString& owner, unsigned smooth_cfg)
+void PriorityMuxer::registerInput(int priority, hyperion::Components component, const QString& origin, const QString& owner, unsigned smooth_cfg)
 {
 	// detect new registers
 	bool newInput = false;
@@ -162,7 +162,7 @@ void PriorityMuxer::registerInput(const int priority, const hyperion::Components
 	}
 }
 
-bool PriorityMuxer::setInput(const int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms)
+bool PriorityMuxer::setInput(int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms)
 {
 	if(!_activeInputs.contains(priority))
 	{
@@ -202,7 +202,7 @@ bool PriorityMuxer::setInput(const int priority, const std::vector<ColorRgb>& le
 	return true;
 }
 
-bool PriorityMuxer::setInputImage(const int priority, const Image<ColorRgb>& image, int64_t timeout_ms)
+bool PriorityMuxer::setInputImage(int priority, const Image<ColorRgb>& image, int64_t timeout_ms)
 {
 	if(!_activeInputs.contains(priority))
 	{
@@ -242,13 +242,13 @@ bool PriorityMuxer::setInputImage(const int priority, const Image<ColorRgb>& ima
 	return true;
 }
 
-bool PriorityMuxer::setInputInactive(const quint8& priority)
+bool PriorityMuxer::setInputInactive(quint8 priority)
 {
 	Image<ColorRgb> image;
 	return setInputImage(priority, image, -100);
 }
 
-bool PriorityMuxer::clearInput(const uint8_t priority)
+bool PriorityMuxer::clearInput(uint8_t priority)
 {
 	if (priority < PriorityMuxer::LOWEST_PRIORITY && _activeInputs.remove(priority))
 	{
@@ -283,7 +283,7 @@ void PriorityMuxer::clearAll(bool forceClearAll)
 	}
 }
 
-void PriorityMuxer::setCurrentTime(void)
+void PriorityMuxer::setCurrentTime()
 {
 	const int64_t now = QDateTime::currentMSecsSinceEpoch();
 	int newPriority;

--- a/libsrc/hyperion/SettingsManager.cpp
+++ b/libsrc/hyperion/SettingsManager.cpp
@@ -14,7 +14,7 @@
 
 QJsonObject SettingsManager::schemaJson;
 
-SettingsManager::SettingsManager(const quint8& instance, QObject* parent)
+SettingsManager::SettingsManager(quint8 instance, QObject* parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("SETTINGSMGR"))
 	, _sTable(new SettingsTable(instance, this))
@@ -107,12 +107,12 @@ SettingsManager::SettingsManager(const quint8& instance, QObject* parent)
 	Debug(_log,"Settings database initialized");
 }
 
-const QJsonDocument SettingsManager::getSetting(const settings::type& type)
+QJsonDocument SettingsManager::getSetting(settings::type type) const
 {
 	return _sTable->getSettingsRecord(settings::typeToString(type));
 }
 
-bool SettingsManager::saveSettings(QJsonObject config, const bool& correct)
+bool SettingsManager::saveSettings(QJsonObject config, bool correct)
 {
 	// optional data upgrades e.g. imported legacy/older configs
 	// handleConfigUpgrade(config);

--- a/libsrc/jsonserver/JsonClientConnection.cpp
+++ b/libsrc/jsonserver/JsonClientConnection.cpp
@@ -6,7 +6,7 @@
 #include <QTcpSocket>
 #include <QHostAddress>
 
-JsonClientConnection::JsonClientConnection(QTcpSocket *socket, const bool& localConnection)
+JsonClientConnection::JsonClientConnection(QTcpSocket *socket, bool localConnection)
 	: QObject()
 	, _socket(socket)
 	, _receiveBuffer()
@@ -53,7 +53,7 @@ qint64 JsonClientConnection::sendMessage(QJsonObject message)
 	return _socket->write(data.data(), data.size());
 }
 
-void JsonClientConnection::disconnected(void)
+void JsonClientConnection::disconnected()
 {
 	emit connectionClosed();
 }

--- a/libsrc/jsonserver/JsonClientConnection.h
+++ b/libsrc/jsonserver/JsonClientConnection.h
@@ -23,7 +23,7 @@ public:
 	/// Constructor
 	/// @param socket The Socket object for this connection
 	///
-	JsonClientConnection(QTcpSocket * socket, const bool& localConnection);
+	JsonClientConnection(QTcpSocket * socket, bool localConnection);
 
 signals:
 	void connectionClosed();

--- a/libsrc/jsonserver/JsonServer.cpp
+++ b/libsrc/jsonserver/JsonServer.cpp
@@ -73,7 +73,7 @@ void JsonServer::stop()
 	Info(_log, "Stopped");
 }
 
-void JsonServer::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void JsonServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::JSONSERVER)
 	{
@@ -113,7 +113,7 @@ void JsonServer::newConnection()
 	}
 }
 
-void JsonServer::closedConnection(void)
+void JsonServer::closedConnection()
 {
 	JsonClientConnection* connection = qobject_cast<JsonClientConnection*>(sender());
 	Debug(_log, "Connection closed");

--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -151,7 +151,7 @@ bool LedDeviceWrapper::enabled()
 	return _enabled;
 }
 
-void LedDeviceWrapper::handleComponentState(const hyperion::Components component, const bool state)
+void LedDeviceWrapper::handleComponentState(hyperion::Components component, bool state)
 {
 	if(component == hyperion::COMP_LEDDEVICE)
 	{

--- a/libsrc/leddevice/dev_hid/ProviderHID.cpp
+++ b/libsrc/leddevice/dev_hid/ProviderHID.cpp
@@ -122,7 +122,7 @@ int ProviderHID::close()
 	return retval;
 }
 
-int ProviderHID::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderHID::writeBytes(unsigned size, const uint8_t * data)
 {
 	if (_blockedForDelay) {
 		return 0;

--- a/libsrc/leddevice/dev_hid/ProviderHID.h
+++ b/libsrc/leddevice/dev_hid/ProviderHID.h
@@ -66,7 +66,7 @@ protected:
 	/// @param[in] data The data
 	/// @return Zero on success, else negative
 	///
-	int writeBytes(const unsigned size, const uint8_t *data);
+	int writeBytes(unsigned size, const uint8_t *data);
 
 	// HID VID and PID
 	unsigned short _VendorId;

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
@@ -342,7 +342,7 @@ bool LedDeviceNanoleaf::initLedsConfiguration()
 	return isInitOK;
 }
 
-bool LedDeviceNanoleaf::initRestAPI(const QString &hostname, const int port, const QString &token )
+bool LedDeviceNanoleaf::initRestAPI(const QString &hostname, int port, const QString &token )
 {
 	bool isInitOK = false;
 

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.h
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.h
@@ -135,7 +135,7 @@ private:
 	///
 	/// @return True, if success
 	///
-	bool initRestAPI(const QString &hostname, const int port, const QString &token );
+	bool initRestAPI(const QString &hostname, int port, const QString &token );
 
 	///
 	/// @brief Get Nanoleaf device details and configuration

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -347,7 +347,7 @@ bool LedDevicePhilipsHueBridge::init(const QJsonObject &deviceConfig)
 	return isInitOK;
 }
 
-bool LedDevicePhilipsHueBridge::initRestAPI(const QString &hostname, const int port, const QString &token )
+bool LedDevicePhilipsHueBridge::initRestAPI(const QString &hostname, int port, const QString &token )
 {
 	bool isInitOK = false;
 
@@ -544,12 +544,12 @@ void LedDevicePhilipsHueBridge::setGroupMap(const QJsonDocument &doc)
 	}
 }
 
-const QMap<quint16,QJsonObject>& LedDevicePhilipsHueBridge::getLightMap(void)
+const QMap<quint16,QJsonObject>& LedDevicePhilipsHueBridge::getLightMap()
 {
 	return _lightsMap;
 }
 
-const QMap<quint16,QJsonObject>& LedDevicePhilipsHueBridge::getGroupMap(void)
+const QMap<quint16,QJsonObject>& LedDevicePhilipsHueBridge::getGroupMap()
 {
 	return _groupsMap;
 }
@@ -642,13 +642,13 @@ QJsonDocument LedDevicePhilipsHueBridge::post(const QString& route, const QStrin
 	return response.getBody();
 }
 
-void LedDevicePhilipsHueBridge::setLightState(const unsigned int lightId, const QString &state)
+void LedDevicePhilipsHueBridge::setLightState(unsigned int lightId, const QString &state)
 {
 	DebugIf( verbose, _log, "SetLightState [%u]: %s", lightId, QSTRING_CSTR(state) );
 	post( QString("%1/%2/%3").arg( API_LIGHTS ).arg( lightId ).arg( API_STATE ), state );
 }
 
-QJsonDocument LedDevicePhilipsHueBridge::getGroupState(const unsigned int groupId)
+QJsonDocument LedDevicePhilipsHueBridge::getGroupState(unsigned int groupId)
 {
 	_restApi->setPath( QString("%1/%2").arg( API_GROUPS ).arg( groupId ) );
 	httpResponse response = _restApi->get();
@@ -656,7 +656,7 @@ QJsonDocument LedDevicePhilipsHueBridge::getGroupState(const unsigned int groupI
 	return response.getBody();
 }
 
-QJsonDocument LedDevicePhilipsHueBridge::setGroupState(const unsigned int groupId, bool state)
+QJsonDocument LedDevicePhilipsHueBridge::setGroupState(unsigned int groupId, bool state)
 {
 	QString active = state ? API_STREAM_ACTIVE_VALUE_TRUE : API_STREAM_ACTIVE_VALUE_FALSE;
 	return post( QString("%1/%2").arg( API_GROUPS ).arg( groupId ), QString("{\"%1\":{\"%2\":%3}}").arg( API_STREAM, API_STREAM_ACTIVE, active ) );

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.h
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.h
@@ -197,7 +197,7 @@ public:
 	///
 	/// @return True, if success
 	///
-	bool initRestAPI(const QString &hostname, const int port, const QString &token );
+	bool initRestAPI(const QString &hostname, int port, const QString &token );
 
 	///
 	/// @param route the route of the POST request.
@@ -233,7 +233,7 @@ protected:
 	///
 	/// @return Zero on success (i.e. device is ready), else negative
 	///
-	virtual int open(void) override;
+	virtual int open() override;
 
 	///
 	/// @brief Closes the Hue-Bridge device and its SSL-connection

--- a/libsrc/leddevice/dev_net/LedDeviceUdpArtNet.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpArtNet.cpp
@@ -44,7 +44,7 @@ bool LedDeviceUdpArtNet::init(const QJsonObject &deviceConfig)
 }
 
 // populates the headers
-void LedDeviceUdpArtNet::prepare(const unsigned this_universe, const unsigned this_sequence, unsigned this_dmxChannelCount)
+void LedDeviceUdpArtNet::prepare(unsigned this_universe, unsigned this_sequence, unsigned this_dmxChannelCount)
 {
 // WTF? why do the specs say:
 // "This value should be an even number in the range 2 – 512. "

--- a/libsrc/leddevice/dev_net/LedDeviceUdpArtNet.h
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpArtNet.h
@@ -80,7 +80,7 @@ private:
 	///
 	/// @brief Generate Art-Net communication header
 	///
-	void prepare(const unsigned this_universe, const unsigned this_sequence, const unsigned this_dmxChannelCount);
+	void prepare(unsigned this_universe, unsigned this_sequence, unsigned this_dmxChannelCount);
 
 	artnet_packet_t artnet_packet;
 	uint8_t _artnet_seq = 1;

--- a/libsrc/leddevice/dev_net/LedDeviceUdpE131.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpE131.cpp
@@ -75,7 +75,7 @@ bool LedDeviceUdpE131::init(const QJsonObject &deviceConfig)
 }
 
 // populates the headers
-void LedDeviceUdpE131::prepare(const unsigned this_universe, const unsigned this_dmxChannelCount)
+void LedDeviceUdpE131::prepare(unsigned this_universe, unsigned this_dmxChannelCount)
 {
 	memset(e131_packet.raw, 0, sizeof(e131_packet.raw));
 

--- a/libsrc/leddevice/dev_net/LedDeviceUdpE131.h
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpE131.h
@@ -125,7 +125,7 @@ private:
 	///
 	/// @brief Generate E1.31 communication header
 	///
-	void prepare(const unsigned this_universe, const unsigned this_dmxChannelCount);
+	void prepare(unsigned this_universe, unsigned this_dmxChannelCount);
 
 	e131_packet_t e131_packet;
 	uint8_t _e131_seq = 0;

--- a/libsrc/leddevice/dev_net/LedDeviceWled.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceWled.cpp
@@ -111,7 +111,7 @@ bool LedDeviceWled::init(const QJsonObject &deviceConfig)
 	return isInitOK;
 }
 
-bool LedDeviceWled::initRestAPI(const QString &hostname, const int port )
+bool LedDeviceWled::initRestAPI(const QString &hostname, int port )
 {
 	Debug(_log, "");
 	bool isInitOK = false;

--- a/libsrc/leddevice/dev_net/LedDeviceWled.h
+++ b/libsrc/leddevice/dev_net/LedDeviceWled.h
@@ -112,7 +112,7 @@ private:
 	/// @param[in] port
 	/// @return True, if success
 	///
-	bool initRestAPI(const QString &hostname, const int port );
+	bool initRestAPI(const QString &hostname, int port );
 
 	///
 	/// @brief Get command to power WLED-device on or off

--- a/libsrc/leddevice/dev_net/LedDeviceYeelight.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceYeelight.cpp
@@ -947,7 +947,7 @@ bool YeelightLight::setMusicMode(bool on, const QHostAddress &hostAddress, int p
 	return rc;
 }
 
-void YeelightLight::log(const int logLevel, const char* msg, const char* type, ...)
+void YeelightLight::log(int logLevel, const char* msg, const char* type, ...)
 {
 	if ( logLevel <= _debugLevel)
 	{

--- a/libsrc/leddevice/dev_net/LedDeviceYeelight.h
+++ b/libsrc/leddevice/dev_net/LedDeviceYeelight.h
@@ -51,14 +51,14 @@ public:
 
 	explicit YeelightResponse() {}
 
-	API_REPLY error() { return _error;}
+	API_REPLY error() const { return _error;}
 	void setError(const YeelightResponse::API_REPLY replyType) { _error = replyType; }
 
 	QJsonArray getResult() const { return _resultArray; }
 	void setResult(const QJsonArray &result) { _resultArray = result; }
 
 	int getErrorCode() const { return _errorCode; }
-	void setErrorCode(const int &errorCode) { _errorCode = errorCode; _error = API_ERROR;}
+	void setErrorCode(int errorCode) { _errorCode = errorCode; _error = API_ERROR;}
 
 	QString getErrorReason() const { return _errorReason; }
 	void setErrorReason(const QString &errorReason) { _errorReason = errorReason; }
@@ -353,7 +353,7 @@ private:
 	/// @param[in] type log message text
 	/// @param[in] ... variable input to log message text
 	/// 	///
-	void log(const int logLevel,const char* msg, const char* type, ...);
+	void log(int logLevel,const char* msg, const char* type, ...);
 
 	Logger* _log;
 	int _debugLevel;

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -16,7 +16,7 @@ const QChar ONE_SLASH = '/';
 
 } //End of constants
 
-ProviderRestApi::ProviderRestApi(const QString &host, const int &port, const QString &basePath)
+ProviderRestApi::ProviderRestApi(const QString &host, int port, const QString &basePath)
 	:_log(Logger::getInstance("LEDDEVICE"))
 	  ,_networkManager(nullptr)
 	  ,_scheme("http")
@@ -31,7 +31,7 @@ ProviderRestApi::ProviderRestApi(const QString &host, const int &port, const QSt
 	_basePath = basePath;
 }
 
-ProviderRestApi::ProviderRestApi(const QString &host, const int &port)
+ProviderRestApi::ProviderRestApi(const QString &host, int port)
 	: ProviderRestApi(host, port, "") {}
 
 ProviderRestApi::ProviderRestApi()

--- a/libsrc/leddevice/dev_net/ProviderRestApi.h
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.h
@@ -19,8 +19,8 @@ public:
 
 	explicit httpResponse() {}
 
-	bool error() { return _hasError;}
-	void setError(const bool hasError) { _hasError = hasError; }
+	bool error() const { return _hasError;}
+	void setError(bool hasError) { _hasError = hasError; }
 
 	QJsonDocument getBody() const { return _responseBody; }
 	void setBody(const QJsonDocument &body) { _responseBody = body; }
@@ -29,7 +29,7 @@ public:
 	void setErrorReason(const QString &errorReason) { _errorReason = errorReason; }
 
 	int getHttpStatusCode() const { return _httpStatusCode; }
-	void setHttpStatusCode(const int httpStatusCode) { _httpStatusCode = httpStatusCode; }
+	void setHttpStatusCode(int httpStatusCode) { _httpStatusCode = httpStatusCode; }
 
 	QNetworkReply::NetworkError getNetworkReplyError() const { return _networkReplyError; }
 	void setNetworkReplyError (const QNetworkReply::NetworkError networkReplyError) { _networkReplyError = networkReplyError; }
@@ -78,7 +78,7 @@ public:
 	/// @param[in] host
 	/// @param[in] port
 	///
-	explicit ProviderRestApi(const QString &host, const int &port);
+	explicit ProviderRestApi(const QString &host, int port);
 
 	///
 	/// @brief Constructor of the REST-API wrapper
@@ -87,7 +87,7 @@ public:
 	/// @param[in] port
 	/// @param[in] API base-path
 	///
-	explicit ProviderRestApi(const QString &host, const int &port, const QString &basePath);
+	explicit ProviderRestApi(const QString &host, int port, const QString &basePath);
 
 	///
 	/// @brief Destructor of the REST-API wrapper

--- a/libsrc/leddevice/dev_net/ProviderUdp.cpp
+++ b/libsrc/leddevice/dev_net/ProviderUdp.cpp
@@ -129,7 +129,7 @@ int ProviderUdp::close()
 	return retval;
 }
 
-int ProviderUdp::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderUdp::writeBytes(unsigned size, const uint8_t * data)
 {
 	qint64 retVal = _udpSocket->writeDatagram((const char *)data,size,_address,_port);
 

--- a/libsrc/leddevice/dev_net/ProviderUdp.h
+++ b/libsrc/leddevice/dev_net/ProviderUdp.h
@@ -61,7 +61,7 @@ protected:
 	///
 	/// @return Zero on success, else negative
 	///
-	int writeBytes(const unsigned size, const uint8_t *data);
+	int writeBytes(unsigned size, const uint8_t *data);
 
 	///
 	QUdpSocket * _udpSocket;

--- a/libsrc/leddevice/dev_net/ProviderUdpSSL.cpp
+++ b/libsrc/leddevice/dev_net/ProviderUdpSSL.cpp
@@ -457,7 +457,7 @@ void ProviderUdpSSL::freeSSLConnection()
 	}
 }
 
-void ProviderUdpSSL::writeBytes(const unsigned size, const unsigned char * data)
+void ProviderUdpSSL::writeBytes(unsigned size, const unsigned char * data)
 {
 	if( _stopConnection ) return;
 

--- a/libsrc/leddevice/dev_net/ProviderUdpSSL.h
+++ b/libsrc/leddevice/dev_net/ProviderUdpSSL.h
@@ -106,7 +106,7 @@ protected:
 	/// @param[in] size The length of the data
 	/// @param[in] data The data
 	///
-	void writeBytes(const unsigned size, const uint8_t *data);
+	void writeBytes(unsigned size, const uint8_t *data);
 
 	///
 	/// get ciphersuites list from mbedtls_ssl_list_ciphersuites

--- a/libsrc/leddevice/dev_serial/ProviderRs232.cpp
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.cpp
@@ -109,7 +109,7 @@ bool ProviderRs232::powerOff()
 	return rc;
 }
 
-bool ProviderRs232::tryOpen(const int delayAfterConnect_ms)
+bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 {
 	if (_deviceName.isEmpty() || _rs232Port.portName().isEmpty())
 	{

--- a/libsrc/leddevice/dev_spi/ProviderSpi.cpp
+++ b/libsrc/leddevice/dev_spi/ProviderSpi.cpp
@@ -125,7 +125,7 @@ int ProviderSpi::close()
 	return retval;
 }
 
-int ProviderSpi::writeBytes(const unsigned size, const uint8_t * data)
+int ProviderSpi::writeBytes(unsigned size, const uint8_t * data)
 {
 	if (_fid < 0)
 	{

--- a/libsrc/leddevice/dev_spi/ProviderSpi.h
+++ b/libsrc/leddevice/dev_spi/ProviderSpi.h
@@ -53,7 +53,7 @@ protected:
 	///
 	/// @return Zero on success, else negative
 	///
-	int writeBytes(const unsigned size, const uint8_t *data);
+	int writeBytes(unsigned size, const uint8_t *data);
 
 	/// The name of the output device
 	QString _deviceName;

--- a/libsrc/protoserver/ProtoClientConnection.cpp
+++ b/libsrc/protoserver/ProtoClientConnection.cpp
@@ -9,7 +9,7 @@
 
 // TODO Remove this class if third-party apps have been migrated (eg. Hyperion Android Grabber, Windows Screen grabber etc.)
 
-ProtoClientConnection::ProtoClientConnection(QTcpSocket* socket, const int &timeout, QObject *parent)
+ProtoClientConnection::ProtoClientConnection(QTcpSocket* socket, int timeout, QObject *parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("PROTOSERVER"))
 	, _socket(socket)

--- a/libsrc/protoserver/ProtoClientConnection.h
+++ b/libsrc/protoserver/ProtoClientConnection.h
@@ -30,28 +30,28 @@ public:
 	/// @param timeout  The timeout when a client is automatically disconnected and the priority unregistered
 	/// @param parent   The parent
 	///
-	explicit ProtoClientConnection(QTcpSocket* socket, const int &timeout, QObject *parent);
+	explicit ProtoClientConnection(QTcpSocket* socket, int timeout, QObject *parent);
 
 signals:
 	///
 	/// @brief forward register data to HyperionDaemon
 	///
-	void registerGlobalInput(const int priority, const hyperion::Components& component, const QString& origin = "ProtoBuffer", const QString& owner = "", unsigned smooth_cfg = 0);
+	void registerGlobalInput(int priority, hyperion::Components component, const QString& origin = "ProtoBuffer", const QString& owner = "", unsigned smooth_cfg = 0);
 
 	///
 	/// @brief Forward clear command to HyperionDaemon
 	///
-	void clearGlobalInput(const int priority, bool forceClearAll=false);
+	void clearGlobalInput(int priority, bool forceClearAll=false);
 
 	///
 	/// @brief forward prepared image to HyperionDaemon
 	///
-	const bool setGlobalInputImage(const int priority, const Image<ColorRgb>& image, const int timeout_ms, const bool& clearEffect = false);
+	bool setGlobalInputImage(int priority, const Image<ColorRgb>& image, int timeout_ms, bool clearEffect = false);
 
 	///
 	/// @brief Forward requested color
 	///
-	void setGlobalInputColor(const int priority, const std::vector<ColorRgb> &ledColor, const int timeout_ms, const QString& origin = "ProtoBuffer" ,bool clearEffects = true);
+	void setGlobalInputColor(int priority, const std::vector<ColorRgb> &ledColor, int timeout_ms, const QString& origin = "ProtoBuffer" ,bool clearEffects = true);
 
 	///
 	/// @brief Emits whenever the client disconnected
@@ -62,7 +62,7 @@ public slots:
 	///
 	/// @brief Requests a registration from the client
 	///
-	void registationRequired(const int priority) { if (_priority == priority) _priority = -1; };
+	void registationRequired(int priority) { if (_priority == priority) _priority = -1; };
 
 	///
 	/// @brief close the socket and call disconnected()

--- a/libsrc/protoserver/ProtoServer.cpp
+++ b/libsrc/protoserver/ProtoServer.cpp
@@ -35,7 +35,7 @@ void ProtoServer::initServer()
 	handleSettingsUpdate(settings::PROTOSERVER, _config);
 }
 
-void ProtoServer::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void ProtoServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::PROTOSERVER)
 	{

--- a/libsrc/ssdp/SSDPDiscover.cpp
+++ b/libsrc/ssdp/SSDPDiscover.cpp
@@ -49,7 +49,7 @@ void SSDPDiscover::searchForService(const QString& st)
 	sendSearch(st);
 }
 
-const QString SSDPDiscover::getFirstService(const searchType& type, const QString& st, const int& timeout_ms)
+const QString SSDPDiscover::getFirstService(const searchType& type, const QString& st, int timeout_ms)
 {
 	_searchTarget = st;
 	_services.clear();

--- a/libsrc/ssdp/SSDPHandler.cpp
+++ b/libsrc/ssdp/SSDPHandler.cpp
@@ -15,7 +15,7 @@
 
 static const QString SSDP_HYPERION_ST("urn:hyperion-project.org:device:basic:1");
 
-SSDPHandler::SSDPHandler(WebServer* webserver, const quint16& flatBufPort, const quint16& jsonServerPort, const QString& name, QObject * parent)
+SSDPHandler::SSDPHandler(WebServer* webserver, quint16 flatBufPort, quint16 jsonServerPort, const QString& name, QObject * parent)
 	: SSDPServer(parent)
 	, _webserver(webserver)
 	, _localAddress()
@@ -73,7 +73,7 @@ void SSDPHandler::stopServer()
 	SSDPServer::stop();
 }
 
-void SSDPHandler::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void SSDPHandler::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	const QJsonObject& obj = config.object();
 
@@ -102,7 +102,7 @@ void SSDPHandler::handleSettingsUpdate(const settings::type& type, const QJsonDo
 	}
 }
 
-void SSDPHandler::handleWebServerStateChange(const bool newState)
+void SSDPHandler::handleWebServerStateChange(bool newState)
 {
 	if(newState)
 	{
@@ -151,7 +151,7 @@ QString SSDPHandler::getLocalAddress() const
 	return QString();
 }
 
-void SSDPHandler::handleMSearchRequest(const QString& target, const QString& mx, const QString address, const quint16 & port)
+void SSDPHandler::handleMSearchRequest(const QString& target, const QString& mx, const QString address, quint16 port)
 {
 	const auto respond = [=] () {
 		// when searched for all devices / root devices / basic device
@@ -202,7 +202,7 @@ QString SSDPHandler::buildDesc() const
 	return SSDP_DESCRIPTION.arg(getBaseAddress(), QString("Hyperion (%1)").arg(_localAddress), QString(HYPERION_VERSION), _uuid);
 }
 
-void SSDPHandler::sendAnnounceList(const bool alive)
+void SSDPHandler::sendAnnounceList(bool alive)
 {
 	for(const auto & entry : _deviceList){
 		alive ? SSDPServer::sendAlive(entry) : SSDPServer::sendByeBye(entry);

--- a/libsrc/ssdp/SSDPServer.cpp
+++ b/libsrc/ssdp/SSDPServer.cpp
@@ -166,7 +166,7 @@ void SSDPServer::readPendingDatagrams()
     }
 }
 
-void SSDPServer::sendMSearchResponse(const QString& st, const QString& senderIp, const quint16& senderPort)
+void SSDPServer::sendMSearchResponse(const QString& st, const QString& senderIp, quint16 senderPort)
 {
 	QString message = UPNP_MSEARCH_RESPONSE.arg(SSDP_MAX_AGE
 		, QDateTime::currentDateTimeUtc().toString("ddd, dd MMM yyyy HH:mm:ss GMT")

--- a/libsrc/utils/NetOrigin.cpp
+++ b/libsrc/utils/NetOrigin.cpp
@@ -48,7 +48,7 @@ bool NetOrigin::isLocalAddress(const QHostAddress& address, const QHostAddress& 
 	return true;
 }
 
-void NetOrigin::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void NetOrigin::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::NETWORK)
 	{

--- a/libsrc/webserver/StaticFileServing.h
+++ b/libsrc/webserver/StaticFileServing.h
@@ -16,7 +16,7 @@ class StaticFileServing : public QObject {
 
 public:
     explicit StaticFileServing (QObject * parent = nullptr);
-    virtual ~StaticFileServing (void);
+    virtual ~StaticFileServing ();
 
 	///
 	/// @brief Overwrite current base url

--- a/libsrc/webserver/WebJsonRpc.cpp
+++ b/libsrc/webserver/WebJsonRpc.cpp
@@ -6,7 +6,7 @@
 
 #include <api/JsonAPI.h>
 
-WebJsonRpc::WebJsonRpc(QtHttpRequest* request, QtHttpServer* server, const bool& localConnection, QtHttpClientWrapper* parent)
+WebJsonRpc::WebJsonRpc(QtHttpRequest* request, QtHttpServer* server, bool localConnection, QtHttpClientWrapper* parent)
 	: QObject(parent)
 	, _server(server)
 	, _wrapper(parent)

--- a/libsrc/webserver/WebJsonRpc.h
+++ b/libsrc/webserver/WebJsonRpc.h
@@ -12,7 +12,7 @@ class JsonAPI;
 class WebJsonRpc : public QObject {
 	Q_OBJECT
 public:
-	WebJsonRpc(QtHttpRequest* request, QtHttpServer* server, const bool& localConnection, QtHttpClientWrapper* parent);
+	WebJsonRpc(QtHttpRequest* request, QtHttpServer* server, bool localConnection, QtHttpClientWrapper* parent);
 
 	void handleMessage(QtHttpRequest* request);
 

--- a/libsrc/webserver/WebServer.cpp
+++ b/libsrc/webserver/WebServer.cpp
@@ -12,7 +12,7 @@
 // netUtil
 #include <utils/NetUtils.h>
 
-WebServer::WebServer(const QJsonDocument& config, const bool& useSsl, QObject * parent)
+WebServer::WebServer(const QJsonDocument& config, bool useSsl, QObject * parent)
 	:  QObject(parent)
 	, _config(config)
 	, _useSsl(useSsl)
@@ -83,7 +83,7 @@ void WebServer::onServerError (QString msg)
 	Error(_log, "%s", msg.toStdString().c_str());
 }
 
-void WebServer::handleSettingsUpdate(const settings::type& type, const QJsonDocument& config)
+void WebServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
 	if(type == settings::WEBSERVER)
 	{

--- a/libsrc/webserver/WebSocketClient.cpp
+++ b/libsrc/webserver/WebSocketClient.cpp
@@ -10,7 +10,7 @@
 #include <QCryptographicHash>
 #include <QJsonObject>
 
-WebSocketClient::WebSocketClient(QtHttpRequest* request, QTcpSocket* sock, const bool& localConnection, QObject* parent)
+WebSocketClient::WebSocketClient(QtHttpRequest* request, QTcpSocket* sock, bool localConnection, QObject* parent)
 	: QObject(parent)
 	, _socket(sock)
 	, _log(Logger::getInstance("WEBSOCKET"))
@@ -46,7 +46,7 @@ WebSocketClient::WebSocketClient(QtHttpRequest* request, QTcpSocket* sock, const
 	_jsonAPI->initialize();
 }
 
-void WebSocketClient::handleWebSocketFrame(void)
+void WebSocketClient::handleWebSocketFrame()
 {
 	while (_socket->bytesAvailable())
 	{

--- a/libsrc/webserver/WebSocketClient.h
+++ b/libsrc/webserver/WebSocketClient.h
@@ -12,7 +12,7 @@ class JsonAPI;
 class WebSocketClient : public QObject {
 	Q_OBJECT
 public:
-	WebSocketClient(QtHttpRequest* request, QTcpSocket* sock, const bool& localConnection, QObject* parent);
+	WebSocketClient(QtHttpRequest* request, QTcpSocket* sock, bool localConnection, QObject* parent);
 
 	struct WebSocketHeader
 	{
@@ -67,6 +67,6 @@ private:
 	static const quint64 FRAME_SIZE_IN_BYTES = 512 * 512 * 2;  //maximum size of a frame when sending a message
 
 private slots:
-	void handleWebSocketFrame(void);
+	void handleWebSocketFrame();
 	qint64 sendMessage(QJsonObject obj);
 };

--- a/src/hyperion-aml/AmlogicWrapper.cpp
+++ b/src/hyperion-aml/AmlogicWrapper.cpp
@@ -5,7 +5,7 @@
 // Linux includes
 #include <unistd.h>
 
-AmlogicWrapper::AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight) :
+AmlogicWrapper::AmlogicWrapper(unsigned grabWidth, unsigned grabHeight) :
 	_thread(this),
 	_grabber(grabWidth, grabHeight)
 {

--- a/src/hyperion-aml/AmlogicWrapper.h
+++ b/src/hyperion-aml/AmlogicWrapper.h
@@ -9,7 +9,7 @@ class AmlogicWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	AmlogicWrapper(const unsigned grabWidth, const unsigned grabHeight);
+	AmlogicWrapper(unsigned grabWidth, unsigned grabHeight);
 
 	const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-dispmanx/DispmanxWrapper.cpp
+++ b/src/hyperion-dispmanx/DispmanxWrapper.cpp
@@ -2,11 +2,11 @@
 // Hyperion-Dispmanx includes
 #include "DispmanxWrapper.h"
 
-DispmanxWrapper::DispmanxWrapper(const unsigned grabWidth, const unsigned grabHeight,
-	const VideoMode& videoMode,
-	const unsigned cropLeft, const unsigned cropRight,
-	const unsigned cropTop, const unsigned cropBottom,
-	const unsigned updateRate_Hz) :
+DispmanxWrapper::DispmanxWrapper(unsigned grabWidth, unsigned grabHeight,
+	VideoMode videoMode,
+	unsigned cropLeft, unsigned cropRight,
+	unsigned cropTop, unsigned cropBottom,
+	unsigned updateRate_Hz) :
 	_timer(this),
 	_grabber(grabWidth, grabHeight)
 {

--- a/src/hyperion-dispmanx/DispmanxWrapper.h
+++ b/src/hyperion-dispmanx/DispmanxWrapper.h
@@ -9,11 +9,11 @@ class DispmanxWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	DispmanxWrapper(const unsigned grabWidth, const unsigned grabHeight,
-		const VideoMode& videoMode,
-		const unsigned cropLeft, const unsigned cropRight,
-		const unsigned cropTop, const unsigned cropBottom,
-		const unsigned updateRate_Hz);
+	DispmanxWrapper(unsigned grabWidth, unsigned grabHeight,
+		VideoMode videoMode,
+		unsigned cropLeft, unsigned cropRight,
+		unsigned cropTop, unsigned cropBottom,
+		unsigned updateRate_Hz);
 
 	const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-framebuffer/FramebufferWrapper.cpp
+++ b/src/hyperion-framebuffer/FramebufferWrapper.cpp
@@ -2,7 +2,7 @@
 // Hyperion-AmLogic includes
 #include "FramebufferWrapper.h"
 
-FramebufferWrapper::FramebufferWrapper(const QString & device, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz) :
+FramebufferWrapper::FramebufferWrapper(const QString & device, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz) :
 	_timer(this),
 	_grabber(device,grabWidth, grabHeight)
 {

--- a/src/hyperion-framebuffer/FramebufferWrapper.h
+++ b/src/hyperion-framebuffer/FramebufferWrapper.h
@@ -10,7 +10,7 @@ class FramebufferWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	FramebufferWrapper(const QString & device, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	FramebufferWrapper(const QString & device, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz);
 
 	const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-osx/OsxWrapper.cpp
+++ b/src/hyperion-osx/OsxWrapper.cpp
@@ -2,7 +2,7 @@
 // Hyperion-AmLogic includes
 #include "OsxWrapper.h"
 
-OsxWrapper::OsxWrapper(const unsigned display, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz) :
+OsxWrapper::OsxWrapper(unsigned display, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz) :
 	_timer(this),
 	_grabber(display,grabWidth, grabHeight)
 {

--- a/src/hyperion-osx/OsxWrapper.h
+++ b/src/hyperion-osx/OsxWrapper.h
@@ -9,7 +9,7 @@ class OsxWrapper : public QObject
 {
 	Q_OBJECT
 public:
-	OsxWrapper(const unsigned display, const unsigned grabWidth, const unsigned grabHeight, const unsigned updateRate_Hz);
+	OsxWrapper(unsigned display, unsigned grabWidth, unsigned grabHeight, unsigned updateRate_Hz);
 
 	const Image<ColorRgb> & getScreenshot();
 

--- a/src/hyperion-qt/QtWrapper.cpp
+++ b/src/hyperion-qt/QtWrapper.cpp
@@ -36,7 +36,7 @@ void QtWrapper::capture()
 	emit sig_screenshot(_screenshot);
 }
 
-void QtWrapper::setVideoMode(const VideoMode mode)
+void QtWrapper::setVideoMode(VideoMode mode)
 {
 	_grabber.setVideoMode(mode);
 }

--- a/src/hyperion-qt/QtWrapper.h
+++ b/src/hyperion-qt/QtWrapper.h
@@ -31,7 +31,7 @@ public slots:
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///
-	void setVideoMode(const VideoMode videoMode);
+	void setVideoMode(VideoMode videoMode);
 
 private slots:
 	///

--- a/src/hyperion-remote/JsonConnection.cpp
+++ b/src/hyperion-remote/JsonConnection.cpp
@@ -290,7 +290,7 @@ void JsonConnection::clearAll()
 	parseReply(reply);
 }
 
-void JsonConnection::setComponentState(const QString & component, const bool state)
+void JsonConnection::setComponentState(const QString & component, bool state)
 {
 	qDebug() << (state ? "Enable" : "Disable") << "Component" << component;
 
@@ -517,7 +517,7 @@ void JsonConnection::setToken(const QString &token)
 	parseReply(reply);
 }
 
-void JsonConnection::setInstance(const int &instance)
+void JsonConnection::setInstance(int instance)
 {
 	// create command
 	QJsonObject command;

--- a/src/hyperion-remote/JsonConnection.h
+++ b/src/hyperion-remote/JsonConnection.h
@@ -111,7 +111,7 @@ public:
 	/// @param component The component [SMOOTHING, BLACKBORDER, FORWARDER, BOBLIGHT_SERVER, GRABBER]
 	/// @param state The state of the component [true | false]
 	///
-	void setComponentState(const QString & component, const bool state);
+	void setComponentState(const QString & component, bool state);
 
 	///
 	/// Set current active priority channel and deactivate auto source switching
@@ -185,7 +185,7 @@ public:
 	/// Send a json message with a specific instance id
 	/// @param instance The instance id
 	///
-	void setInstance(const int &instance);
+	void setInstance(int instance);
 
 
 private:

--- a/src/hyperion-x11/X11Wrapper.cpp
+++ b/src/hyperion-x11/X11Wrapper.cpp
@@ -41,7 +41,7 @@ void X11Wrapper::capture()
 	_inited = true;
 }
 
-void X11Wrapper::setVideoMode(const VideoMode mode)
+void X11Wrapper::setVideoMode(VideoMode mode)
 {
 	_grabber.setVideoMode(mode);
 }

--- a/src/hyperion-x11/X11Wrapper.h
+++ b/src/hyperion-x11/X11Wrapper.h
@@ -34,7 +34,7 @@ public slots:
 	/// Set the video mode (2D/3D)
 	/// @param[in] mode The new video mode
 	///
-	void setVideoMode(const VideoMode videoMode);
+	void setVideoMode(VideoMode videoMode);
 
 private slots:
 	///

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -60,7 +60,7 @@
 
 HyperionDaemon *HyperionDaemon::daemon = nullptr;
 
-HyperionDaemon::HyperionDaemon(const QString rootPath, QObject *parent, const bool &logLvlOverwrite)
+HyperionDaemon::HyperionDaemon(const QString rootPath, QObject *parent, bool logLvlOverwrite)
 		: QObject(parent), _log(Logger::getInstance("DAEMON"))
 		, _instanceManager(new HyperionIManager(rootPath, this))
 		, _authManager(new AuthManager(this))
@@ -153,7 +153,7 @@ HyperionDaemon::~HyperionDaemon()
 	delete _pyInit;
 }
 
-void HyperionDaemon::setVideoMode(const VideoMode &mode)
+void HyperionDaemon::setVideoMode(VideoMode mode)
 {
 	if (_currVideoMode != mode)
 	{
@@ -162,7 +162,7 @@ void HyperionDaemon::setVideoMode(const VideoMode &mode)
 	}
 }
 
-const QJsonDocument HyperionDaemon::getSetting(const settings::type &type)
+QJsonDocument HyperionDaemon::getSetting(settings::type type) const
 {
 	return _settingsManager->getSetting(type);
 }
@@ -311,7 +311,7 @@ void HyperionDaemon::startNetworkServices()
 	ssdpThread->start();
 }
 
-void HyperionDaemon::handleSettingsUpdate(const settings::type &settingsType, const QJsonDocument &config)
+void HyperionDaemon::handleSettingsUpdate(settings::type settingsType, const QJsonDocument &config)
 {
 	if (settingsType == settings::LOGGER)
 	{

--- a/src/hyperiond/hyperiond.h
+++ b/src/hyperiond/hyperiond.h
@@ -74,7 +74,7 @@ class HyperionDaemon : public QObject
 	friend SysTray;
 
 public:
-	HyperionDaemon(QString rootPath, QObject *parent, const bool& logLvlOverwrite);
+	HyperionDaemon(QString rootPath, QObject *parent, bool logLvlOverwrite);
 	~HyperionDaemon();
 
 	///
@@ -85,12 +85,12 @@ public:
 	///
 	/// @brief Get the current videoMode
 	///
-	const VideoMode & getVideoMode() { return _currVideoMode; };
+	VideoMode getVideoMode() const { return _currVideoMode; };
 
 	///
 	/// @brief get the settings
 	///
-	const QJsonDocument getSetting(const settings::type& type);
+	QJsonDocument getSetting(settings::type type) const;
 
 	void startNetworkServices();
 
@@ -108,7 +108,7 @@ signals:
 	///
 	/// @brief After eval of setVideoMode this signal emits with a new one on change
 	///
-	void videoMode(const VideoMode& mode);
+	void videoMode(VideoMode mode);
 
 	///////////////////////////////////////
 	/// FROM HYPERION TO HYPERIONDAEMON ///
@@ -117,12 +117,12 @@ signals:
 	///
 	/// @brief PIPE settings events from Hyperion class to HyperionDaemon components
 	///
-	void settingsChanged(const settings::type& type, const QJsonDocument& data);
+	void settingsChanged(settings::type type, const QJsonDocument& data);
 
 	///
 	/// @brief PIPE component state changes events from Hyperion class to HyperionDaemon components
 	///
-	void compStateChangeRequest(const hyperion::Components component, bool enable);
+	void compStateChangeRequest(hyperion::Components component, bool enable);
 
 private slots:
 	///
@@ -130,13 +130,13 @@ private slots:
 	/// @param type   settingyType from enum
 	/// @param config configuration object
 	///
-	void handleSettingsUpdate(const settings::type& type, const QJsonDocument& config);
+	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	///
 	/// @brief Listen for videoMode changes and emit videoMode in case of a change, update _currVideoMode
 	/// @param mode  The requested video mode
 	///
-	void setVideoMode(const VideoMode& mode);
+	void setVideoMode(VideoMode mode);
 
 private:
 	void createGrabberDispmanx();

--- a/src/hyperiond/main.cpp
+++ b/src/hyperiond/main.cpp
@@ -50,7 +50,7 @@ using namespace commandline;
 #define PERM0664 QFileDevice::ReadOwner | QFileDevice::ReadGroup | QFileDevice::ReadOther | QFileDevice::WriteOwner | QFileDevice::WriteGroup
 
 #ifndef _WIN32
-void signal_handler(const int signum)
+void signal_handler(int signum)
 {
 	// Hyperion Managment instance
 	HyperionIManager *_hyperion = HyperionIManager::getInstance();

--- a/src/hyperiond/systray.cpp
+++ b/src/hyperiond/systray.cpp
@@ -211,7 +211,7 @@ void SysTray::clearEfxColor()
 	_hyperion->clear(1);
 }
 
-void SysTray::handleInstanceStateChange(const InstanceState& state, const quint8& instance, const QString& name)
+void SysTray::handleInstanceStateChange(InstanceState state, quint8 instance, const QString& name)
 {
 	switch(state){
 		case InstanceState::H_STARTED:

--- a/src/hyperiond/systray.h
+++ b/src/hyperiond/systray.h
@@ -35,12 +35,12 @@ private slots:
 	///
 	/// @brief is called whenever the webserver changes the port
 	///
-	void webserverPortChanged(const quint16& port) { _webPort = port; };
+	void webserverPortChanged(quint16 port) { _webPort = port; };
 
 	///
 	/// @brief is called whenever a hyperion instance state changes
 	///
-	void handleInstanceStateChange(const InstanceState& state, const quint8& instance, const QString& name);
+	void handleInstanceStateChange(InstanceState state, quint8 instance, const QString& name);
 
 private:
 	void createTrayIcon();


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Sorry for huge review. Good news is, no need to review each file individually. It is basically about getting rid of all ````const int````, ````const bool &````, ````const SomeEnum````, vs.

because of two reasons :
- Passing primitive types by value requires less instructions than the indirection required for passing it as reference, also cleaner.
- Marking a non reference paramater as const (````const int````) is superflous because changes will not be reflected to caller anyway. It prevents user from assigning a new value to input but that's something which should not be done from the beginning. If changes required to input, then just a new copy should be made.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
