### PR TITLE
Extend logging and error reporting

### DIFF
--- a/assets/webconfig/i18n/de.json
+++ b/assets/webconfig/i18n/de.json
@@ -869,7 +869,7 @@
     "wiz_cc_chooseid": "Wähle einen Namen für dieses Farb-Profil.",
     "wiz_cc_intro1": "Der Assistent wird dich durch die Kalibrierung deiner LEDs leiten. Sofern du Kodi nutzt, können die Bilder und Testvideos direkt an Kodi geschickt werden. Andernfalls musst du das Material selbst herunterladen und anwenden.",
     "wiz_cc_kodicon": "Kodi Webserver gefunden, fahre mit Kodi-Unterstützung fort.",
-    "wiz_cc_kodidiscon": "Kodi Webserver nicht gefunden, fahre ohne Kodi-Unterstützung fort.",
+    "wiz_cc_kodidiscon": "Kodi Webserver nicht gefunden, fahre ohne Kodi-Unterstützung fort (prüfe, ob Fernsteuerung durch Programme auf anderen Rechnern erlaubt ist).",
     "wiz_cc_kodidisconlink": "Download Link Bilder:",
     "wiz_cc_kodimsg_start": "Test bestanden - Zeit zu beginnen",
     "wiz_cc_kodishould": "Kodi sollte jetzt folgendes Bild anzeigen: $1",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -869,7 +869,7 @@
     "wiz_cc_chooseid": "Define a name for this color profile.",
     "wiz_cc_intro1": "This wizard will guide you through your led calibration. If you are using Kodi, the calibration pictures and videos can be sent directly to it. Prerequisite: You need to enable \"Allow remote control from applications on other systems\" in Kodi.<br />Alternatively, you might want downloading these files yourself and display them when the wizard asks you to adjust the setting.",
     "wiz_cc_kodicon": "Kodi found, proceed with Kodi support.",
-    "wiz_cc_kodidiscon": "Kodi not found, proceed without Kodi support.",
+    "wiz_cc_kodidiscon": "Kodi not found, proceed without Kodi support (please check, if remote control by other systems is activated).",
     "wiz_cc_kodidisconlink": "Download link pictures:",
     "wiz_cc_kodimsg_start": "Test success - time to proceed!",
     "wiz_cc_kodishould": "Kodi should show the following picture: $1",

--- a/libsrc/leddevice/dev_serial/ProviderRs232.cpp
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.cpp
@@ -43,7 +43,9 @@ bool ProviderRs232::init(const QJsonObject &deviceConfig)
 
 		// If device name was given as unix /dev/ system-location, get port name
 		if ( _deviceName.startsWith(QLatin1String("/dev/")) )
+		{
 			_deviceName = _deviceName.mid(5);
+		}
 
 		_isAutoDeviceName     = _deviceName.toLower() == "auto";
 		_baudRate_Hz          = deviceConfig["rate"].toInt();
@@ -141,18 +143,16 @@ bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 		Debug(_log, "_rs232Port.open(QIODevice::ReadWrite): %s, Baud rate [%d]bps", QSTRING_CSTR(_deviceName), _baudRate_Hz);
 
 		QSerialPortInfo serialPortInfo(_deviceName);
-
-		QJsonObject portInfo;
-		Debug(_log, "portName:          %s", QSTRING_CSTR(serialPortInfo.portName()));
-		Debug(_log, "systemLocation:    %s", QSTRING_CSTR(serialPortInfo.systemLocation()));
-		Debug(_log, "description:       %s", QSTRING_CSTR(serialPortInfo.description()));
-		Debug(_log, "manufacturer:      %s", QSTRING_CSTR(serialPortInfo.manufacturer()));
-		Debug(_log, "productIdentifier: %s", QSTRING_CSTR(QString("0x%1").arg(serialPortInfo.productIdentifier(), 0, 16)));
-		Debug(_log, "vendorIdentifier:  %s", QSTRING_CSTR(QString("0x%1").arg(serialPortInfo.vendorIdentifier(), 0, 16)));
-		Debug(_log, "serialNumber:      %s", QSTRING_CSTR(serialPortInfo.serialNumber()));
-
 		if (!serialPortInfo.isNull() )
 		{
+			Debug(_log, "portName:          %s", QSTRING_CSTR(serialPortInfo.portName()));
+			Debug(_log, "systemLocation:    %s", QSTRING_CSTR(serialPortInfo.systemLocation()));
+			Debug(_log, "description:       %s", QSTRING_CSTR(serialPortInfo.description()));
+			Debug(_log, "manufacturer:      %s", QSTRING_CSTR(serialPortInfo.manufacturer()));
+			Debug(_log, "vendorIdentifier:  %s", QSTRING_CSTR(QString("0x%1").arg(serialPortInfo.vendorIdentifier(), 0, 16)));
+			Debug(_log, "productIdentifier: %s", QSTRING_CSTR(QString("0x%1").arg(serialPortInfo.productIdentifier(), 0, 16)));
+			Debug(_log, "serialNumber:      %s", QSTRING_CSTR(serialPortInfo.serialNumber()));
+
 			if ( !_rs232Port.open(QIODevice::ReadWrite) )
 			{
 				this->setInError(_rs232Port.errorString());
@@ -161,14 +161,20 @@ bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 		}
 		else
 		{
-			// List available device
-			Debug(_log, "Available devices:");
-			for (auto &port : QSerialPortInfo::availablePorts() ) {
-				Debug(_log, "portName:    %s", QSTRING_CSTR(port.portName()));
-				Debug(_log, "description: %s", QSTRING_CSTR(port.description()));
-			}
 			QString errortext = QString("Invalid serial device name: [%1]!").arg(_deviceName);
 			this->setInError( errortext );
+
+			// List available device
+			for (auto &port : QSerialPortInfo::availablePorts() ) {
+				Debug(_log, "Avail. serial device: [%s]-(%s|%s), Manufacturer: %s, Description: %s",
+					  QSTRING_CSTR(port.portName()),
+					  QSTRING_CSTR(QString("0x%1").arg(port.vendorIdentifier(), 0, 16)),
+					  QSTRING_CSTR(QString("0x%1").arg(port.productIdentifier(), 0, 16)),
+					  QSTRING_CSTR(port.manufacturer()),
+					  QSTRING_CSTR(port.description())
+					  );
+			}
+
 			return false;
 		}
 	}
@@ -221,7 +227,7 @@ int ProviderRs232::writeBytes(const qint64 size, const uint8_t *data)
 		{
 			if ( _rs232Port.error() == QSerialPort::TimeoutError )
 			{
-				Debug(_log, "Timeout after %dms: %d frames already dropped", WRITE_TIMEOUT, _frameDropCounter);
+				Debug(_log, "Timeout after %dms: %d frames already dropped", WRITE_TIMEOUT.count(), _frameDropCounter);
 
 				++_frameDropCounter;
 
@@ -251,7 +257,7 @@ int ProviderRs232::writeBytes(const qint64 size, const uint8_t *data)
 QString ProviderRs232::discoverFirst()
 {
 	// take first available USB serial port - currently no probing!
-	for (auto const & port : QSerialPortInfo::availablePorts())
+	for (auto & port : QSerialPortInfo::availablePorts())
 	{
 		if (!port.isNull() && !port.isBusy())
 		{
@@ -272,7 +278,7 @@ QJsonObject ProviderRs232::discover(const QJsonObject& /*params*/)
 	// Discover serial Devices
 	for (auto &port : QSerialPortInfo::availablePorts() )
 	{
-		if ( !port.isNull() )
+		if ( !port.isNull() && !port.portName().startsWith("ttyS"))
 		{
 			QJsonObject portInfo;
 			portInfo.insert("description", port.description());

--- a/libsrc/leddevice/dev_serial/ProviderRs232.cpp
+++ b/libsrc/leddevice/dev_serial/ProviderRs232.cpp
@@ -161,6 +161,12 @@ bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 		}
 		else
 		{
+			// List available device
+			Debug(_log, "Available devices:");
+			for (auto &port : QSerialPortInfo::availablePorts() ) {
+				Debug(_log, "portName:    %s", QSTRING_CSTR(port.portName()));
+				Debug(_log, "description: %s", QSTRING_CSTR(port.description()));
+			}
 			QString errortext = QString("Invalid serial device name: [%1]!").arg(_deviceName);
 			this->setInError( errortext );
 			return false;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This PR introduces two changes (both should improve usability):

#### 1. ProviderRs232: Be more verbose about correct device in error case
    
QtSerialPort accepts only certain names as SerialPort devices, not
paths. Guessing this names can be cumbersome so give some hint in the
log, if the given device name cannot be detected.

#### 2. webconfig: better error description, if Kodi is not found
    
Even if the normal Kodi webinterface is activated and capable of
receiving JSON RPC calls (on port 8080), the js in Hyperion sets the
port to 9090 (normally only accessible via localhost). Since the js code
is executed on the users device, Kodi denies access even if Hyperion and
Kodi are installed on the same device.
    
This change helps in this situation by pointing to the correct Kodi setting.

Unfortunately, I'm only able to modify English and German.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:
maybe improved usability?

If changing the UI of web configuration, please provide the **before/after** screenshot:

I will hand in later.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
