### PR TITLE
boblight: reduce cpu time spent on memcopy and parsing rgb values

### DIFF
--- a/include/utils/QStringUtils.h
+++ b/include/utils/QStringUtils.h
@@ -52,7 +52,7 @@ inline QVector<QStringRef> splitRef(const QString &string, const QString &sep, S
 inline QVector<QStringRef> splitRef(const QString &string, QChar sep, SplitBehavior behavior = SplitBehavior::KeepEmptyParts, Qt::CaseSensitivity cs = Qt::CaseSensitive)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? Qt::SkipEmptyParts : Qt::KeepEmptyParts, cs)
+	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? Qt::SkipEmptyParts : Qt::KeepEmptyParts, cs);
 #else
 	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? QString::SkipEmptyParts : QString::KeepEmptyParts, cs);
 #endif

--- a/include/utils/QStringUtils.h
+++ b/include/utils/QStringUtils.h
@@ -3,6 +3,8 @@
 
 #include <QString>
 #include <QStringList>
+#include <QStringRef>
+#include <QVector>
 
 namespace QStringUtils {
 
@@ -13,11 +15,11 @@ enum class SplitBehavior {
 
 inline QStringList split (const QString &string, const QString &sep, SplitBehavior behavior = SplitBehavior::KeepEmptyParts, Qt::CaseSensitivity cs = Qt::CaseSensitive)
 {
-	#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
 	return behavior == SplitBehavior::SkipEmptyParts ? string.split(sep, Qt::SkipEmptyParts , cs) : string.split(sep, Qt::KeepEmptyParts , cs);
-	#else
+#else
 	return behavior == SplitBehavior::SkipEmptyParts ? string.split(sep, QString::SkipEmptyParts , cs) : string.split(sep, QString::KeepEmptyParts , cs);
-	#endif
+#endif
 }
 
 inline QStringList split (const QString &string, QChar sep, SplitBehavior behavior = SplitBehavior::KeepEmptyParts, Qt::CaseSensitivity cs = Qt::CaseSensitive)
@@ -37,6 +39,34 @@ inline QStringList split (const QString &string, const QRegExp &rx, SplitBehavio
 	return behavior == SplitBehavior::SkipEmptyParts ? string.split(rx, QString::SkipEmptyParts) : string.split(rx, QString::KeepEmptyParts);
 #endif
 }
+
+inline QVector<QStringRef> splitRef(const QString &string, const QString &sep, SplitBehavior behavior = SplitBehavior::KeepEmptyParts, Qt::CaseSensitivity cs = Qt::CaseSensitive)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? Qt::SkipEmptyParts : Qt::KeepEmptyParts , cs);
+#else
+	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? QString::SkipEmptyParts : QString::KeepEmptyParts, cs);
+#endif
+}
+
+inline QVector<QStringRef> splitRef(const QString &string, QChar sep, SplitBehavior behavior = SplitBehavior::KeepEmptyParts, Qt::CaseSensitivity cs = Qt::CaseSensitive)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? Qt::SkipEmptyParts : Qt::KeepEmptyParts, cs)
+#else
+	return string.splitRef(sep, behavior == SplitBehavior::SkipEmptyParts ? QString::SkipEmptyParts : QString::KeepEmptyParts, cs);
+#endif
+}
+
+inline QVector<QStringRef> splitRef(const QString &string, const QRegExp &rx, SplitBehavior behavior = SplitBehavior::KeepEmptyParts)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+	return string.splitRef(rx,behavior == SplitBehavior::SkipEmptyParts ? Qt::SkipEmptyParts : Qt::KeepEmptyParts);
+#else
+	return string.splitRef(rx, behavior == SplitBehavior::SkipEmptyParts ? QString::SkipEmptyParts : QString::KeepEmptyParts);
+#endif
+}
+
 }
 
 #endif // QSTRINGUTILS_H

--- a/libsrc/boblightserver/BoblightClientConnection.cpp
+++ b/libsrc/boblightserver/BoblightClientConnection.cpp
@@ -3,11 +3,13 @@
 #include <cassert>
 #include <iomanip>
 #include <cstdio>
+#include <cmath>
 
 // stl includes
 #include <iostream>
 #include <sstream>
 #include <iterator>
+#include <locale>
 
 // Qt includes
 #include <QResource>
@@ -54,18 +56,19 @@ BoblightClientConnection::~BoblightClientConnection()
 
 void BoblightClientConnection::readData()
 {
-	_receiveBuffer += _socket->readAll();
+	_receiveBuffer.append(_socket->readAll());
 
 	int bytes = _receiveBuffer.indexOf('\n') + 1;
 	while(bytes > 0)
 	{
 		// create message string (strip the newline)
-		QString message = QString::fromLatin1(_receiveBuffer.data(), bytes-1);
-		// remove message data from buffer
-		_receiveBuffer = _receiveBuffer.mid(bytes);
+		const QString message = readMessage(_receiveBuffer.data(), bytes);
 
 		// handle trimmed message
-		handleMessage(message.trimmed());
+		handleMessage(message);
+
+		// remove message data from buffer
+		_receiveBuffer.remove(0, bytes);
 
 		// drop messages if the buffer is too full
 		if (_receiveBuffer.size() > 100*1024)
@@ -79,6 +82,31 @@ void BoblightClientConnection::readData()
 	}
 }
 
+QString BoblightClientConnection::readMessage(const char *data, const size_t size) const
+{
+	char *end = (char *)data + size - 1;
+
+	// Trim left
+	while (data < end && std::isspace(*data))
+	{
+		++data;
+	}
+
+	// Trim right
+	while (end > data && std::isspace(*end))
+	{
+		--end;
+	}
+
+	// create message string (strip the newline)
+	const int len = end - data + 1;
+	const QString message =  QString::fromLatin1(data, len);
+
+	//std::cout << bytes << ": \"" << message.toUtf8().constData() << std::endl;
+
+	return message;
+}
+
 void BoblightClientConnection::socketClosed()
 {
 	 // clear the current channel
@@ -88,10 +116,17 @@ void BoblightClientConnection::socketClosed()
 	emit connectionClosed(this);
 }
 
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#define SkipEmptyParts (Qt::SkipEmptyParts)
+#else
+#define SkipEmptyParts (QString::SkipEmptyParts)
+#endif
+
 void BoblightClientConnection::handleMessage(const QString & message)
 {
 	//std::cout << "boblight message: " << message.toStdString() << std::endl;
-	QStringList messageParts = QStringUtils::split(message," ",QStringUtils::SplitBehavior::SkipEmptyParts);
+	const QVector<QStringRef> messageParts = message.splitRef(' ', SkipEmptyParts, Qt::CaseSensitive);
 	if (messageParts.size() > 0)
 	{
 		if (messageParts[0] == "hello")
@@ -122,32 +157,18 @@ void BoblightClientConnection::handleMessage(const QString & message)
 			if (messageParts.size() > 3 && messageParts[1] == "light")
 			{
 				bool rc;
-				unsigned ledIndex = messageParts[2].toUInt(&rc);
+				const unsigned ledIndex = parseUInt(messageParts[2], &rc);
 				if (rc && ledIndex < _ledColors.size())
 				{
 					if (messageParts[3] == "rgb" && messageParts.size() == 7)
 					{
-						// replace decimal comma with decimal point
-						messageParts[4].replace(',', '.');
-						messageParts[5].replace(',', '.');
-						messageParts[6].replace(',', '.');
+						// custom parseByte accepts both ',' and '.' as decimal separator
+						// no need to replace decimal comma with decimal point
 
 						bool rc1, rc2, rc3;
-						uint8_t red = qMax(0, qMin(255, int(255 * messageParts[4].toFloat(&rc1))));
-
-						// check for correct locale should not be needed anymore - please check!
-						if (!rc1)
-						{
-							// maybe a locale issue. switch to a locale with a comma instead of a dot as decimal seperator (or vice versa)
-							_locale = QLocale((_locale.decimalPoint() == QChar('.')) ? QLocale::Dutch : QLocale::C);
-							_locale.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
-
-							// try again
-							red = qMax(0, qMin(255, int(255 * messageParts[4].toFloat(&rc1))));
-						}
-
-						uint8_t green = qMax(0, qMin(255, int(255 * messageParts[5].toFloat(&rc2))));
-						uint8_t blue  = qMax(0, qMin(255, int(255 * messageParts[6].toFloat(&rc3))));
+						const uint8_t red = parseByte(messageParts[4], &rc1);
+						const uint8_t green = parseByte(messageParts[5], &rc2);
+						const uint8_t blue = parseByte(messageParts[6], &rc3);
 
 						if (rc1 && rc2 && rc3)
 						{
@@ -181,7 +202,7 @@ void BoblightClientConnection::handleMessage(const QString & message)
 			else if (messageParts.size() == 3 && messageParts[1] == "priority")
 			{
 				bool rc;
-				int prio = messageParts[2].toInt(&rc);
+				const unsigned prio = parseUInt(messageParts[2], &rc);
 				if (rc && prio != _priority)
 				{
 					if (_priority != 0 && _hyperion->getPriorityInfo(_priority).componentId == hyperion::COMP_BOBLIGHTSERVER)
@@ -221,6 +242,148 @@ void BoblightClientConnection::handleMessage(const QString & message)
 	}
 
 	Debug(_log, "unknown boblight message: %s", QSTRING_CSTR(message));
+}
+
+/// Float values 10 to the power of -p for p in 0 .. 8.
+const float ipows[] = {
+	1,
+	1.0f / 10.0f,
+	1.0f / 100.0f,
+	1.0f / 1000.0f,
+	1.0f / 10000.0f,
+	1.0f / 100000.0f,
+	1.0f / 1000000.0f,
+	1.0f / 10000000.0f,
+	1.0f / 100000000.0f};
+
+float BoblightClientConnection::parseFloat(QStringRef s, bool *ok) const
+{
+	// We parse radix 10
+	const char MIN_DIGIT = '0';
+	const char MAX_DIGIT = '9';
+	const char SEP_POINT = '.';
+	const char SEP_COMMA = ',';
+	const int NUM_POWS = 9;
+
+	/// The maximum number of characters we want to process
+	const int MAX_LEN = 18; // Chosen randomly
+
+	/// The index of the current character
+	int q = 0;
+
+	/// The integer part of the number
+	int64_t n = 0;
+
+	auto it = s.begin();
+
+#define STEP ((it != s.end()) && (q++ < MAX_LEN))
+
+	// parse the integer-part
+	while (it->unicode() >= MIN_DIGIT && it->unicode() <= MAX_DIGIT && STEP)
+	{
+		n = (n * 10) + (it->unicode() - MIN_DIGIT);
+		++it;
+	}
+
+	/// The resulting float value
+	float f = static_cast<float>(n);
+
+	// parse decimal part
+	if ((it->unicode() == SEP_POINT || it->unicode() == SEP_COMMA) && STEP)
+	{
+		/// The decimal part of the number
+		int64_t d = 0;
+
+		/// The exponent for the scale-factor 10 to the power -e
+		int e = 0;
+
+		++it;
+		while (it->unicode() >= MIN_DIGIT && it->unicode() <= MAX_DIGIT && STEP)
+		{
+			d = (d * 10) + (it->unicode() - MIN_DIGIT);
+			++e;
+			++it;
+		}
+
+		const float h = static_cast<float>(d);
+
+		// We want to use pre-calculated power whenever possible
+		if (e < NUM_POWS)
+		{
+			f += h * ipows[e];
+		}
+		else
+		{
+			f += h / std::pow(10.0f, e);
+		}
+	}
+
+	if (q >= MAX_LEN)
+	{
+		if (ok)
+		{
+			//std::cout << "FAIL L " << q << ": " << s.toUtf8().constData() << std::endl;
+			*ok = false;
+		}
+		return 0;
+	}
+
+	if (ok)
+	{
+		//std::cout << "OK " << d << ": " << s.toUtf8().constData() << std::endl;
+		*ok = true;
+	}
+
+	return f;
+}
+
+unsigned BoblightClientConnection::parseUInt(QStringRef s, bool *ok) const
+{
+	// We parse radix 10
+	const char MIN_DIGIT = '0';
+	const char MAX_DIGIT = '9';
+
+	/// The maximum number of characters we want to process
+	const int MAX_LEN = 10;
+
+	/// The index of the current character
+	int q = 0;
+
+	/// The integer part of the number
+	int n = 0;
+
+	auto it = s.begin();
+
+#define STEP ((it != s.end()) && (q++ < MAX_LEN))
+
+	// parse the integer-part
+	while (it->unicode() >= MIN_DIGIT && it->unicode() <= MAX_DIGIT && STEP)
+	{
+		n = (n * 10) + (it->unicode() - MIN_DIGIT);
+		++it;
+	}
+
+	if (ok)
+	{
+		*ok = q < MAX_LEN;
+	}
+
+	return n;
+}
+
+uint8_t BoblightClientConnection::parseByte(QStringRef s, bool *ok) const
+{
+	const int LO = 0;
+	const int HI = 255;
+
+#if defined(FAST_FLOAT_PARSE)
+	const float d = parseFloat(s, ok);
+#else
+	const float d = s.toFloat(ok);
+#endif
+
+	// Clamp to byte range 0 to 255
+	return static_cast<uint8_t>(std::max(LO, std::min(HI, int(HI * d))));
 }
 
 void BoblightClientConnection::sendLightMessage()

--- a/libsrc/boblightserver/BoblightClientConnection.cpp
+++ b/libsrc/boblightserver/BoblightClientConnection.cpp
@@ -250,7 +250,7 @@ const float ipows[] = {
 	1.0f / 10000000.0f,
 	1.0f / 100000000.0f};
 
-float BoblightClientConnection::parseFloat(QStringRef s, bool *ok) const
+float BoblightClientConnection::parseFloat(const QStringRef& s, bool *ok) const
 {
 	// We parse radix 10
 	const char MIN_DIGIT = '0';
@@ -331,7 +331,7 @@ float BoblightClientConnection::parseFloat(QStringRef s, bool *ok) const
 	return f;
 }
 
-unsigned BoblightClientConnection::parseUInt(QStringRef s, bool *ok) const
+unsigned BoblightClientConnection::parseUInt(const QStringRef& s, bool *ok) const
 {
 	// We parse radix 10
 	const char MIN_DIGIT = '0';
@@ -363,7 +363,7 @@ unsigned BoblightClientConnection::parseUInt(QStringRef s, bool *ok) const
 	return n;
 }
 
-uint8_t BoblightClientConnection::parseByte(QStringRef s, bool *ok) const
+uint8_t BoblightClientConnection::parseByte(const QStringRef& s, bool *ok) const
 {
 	const int LO = 0;
 	const int HI = 255;

--- a/libsrc/boblightserver/BoblightClientConnection.cpp
+++ b/libsrc/boblightserver/BoblightClientConnection.cpp
@@ -375,7 +375,7 @@ uint8_t BoblightClientConnection::parseByte(const QStringRef& s, bool *ok) const
 #endif
 
 	// Clamp to byte range 0 to 255
-	return static_cast<uint8_t>(std::max(LO, std::min(HI, int(HI * d))));
+	return static_cast<uint8_t>(qBound(LO, int(HI * d), HI)); // qBound args are in order min, value, max; see: https://doc.qt.io/qt-5/qtglobal.html#qBound
 }
 
 void BoblightClientConnection::sendLightMessage()

--- a/libsrc/boblightserver/BoblightClientConnection.h
+++ b/libsrc/boblightserver/BoblightClientConnection.h
@@ -81,7 +81,7 @@ private:
 	/// @param ok whether the result is ok
 	/// @return the parsed byte value in range 0 to 255, or 0
 	///
-	uint8_t parseByte(QStringRef s, bool *ok = nullptr) const;
+	uint8_t parseByte(const QStringRef& s, bool *ok = nullptr) const;
 
 	///
 	/// Parse the given QString as unsigned int value.
@@ -90,7 +90,7 @@ private:
 	/// @param ok whether the result is ok
 	/// @return the parsed unsigned int value
 	///
-	unsigned parseUInt(QStringRef s, bool *ok = nullptr) const;
+	unsigned parseUInt(const QStringRef& s, bool *ok = nullptr) const;
 
 	///
 	/// Parse the given QString as float value, e.g. the 16-bit (wide char) QString "1" shall represent 1, "0.5" is 0.5 and so on.
@@ -99,7 +99,7 @@ private:
 	/// @param ok whether the result is ok
 	/// @return the parsed float value, or 0
 	///
-	float parseFloat(QStringRef s, bool *ok = nullptr) const;
+	float parseFloat(const QStringRef& s, bool *ok = nullptr) const;
 
 	///
 	/// Read an incoming boblight message as QString

--- a/libsrc/boblightserver/BoblightClientConnection.h
+++ b/libsrc/boblightserver/BoblightClientConnection.h
@@ -4,10 +4,14 @@
 #include <QByteArray>
 #include <QTcpSocket>
 #include <QLocale>
+#include <QString>
 
 // utils includes
 #include <utils/Logger.h>
 #include <utils/ColorRgb.h>
+
+/// Whether to parse floats with an eye on performance
+#define FAST_FLOAT_PARSE
 
 class ImageProcessor;
 class Hyperion;
@@ -69,6 +73,42 @@ private:
 	/// Send a lights message the to connected client
 	///
 	void sendLightMessage();
+
+	///
+	/// Interpret the float value "0.0" to "1.0" of the QString byte values 0 .. 255
+	///
+	/// @param s the string to parse
+	/// @param ok whether the result is ok
+	/// @return the parsed byte value in range 0 to 255, or 0
+	///
+	uint8_t parseByte(QStringRef s, bool *ok = nullptr) const;
+
+	///
+	/// Parse the given QString as unsigned int value.
+	///
+	/// @param s the string to parse
+	/// @param ok whether the result is ok
+	/// @return the parsed unsigned int value
+	///
+	unsigned parseUInt(QStringRef s, bool *ok = nullptr) const;
+
+	///
+	/// Parse the given QString as float value, e.g. the 16-bit (wide char) QString "1" shall represent 1, "0.5" is 0.5 and so on.
+	///
+	/// @param s the string to parse
+	/// @param ok whether the result is ok
+	/// @return the parsed float value, or 0
+	///
+	float parseFloat(QStringRef s, bool *ok = nullptr) const;
+
+	///
+	/// Read an incoming boblight message as QString
+	///
+	/// @param data the char data buffer of the incoming message
+	/// @param size the length of the buffer buffer
+	/// @returns the incoming boblight message as QString
+	///
+	QString readMessage(const char *data, const size_t size) const;
 
 private:
 	/// Locale used for parsing floating point values


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**The amount of memory allocations in BoblightClientConnection is reduced drastically.**

BoblightClientConnection used to perform a huge amount of memcopy-operations - mostly involving read only string data – that led to high CPU usage. Now QStringRef is used to store tokenized Boblight messages instead of creating read-only copies of such strings. 

The parsing of RGB values (given as float-strings) is optimized to be allocation-free. This is archived using a native (thus performant) implementation based on QChar character values and mostly int-arithmetic.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**


Benchmarks show the number of CPU-Cycles consumed by memory allocation and parsing plummet significantly freeing valuable system resources. Measured on raspberry pi 4 with *perf* on debian AArch64, 10 seconds of real life boblight data, 600 LEDs.

**Performance with refactoring:**

```Samples: 38K of event 'cycles:ppp', Event count (approx.): 1335978767
  Children      Self  Command         Shared Ob  Symbol
+   29.78%     0.50%  HyperionThread  hyperiond  [.] BoblightClientConnection::readData      
-   16.29%     1.62%  HyperionThread  hyperiond  [.] BoblightClientConnection::handleMessage 
   - 14.67% BoblightClientConnection::handleMessage                                          
      + 6.92% QString::splitRef                                                              
      + 3.08% Hyperion::setInput                                                             
      + 1.27% BoblightClientConnection::parseByte                                            
        0.98% QString::compare_helper                                                        
        0.58% QStringRef::operator==                                                         
   + 1.62% thread_start                                                                      
+    1.32%     0.14%  HyperionThread  hyperiond  [.] BoblightClientConnection::parseByte     
+    1.20%     1.18%  HyperionThread  hyperiond  [.] BoblightClientConnection::parseFloat    
+    0.73%     0.11%  HyperionThread  hyperiond  [.] BoblightClientConnection::readMessage   
     0.25%     0.25%  HyperionThread  hyperiond  [.] BoblightClientConnection::parseUInt     
```

**Performance baseline:**

```Samples: 48K of event 'cycles:ppp', Event count (approx.): 1882635196
  Children      Self  Command         Shared Ob  Symbol
-   50.92%     0.95%  HyperionThread  hyperiond  [.] BoblightClientConnection::readData      
   - 49.97% BoblightClientConnection::readData                                               
      + 36.55% BoblightClientConnection::handleMessage                                       
      + 9.93% QByteArray::mid                                                                
        0.76% _int_free                                                                      
        0.76% QString::fromLatin1_helper                                                     
   + 0.95% thread_start                                                                      
-   36.55%     0.98%  HyperionThread  hyperiond  [.] BoblightClientConnection::handleMessage 
   - 35.57% BoblightClientConnection::handleMessage                                          
      + 11.61% QString::split                                                                
      + 10.78% QString::toFloat                                                              
      + 2.89% QList<QString>::~QList                                                         
      + 2.23% Hyperion::setInput                                                             
      + 1.60% QString::fromAscii_helper                                                      
      + 1.57% QString::toUInt                                                                
        0.78% QString::compare_helper                                                        
        0.74% _int_free                                                                      ```