### PR TITLE
Fix for sk9822 frame sufix

### DIFF
--- a/libsrc/leddevice/dev_spi/LedDeviceSK9822.cpp
+++ b/libsrc/leddevice/dev_spi/LedDeviceSK9822.cpp
@@ -34,14 +34,15 @@ bool LedDeviceSK9822::init(const QJsonObject &deviceConfig)
 		Info(_log, "[SK9822] Using global brightness control with threshold of %d and max level of %d", _globalBrightnessControlThreshold, _globalBrightnessControlMaxLevel);
 
 		const unsigned int startFrameSize = 4;
-		const unsigned int endFrameSize = qMax<unsigned int>(((_ledCount + 15) / 16), 4);
+		const unsigned int endFrameSize = ((_ledCount/32) + 1)*4;
 		const unsigned int bufferSize = (_ledCount * 4) + startFrameSize + endFrameSize;
 
-		_ledBuffer.resize(bufferSize, 0xFF);
-		_ledBuffer[0] = 0x00;
-		_ledBuffer[1] = 0x00;
-		_ledBuffer[2] = 0x00;
-		_ledBuffer[3] = 0x00;
+		_ledBuffer.resize(0, 0x00);
+		_ledBuffer.resize(bufferSize, 0x00);
+		//_ledBuffer[0] = 0x00;
+		//_ledBuffer[1] = 0x00;
+		//_ledBuffer[2] = 0x00;
+		//_ledBuffer[3] = 0x00;
 
 		isInitOK = true;
 	}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

According to this article https://cpldcpu.wordpress.com/2016/12/13/sk9822-a-clone-of-the-apa102/ sk9822 requires zero segment at the end of frame to force led update. Similar solutions are applied in other libraries. Hyperion.ng ends frame with 0xFF which was OK for APA102 but not for sk9822 since support for it was included.



**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
