### PR TITLE
FIX: display argument in hyperion-qt

### DIFF
--- a/src/hyperion-osx/hyperion-osx.cpp
+++ b/src/hyperion-osx/hyperion-osx.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
 		// create the option parser and initialize all parameters
 		Parser parser("OSX capture application for Hyperion. Will automatically search a Hyperion server if -a option isn't used. Please note that if you have more than one server running it's more or less random which one will be used.");
 
-		Option        & argDisplay    = parser.add<Option>       ('d', "display",    "Set the display to capture [default: %1]", "0");
+		IntOption     & argDisplay    = parser.add<IntOption>    ('d', "display",    "Set the display to capture [default: %1]", "0");
 		IntOption     & argFps        = parser.add<IntOption>    ('f', "framerate",  "Capture frame rate [default: %1]", "10", 1, 25);
 		IntOption     & argWidth      = parser.add<IntOption>    (0x0, "width",      "Width of the captured image [default: %1]", "160", 160);
 		IntOption     & argHeight     = parser.add<IntOption>    (0x0, "height",     "Height of the captured image [default: %1]", "160", 160);
@@ -54,7 +54,7 @@ int main(int argc, char ** argv)
 		}
 
 		OsxWrapper osxWrapper
-			(parser.isSet(argDisplay), argWidth.getInt(parser), argHeight.getInt(parser), 1000 / argFps.getInt(parser));
+			(argDisplay.getInt(parser), argWidth.getInt(parser), argHeight.getInt(parser), 1000 / argFps.getInt(parser));
 
 		if (parser.isSet(argScreenshot))
 		{

--- a/src/hyperion-qt/hyperion-qt.cpp
+++ b/src/hyperion-qt/hyperion-qt.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
 		// create the option parser and initialize all parameters
 		Parser parser("Qt interface capture application for Hyperion");
 
-		Option        & argDisplay         = parser.add<Option>       ('d', "display",    "Set the display to capture [default: %1]","0");
+		IntOption     & argDisplay         = parser.add<IntOption>    ('d', "display",    "Set the display to capture [default: %1]", 0);
 		IntOption     & argFps             = parser.add<IntOption>    ('f', "framerate",  "Capture frame rate [default: %1]", "10", 1, 25);
 		IntOption     & argCropLeft        = parser.add<IntOption>    (0x0, "crop-left", "Number of pixels to crop from the left of the picture before decimation (overrides --crop-width)");
 		IntOption     & argCropRight       = parser.add<IntOption>    (0x0, "crop-right", "Number of pixels to crop from the right of the picture before decimation (overrides --crop-width)");
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
 			argCropTop.getInt(parser),
 			argCropBottom.getInt(parser),
 			argSizeDecimation.getInt(parser),
-			parser.isSet(argDisplay));
+			argDisplay.getInt(parser));
 
 		if (parser.isSet(argScreenshot))
 		{

--- a/src/hyperion-qt/hyperion-qt.cpp
+++ b/src/hyperion-qt/hyperion-qt.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
 		// create the option parser and initialize all parameters
 		Parser parser("Qt interface capture application for Hyperion");
 
-		IntOption     & argDisplay         = parser.add<IntOption>    ('d', "display",    "Set the display to capture [default: %1]", 0);
+		IntOption     & argDisplay         = parser.add<IntOption>    ('d', "display",    "Set the display to capture [default: %1]", "0");
 		IntOption     & argFps             = parser.add<IntOption>    ('f', "framerate",  "Capture frame rate [default: %1]", "10", 1, 25);
 		IntOption     & argCropLeft        = parser.add<IntOption>    (0x0, "crop-left", "Number of pixels to crop from the left of the picture before decimation (overrides --crop-width)");
 		IntOption     & argCropRight       = parser.add<IntOption>    (0x0, "crop-right", "Number of pixels to crop from the right of the picture before decimation (overrides --crop-width)");


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This fixes the display argument in hyperion-qt, so it actually uses the display given to the program through argument.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
