### PR TITLE
Add spidev1.0 and spidev1.1 device for Raspberry Pi WS2801 schema

### DIFF
--- a/libsrc/leddevice/schemas/schema-ws2801.json
+++ b/libsrc/leddevice/schemas/schema-ws2801.json
@@ -5,7 +5,7 @@
 		"output": {
 			"type": "string",
 			"title":"edt_dev_spec_spipath_title",
-			"enum" : ["/dev/spidev0.0","/dev/spidev0.1"],
+			"enum" : ["/dev/spidev0.0","/dev/spidev0.1","/dev/spidev1.0","/dev/spidev1.1"],
 			"propertyOrder" : 1
 		},
 		"rate": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
One raspberry PI can drive several LED strips on different GPIO ports. Until now only spidev0.0 or spidev0.1 could be selected. With this change a second LED strip can be controlled and selected in the Hyperion web interface.

For this purpose it is necessary to enable the additional GPIOs in the Raspberry. For this purpose we add the following line in the /boot/config.txt or change it accordingly.

`dtoverlay=spi1-3cs`

Then we restart the Raspberry with `shutdown -r -f now`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

After:
<img width="1430" alt="Bildschirmfoto 2020-12-07 um 14 10 43" src="https://user-images.githubusercontent.com/49807897/101354898-23b13d00-3896-11eb-9fe7-3d2d61339b59.png">

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Issue has been created: #1110 
https://github.com/hyperion-project/hyperion.ng/issues/1110#issue-757987223

Raspberry example for the second SPI Device (spidev1.0) are GPIO-20 (PIN 38)  and GPIO-21 (PIN 40).
For old (first) spidev0.0 are GPIO-10 (PIN 19) and GPIO-11 (PIN 23)

<img width="1268" alt="Bildschirmfoto 2020-12-06 um 16 02 44" src="https://user-images.githubusercontent.com/49807897/101357372-a1c31300-3899-11eb-89fc-a08bb48d9f9e.png">


