### PR TITLE
Fix reopened issue 993

### DIFF
--- a/include/hyperion/PriorityMuxer.h
+++ b/include/hyperion/PriorityMuxer.h
@@ -213,13 +213,6 @@ signals:
 	void visibleComponentChanged(hyperion::Components comp);
 
 	///
-	/// @brief Emits whenever a priority changes active state
-	/// @param  priority  The priority who changed the active state
-	/// @param  state     The new state, state true = active else false
-	///
-	void activeStateChanged(quint8 priority, bool state);
-
-	///
 	/// @brief Emits whenever the auto selection state has been changed
 	/// @param  state  The new state of auto selection; True enabled else false
 	///

--- a/include/hyperion/PriorityMuxer.h
+++ b/include/hyperion/PriorityMuxer.h
@@ -213,12 +213,6 @@ signals:
 	void visibleComponentChanged(hyperion::Components comp);
 
 	///
-	/// @brief Emits whenever the auto selection state has been changed
-	/// @param  state  The new state of auto selection; True enabled else false
-	///
-	void autoSelectChanged(bool state);
-
-	///
 	/// @brief Emits whenever something changes which influences the priorities listing
 	///        Emits also in 1s interval when a COLOR or EFFECT is running with a timeout > -1
 	///

--- a/libsrc/api/JsonCB.cpp
+++ b/libsrc/api/JsonCB.cpp
@@ -72,12 +72,10 @@ bool JsonCB::subscribeFor(const QString& type, bool unsubscribe)
 
 	if(type == "priorities-update")
 	{
-		if(unsubscribe){
+		if (unsubscribe)
 			disconnect(_prioMuxer,0 ,0 ,0);
-		} else {
+		else
 			connect(_prioMuxer, &PriorityMuxer::prioritiesChanged, this, &JsonCB::handlePriorityUpdate, Qt::UniqueConnection);
-			connect(_prioMuxer, &PriorityMuxer::autoSelectChanged, this, &JsonCB::handlePriorityUpdate, Qt::UniqueConnection);
-		}
 	}
 
 	if(type == "imageToLedMapping-update")

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -391,10 +391,8 @@ end:
 	// register color
 	registerInput(priority, hyperion::COMP_COLOR, origin);
 
-	// write color to muxer & queuePush
+	// write color to muxer
 	setInput(priority, newLedColors, timeout_ms);
-	if (timeout_ms <= 0)
-		_muxer.queuePush();
 }
 
 QStringList Hyperion::getAdjustmentIds() const

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -163,7 +163,7 @@ void PriorityMuxer::registerInput(int priority, hyperion::Components component, 
 		return;
 	}
 
-	if (reusedInput) emit prioritiesChanged();
+	if (reusedInput && component != hyperion::COMP_COLOR) emit prioritiesChanged();
 }
 
 bool PriorityMuxer::setInput(int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms)

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -141,7 +141,7 @@ hyperion::Components PriorityMuxer::getComponentOfPriority(int priority) const
 void PriorityMuxer::registerInput(int priority, hyperion::Components component, const QString& origin, const QString& owner, unsigned smooth_cfg)
 {
 	// detect new registers
-	bool newInput, reusedInput = false;
+	bool newInput = false, reusedInput = false;
 	if (!_activeInputs.contains(priority))
 		newInput = true;
 	else if(_prevVisComp == component || _activeInputs[priority].componentId == component)
@@ -165,7 +165,7 @@ void PriorityMuxer::registerInput(int priority, hyperion::Components component, 
 	}
 
 	if (reusedInput)
-		emit prioritiesChanged();
+		emit timeRunner();
 }
 
 bool PriorityMuxer::setInput(int priority, const std::vector<ColorRgb>& ledColors, int64_t timeout_ms)

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -144,7 +144,7 @@ void PriorityMuxer::registerInput(int priority, hyperion::Components component, 
 	bool newInput, reusedInput = false;
 	if (!_activeInputs.contains(priority))
 		newInput = true;
-	else if(_prevVisComp == component)
+	else if(_prevVisComp == component || _activeInputs[priority].componentId == component)
 		reusedInput = true;
 
 	InputInfo& input     = _activeInputs[priority];
@@ -158,7 +158,7 @@ void PriorityMuxer::registerInput(int priority, hyperion::Components component, 
 	if (newInput)
 	{
 		Debug(_log,"Register new input '%s/%s' with priority %d as inactive", QSTRING_CSTR(origin), hyperion::componentToIdString(component), priority);
-		// emit 'prioritiesChanged' only on when _sourceAutoSelectEnabled is false
+		// emit 'prioritiesChanged' only if _sourceAutoSelectEnabled is false
 		if (!_sourceAutoSelectEnabled)
 			emit prioritiesChanged();
 		return;
@@ -202,8 +202,11 @@ bool PriorityMuxer::setInput(int priority, const std::vector<ColorRgb>& ledColor
 	if(activeChange)
 	{
 		Debug(_log, "Priority %d is now %s", priority, active ? "active" : "inactive");
+		if (_currentPriority < priority)
+			emit prioritiesChanged();
 		setCurrentTime();
 	}
+
 	return true;
 }
 
@@ -241,8 +244,11 @@ bool PriorityMuxer::setInputImage(int priority, const Image<ColorRgb>& image, in
 	if(activeChange)
 	{
 		Debug(_log, "Priority %d is now %s", priority, active ? "active" : "inactive");
+		if (_currentPriority < priority)
+			emit prioritiesChanged();
 		setCurrentTime();
 	}
+
 	return true;
 }
 
@@ -259,8 +265,8 @@ bool PriorityMuxer::clearInput(uint8_t priority)
 		Debug(_log,"Removed source priority %d",priority);
 		// on clear success update _currentPriority
 		setCurrentTime();
-		// emit 'prioritiesChanged' only on when _sourceAutoSelectEnabled is false
-		if (!_sourceAutoSelectEnabled)
+		// emit 'prioritiesChanged' only if _sourceAutoSelectEnabled is false
+		if (!_sourceAutoSelectEnabled || _currentPriority < priority)
 			emit prioritiesChanged();
 		return true;
 	}

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -44,7 +44,6 @@ PriorityMuxer::PriorityMuxer(int ledCount, QObject * parent)
 	// forward timeRunner signal to prioritiesChanged signal & threading workaround
 	connect(this, &PriorityMuxer::timeRunner, this, &PriorityMuxer::prioritiesChanged);
 	connect(this, &PriorityMuxer::signalTimeTrigger, this, &PriorityMuxer::timeTrigger);
-	connect(this, &PriorityMuxer::activeStateChanged, this, &PriorityMuxer::prioritiesChanged);
 
 	// start muxer timer
 	connect(_updateTimer, &QTimer::timeout, this, &PriorityMuxer::setCurrentTime);
@@ -201,7 +200,6 @@ bool PriorityMuxer::setInput(int priority, const std::vector<ColorRgb>& ledColor
 	if(activeChange)
 	{
 		Debug(_log, "Priority %d is now %s", priority, active ? "active" : "inactive");
-		emit activeStateChanged(priority, active);
 		setCurrentTime();
 	}
 	return true;
@@ -241,7 +239,6 @@ bool PriorityMuxer::setInputImage(int priority, const Image<ColorRgb>& image, in
 	if(activeChange)
 	{
 		Debug(_log, "Priority %d is now %s", priority, active ? "active" : "inactive");
-		emit activeStateChanged(priority, active);
 		setCurrentTime();
 	}
 	return true;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The "activeStateChanged" signal in the PriorityMuxer was removed because it caused duplicate JsonCB signals.
Details in issue #993 .


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes: #993 