### PR TITLE
Interrupt effect on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated dependency rpi_ws281x to latest upstream
+- Fix High CPU load (RPI3B+) (#1013)
 
 ### Fixed
 

--- a/include/effectengine/Effect.h
+++ b/include/effectengine/Effect.h
@@ -44,10 +44,22 @@ public:
 	void requestInterruption() { _interupt = true; }
 
 	///
-	/// @brief Check if the interruption flag has been set
+	/// @brief Check an interruption was requested.
+	///        This can come from requestInterruption()
+	///        or the effect's timeout expiring.
+	///
 	/// @return    The flag state
 	///
-	bool isInterruptionRequested() { return _interupt; }
+	bool isInterruptionRequested();
+
+	///
+	/// @brief Get the remaining timeout, or 0 if there
+	///        is no timeout for this effect.
+	///
+	/// @return    The flag state
+	///
+	int getRemaining();
+
 
 	QString getScript() const { return _script; }
 	QString getName() const { return _name; }

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -47,6 +47,25 @@ Effect::~Effect()
 	_imageStack.clear();
 }
 
+bool Effect::isInterruptionRequested()
+{
+	return _interupt || getRemaining() < 0;
+}
+
+int Effect::getRemaining()
+{
+	// determine the timeout
+	int timeout = _timeout;
+
+	if (timeout > 0)
+	{
+		timeout = _endTime - QDateTime::currentMSecsSinceEpoch();
+		return timeout;
+	}
+
+	return timeout;
+}
+
 void Effect::setModuleParameters()
 {
 	// import the buildtin Hyperion module

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -124,16 +124,6 @@ PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 	// check if we have aborted already
 	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
 
-	// determine the timeout
-	int timeout = getEffect()->_timeout;
-	if (timeout > 0)
-	{
-		timeout = getEffect()->_endTime - QDateTime::currentMSecsSinceEpoch();
-
-		// we are done if the time has passed
-		if (timeout <= 0) Py_RETURN_NONE;
-	}
-
 	// check the number of arguments
 	int argCount = PyTuple_Size(args);
 	if (argCount == 3)
@@ -144,7 +134,7 @@ PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 		{
 			getEffect()->_colors.fill(color);
 			QVector<ColorRgb> _cQV = getEffect()->_colors;
-			emit getEffect()->setInput(getEffect()->_priority, std::vector<ColorRgb>( _cQV.begin(), _cQV.end() ), timeout, false);
+			emit getEffect()->setInput(getEffect()->_priority, std::vector<ColorRgb>( _cQV.begin(), _cQV.end() ), getEffect()->getRemaining(), false);
 			Py_RETURN_NONE;
 		}
 		return nullptr;
@@ -163,7 +153,7 @@ PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 					char * data = PyByteArray_AS_STRING(bytearray);
 					memcpy(getEffect()->_colors.data(), data, length);
 					QVector<ColorRgb> _cQV = getEffect()->_colors;
-					emit getEffect()->setInput(getEffect()->_priority, std::vector<ColorRgb>( _cQV.begin(), _cQV.end() ), timeout, false);
+					emit getEffect()->setInput(getEffect()->_priority, std::vector<ColorRgb>( _cQV.begin(), _cQV.end() ), getEffect()->getRemaining(), false);
 					Py_RETURN_NONE;
 				}
 				else
@@ -195,16 +185,6 @@ PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 	// check if we have aborted already
 	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
 
-	// determine the timeout
-	int timeout = getEffect()->_timeout;
-	if (timeout > 0)
-	{
-		timeout = getEffect()->_endTime - QDateTime::currentMSecsSinceEpoch();
-
-		// we are done if the time has passed
-		if (timeout <= 0) Py_RETURN_NONE;
-	}
-
 	// bytearray of values
 	int width, height;
 	PyObject * bytearray = nullptr;
@@ -218,7 +198,7 @@ PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 				Image<ColorRgb> image(width, height);
 				char * data = PyByteArray_AS_STRING(bytearray);
 				memcpy(image.memptr(), data, length);
-				emit getEffect()->setInputImage(getEffect()->_priority, image, timeout, false);
+				emit getEffect()->setInputImage(getEffect()->_priority, image, getEffect()->getRemaining(), false);
 				Py_RETURN_NONE;
 			}
 			else
@@ -332,16 +312,6 @@ PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 	// check if we have aborted already
 	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
 
-	// determine the timeout
-	int timeout = getEffect()->_timeout;
-	if (timeout > 0)
-	{
-		timeout = getEffect()->_endTime - QDateTime::currentMSecsSinceEpoch();
-
-		// we are done if the time has passed
-		if (timeout <= 0) Py_RETURN_NONE;
-	}
-
 	int argCount = PyTuple_Size(args);
 	int imgId = -1;
 	bool argsOk = (argCount == 0);
@@ -375,7 +345,7 @@ PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 	}
 
 	memcpy(image.memptr(), binaryImage.data(), binaryImage.size());
-	emit getEffect()->setInputImage(getEffect()->_priority, image, timeout, false);
+	emit getEffect()->setInputImage(getEffect()->_priority, image, getEffect()->getRemaining(), false);
 
 	return Py_BuildValue("");
 }


### PR DESCRIPTION
**Summary**

An effect timing out wouldn't make hyperion.abort() return True in an effect script. This updates the effect module to reflect this.

Fixes #1013

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot: **n/a**

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [x] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
