### PR TITLE
Fix issue #909 - "Set many LEDs on the horizontal bottom crashes Hyperion"

### DIFF
--- a/include/utils/hyperion.h
+++ b/include/utils/hyperion.h
@@ -234,12 +234,6 @@ namespace hyperion {
 		midPointsY.erase(std::unique(midPointsY.begin(), midPointsY.end()), midPointsY.end());
 
 		QSize gridSize( midPointsX.size(), midPointsY.size() );
-		//Debug(_log, "LED layout grid size: %dx%d", gridSize.width(), gridSize.height());
-
-		// Limit to 80px for performance reasons
-		const int pl = 80;
-		if(gridSize.width() > pl || gridSize.height() > pl)
-			gridSize.scale(pl, pl, Qt::KeepAspectRatio);
 
 		// Correct the grid in case it is malformed in width vs height
 		// Expected is at least 50% of width <-> height
@@ -247,6 +241,13 @@ namespace hyperion {
 			gridSize.setHeight(qMax(1,gridSize.width()/2));
 		else if((gridSize.width() / gridSize.height()) < 0.5)
 			gridSize.setWidth(qMax(1,gridSize.height()/2));
+
+		// Limit to 80px for performance reasons
+		const int pl = 80;
+		if(gridSize.width() > pl || gridSize.height() > pl)
+		{
+			gridSize.scale(pl, pl, Qt::KeepAspectRatio);
+		}
 
 		return gridSize;
 	}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix issue #909 - "Set many LEDs on the horizontal bottom of the layout causes Hyperion to crash forever"

Do Hight :Width ratio correction first and then scale to max 80px.
This will ensure the height is not zero and fix the divide by zero issue.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes: #909 