### PR TITLE
Fix #1131 - Have Global (Grabber) settings reflected correctly in non-default instances

### DIFF
--- a/include/hyperion/SettingsManager.h
+++ b/include/hyperion/SettingsManager.h
@@ -42,7 +42,7 @@ public:
 	/// @brief get the full settings object of this instance (with global settings)
 	/// @return The requested json
 	///
-	const QJsonObject & getSettings() const { return _qconfig; }
+	QJsonObject getSettings() const;
 
 signals:
 	///

--- a/libsrc/hyperion/SettingsManager.cpp
+++ b/libsrc/hyperion/SettingsManager.cpp
@@ -114,6 +114,17 @@ QJsonDocument SettingsManager::getSetting(settings::type type) const
 	return _sTable->getSettingsRecord(settings::typeToString(type));
 }
 
+QJsonObject SettingsManager::getSettings() const
+{
+	QJsonObject config;
+	for(const auto & key : _qconfig.keys())
+	{
+		//Read all records from database to ensure that global settings are read across instances
+		config.insert(key, _sTable->getSettingsRecord(key).object());
+	}
+	return config;
+}
+
 bool SettingsManager::saveSettings(QJsonObject config, bool correct)
 {
 	// optional data upgrades e.g. imported legacy/older configs


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- Fix that global settings were not correctly reflected across instances after updates in other non default instance

Configuration is now read from database which takes care of global and instance specific configurations, rather than using an instance's cache.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes #1131 