### PR TITLE
FIX: [hue] XY == 0 => bri  = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dependency rpi_ws281x to latest upstream
 
 ### Fixed
+- LED-Hue: Proper black in Entertainement mode if min brightness is set
 
 ### Removed
 

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -1235,7 +1235,7 @@ QByteArray LedDevicePhilipsHue::prepareStreamData() const
 		CiColor lightC = light.getColor();
 		quint64 R = lightC.x * 0xffff;
 		quint64 G = lightC.y * 0xffff;
-		quint64 B = lightC.bri * 0xffff;
+		quint64 B = (lightC.x || lightC.y) ? lightC.bri * 0xffff : 0;
 		unsigned int id = light.getId();
 		const uint8_t payload[] = {
 			0x00, 0x00, static_cast<uint8_t>(id),


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
For Hue, in stream mode, black produces a XY of (0,0).
However, if min brightness is configured, it is nonetheless applied, which leads to blue (closest to 0,0 in gamut).

This forces brightness to 0 if XY = (0,0) 


**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No


**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

