### PR TITLE
Fix hostname/domain split

### DIFF
--- a/libsrc/leddevice/dev_net/LedDeviceCololight.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceCololight.cpp
@@ -668,7 +668,8 @@ QJsonObject LedDeviceCololight::discover()
 	{
 		QJsonObject obj;
 
-		obj.insert("ip", i.key());
+		QString ipAddress = i.key();
+		obj.insert("ip", ipAddress);
 		obj.insert("model", i.value().value(COLOLIGHT_MODEL));
 		obj.insert("type", i.value().value(COLOLIGHT_MODEL_TYPE));
 		obj.insert("mac", i.value().value(COLOLIGHT_MAC));
@@ -678,7 +679,6 @@ QJsonObject LedDeviceCololight::discover()
 		if (hostInfo.error() == QHostInfo::NoError)
 		{
 			QString hostname = hostInfo.hostName();
-			//Seems that for Windows no local domain name is resolved
 			if (!QHostInfo::localDomainName().isEmpty())
 			{
 				obj.insert("hostname", hostname.remove("." + QHostInfo::localDomainName()));
@@ -686,9 +686,23 @@ QJsonObject LedDeviceCololight::discover()
 			}
 			else
 			{
-				int domainPos = hostname.indexOf('.');
-				obj.insert("hostname", hostname.left(domainPos));
-				obj.insert("domain", hostname.mid(domainPos + 1));
+				if (hostname.startsWith(ipAddress))
+				{
+					obj.insert("hostname", ipAddress);
+
+					QString domain = hostname.remove(ipAddress);
+					if (domain.at(0) == '.')
+					{
+						domain.remove(0, 1);
+					}
+					obj.insert("domain", domain);
+				}
+				else
+				{
+					int domainPos = hostname.indexOf('.');
+					obj.insert("hostname", hostname.left(domainPos));
+					obj.insert("domain", hostname.mid(domainPos + 1));
+				}
 			}
 		}
 

--- a/libsrc/ssdp/SSDPDiscover.cpp
+++ b/libsrc/ssdp/SSDPDiscover.cpp
@@ -316,24 +316,40 @@ QJsonArray SSDPDiscover::getServicesDiscoveredJson() const
 		obj.insert("usn", i.value().uniqueServiceName);
 
 		QUrl url (i.value().location);
-		obj.insert("ip", url.host());
+		QString ipAddress = url.host();
+
+		obj.insert("ip", ipAddress);
 		obj.insert("port", url.port());
 
 		QHostInfo hostInfo = QHostInfo::fromName(url.host());
-		if (hostInfo.error() == QHostInfo::NoError )
+		if (hostInfo.error() == QHostInfo::NoError)
 		{
 			QString hostname = hostInfo.hostName();
-			//Seems that for Windows no local domain name is resolved
-			if (!hostInfo.localDomainName().isEmpty() )
+
+			if (!QHostInfo::localDomainName().isEmpty())
 			{
-				obj.insert("hostname", hostname.remove("."+hostInfo.localDomainName()));
-				obj.insert("domain", hostInfo.localDomainName());
+				obj.insert("hostname", hostname.remove("." + QHostInfo::localDomainName()));
+				obj.insert("domain", QHostInfo::localDomainName());
 			}
 			else
 			{
-				int domainPos = hostname.indexOf('.');
-				obj.insert("hostname", hostname.left(domainPos));
-				obj.insert("domain", hostname.mid(domainPos+1));
+				if (hostname.startsWith(ipAddress))
+				{
+					obj.insert("hostname", ipAddress);
+
+					QString domain = hostname.remove(ipAddress);
+					if (domain.at(0) == '.')
+					{
+						domain.remove(0, 1);
+					}
+					obj.insert("domain", domain);
+				}
+				else
+				{
+					int domainPos = hostname.indexOf('.');
+					obj.insert("hostname", hostname.left(domainPos));
+					obj.insert("domain", hostname.mid(domainPos + 1));
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fixes the splitting of domain from hostname.
Code considers now, if an IP-Address is part of the hostname.

Address issue raised in forum:

https://hyperion-project.org/threads/how-to-setup-hyperion-with-a-yeelight-solution.3342/#post-29249

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
