### PR TITLE
Allow 8-LED configuration for KarateLight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - Also allow an 8-LED configuration when using Karatelight
 
 ### Removed
 

--- a/libsrc/leddevice/dev_serial/LedDeviceKarate.cpp
+++ b/libsrc/leddevice/dev_serial/LedDeviceKarate.cpp
@@ -18,10 +18,10 @@ bool LedDeviceKarate::init(const QJsonObject &deviceConfig)
 	// Initialise sub-class
 	if ( ProviderRs232::init(deviceConfig) )
 	{
-		if (_ledCount != 16)
+		if (_ledCount != 8 && _ledCount != 16)
 		{
 			//Error( _log, "%d channels configured. This should always be 16!", _ledCount);
-			QString errortext = QString ("%1 channels configured. This should always be 16!").arg(_ledCount);
+			QString errortext = QString ("%1 channels configured. This should always be 8 or 16!").arg(_ledCount);
 			this->setInError(errortext);
 			isInitOK = false;
 		}


### PR DESCRIPTION
The Karatelight integration only allowed a 16-LED setup. This was actually only possible when using a separately sold "expansion pack" to the Karatelight. Without this, only 8 channels are supported. This minimal change also allows an 8-channel setup. I have tested the change on my setup and can confirm it working. An 8-channel controller will not work with the unchanged code, since it will not accept data for 16 channels.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [x] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**