### PR TITLE
Fixed issue where schemas failed to load

### DIFF
--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -253,7 +253,7 @@ void EffectFileHandler::updateEffects()
 					efxCount++;
 				}
 			}
-			InfoIf(efxCount > 0, _log, "%d effect schemas loaded from directory %s", efxCount, QSTRING_CSTR((path + "schema/")));
+			InfoIf(efxCount > 0, _log, "%d effect schemas loaded from directory %s", efxCount, QSTRING_CSTR((path + "/schema/")));
 		}
 	}
 
@@ -309,7 +309,7 @@ bool EffectFileHandler::loadEffectDefinition(const QString &path, const QString 
 
 bool EffectFileHandler::loadEffectSchema(const QString &path, const QString &effectSchemaFile, EffectSchema & effectSchema)
 {
-	QString fileName = path + "schema/" + QDir::separator() + effectSchemaFile;
+	QString fileName = path + "/schema/" + QDir::separator() + effectSchemaFile;
 
 	// Read and parse the effect schema file
 	QJsonObject schemaEffect;


### PR DESCRIPTION
Schemas were failing to load for custom effects. I found this while developing an effect.

In the log I received an error that said it could not find the schema for "/.hyperion/custom-effectsschema/".

This small change fixes it to look for the schema in "/.hyperion/custom-effects/schema/"

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
