### PR TITLE
Adalight - Fix LED Num for non analogue output

### DIFF
--- a/assets/firmware/arduino/adalight/adalight.ino
+++ b/assets/firmware/arduino/adalight/adalight.ino
@@ -139,7 +139,7 @@ void setup() {
   }
 
   int ledCount = MAX_LEDS;
-  if (ANALOG_MODE == ANALOG_MODE_LAST_LED) {
+  if (ANALOG_OUTPUT_ENABLED == true && ANALOG_MODE == ANALOG_MODE_LAST_LED) {
     ledCount--;
   }
 
@@ -170,7 +170,7 @@ void setup() {
   showColor(CRGB(0, 0, 0));
 
   Serial.print("Ada\n"); // Send "Magic Word" string to host
-
+  Serial.println("Ada: LED num: " +  String(FastLED.size())); //Return number of LEDs configured
 
   boolean transmissionSuccess;
   unsigned long sum_r, sum_g, sum_b;
@@ -254,4 +254,3 @@ void setup() {
 void loop() {
   // Not used. See note in setup() function.
 }
-


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Adalight
- Fix LED Num for non analogue output
- Send back number of LED configured

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Addresses issue reported via forum:
https://hyperion-project.org/threads/first-led-always-on-with-arduino.11127/#post-31796
