### PR TITLE
Proto*: fix Error macro conflict

### DIFF
--- a/libsrc/protoserver/ProtoClientConnection.cpp
+++ b/libsrc/protoserver/ProtoClientConnection.cpp
@@ -1,11 +1,12 @@
-// project includes
-#include "ProtoClientConnection.h"
-
 // qt
 #include <QTcpSocket>
 #include <QHostAddress>
 #include <QTimer>
 #include <QRgb>
+
+// project includes
+#include "ProtoClientConnection.h"
+
 
 // TODO Remove this class if third-party apps have been migrated (eg. Hyperion Android Grabber, Windows Screen grabber etc.)
 

--- a/libsrc/protoserver/ProtoClientConnection.h
+++ b/libsrc/protoserver/ProtoClientConnection.h
@@ -1,13 +1,15 @@
 #pragma once
 
+// protobuffer PROTO
+// protobuf defines an Error() function itself, so undef it here
+#undef Error
+#include "message.pb.h"
+
 // util
 #include <utils/Logger.h>
 #include <utils/Image.h>
 #include <utils/ColorRgb.h>
 #include <utils/Components.h>
-
-// protobuffer PROTO
-#include "message.pb.h"
 
 class QTcpSocket;
 class QTimer;

--- a/libsrc/protoserver/ProtoServer.cpp
+++ b/libsrc/protoserver/ProtoServer.cpp
@@ -1,5 +1,5 @@
-#include <protoserver/ProtoServer.h>
 #include "ProtoClientConnection.h"
+#include <protoserver/ProtoServer.h>
 
 // util
 #include <utils/NetOrigin.h>


### PR DESCRIPTION
**Summary**

utils/Logger.h contains a preprocessor macro Error() for easy logging.
However, the upstream protobuf/io/coded_stream.h also defines a private
function Error() in one of its classes that conflicts with this macro.

Thus, unfortunate include orders result in a build error. This commit
reorders the includes to prevent the error. It also defines an extra
`#undef Error` before including upstream protobuf to make the problem
more visible (a compiler error would not point to an obscure place
somewhere in protobuf but to the usage of the Error() macro within
Hyperion itself).

Fixes: #882

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**