### PR TITLE
Fix invalid return type when an effect has aborted

### DIFF
--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -121,9 +121,6 @@ PyMethodDef EffectModule::effectMethods[] = {
 
 PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	// check the number of arguments
 	int argCount = PyTuple_Size(args);
 	if (argCount == 3)
@@ -182,9 +179,6 @@ PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	// bytearray of values
 	int width, height;
 	PyObject * bytearray = nullptr;
@@ -225,9 +219,6 @@ PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapGetImage(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	QString file;
 	QBuffer buffer;
 	QImageReader reader;
@@ -309,9 +300,6 @@ PyObject* EffectModule::wrapAbort(PyObject *self, PyObject *)
 
 PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int imgId = -1;
 	bool argsOk = (argCount == 0);
@@ -352,9 +340,6 @@ PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageLinearGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int startRX = 0;
@@ -422,9 +407,6 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageConicalGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int centerX, centerY, angle;
@@ -491,9 +473,6 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageRadialGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int centerX, centerY, radius, focalX, focalY, focalRadius, spread;
@@ -572,9 +551,6 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPolygon(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	PyObject * bytearray = nullptr;
 
 	int argCount = PyTuple_Size(args);
@@ -633,9 +609,6 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPie(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	PyObject * bytearray = nullptr;
 
 	QString brush;
@@ -730,9 +703,6 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSolidFill(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a = 255;
@@ -772,9 +742,6 @@ PyObject* EffectModule::wrapImageSolidFill(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawLine(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a      = 255;
@@ -813,9 +780,6 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPoint(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b, x, y;
 	int a      = 255;
@@ -849,9 +813,6 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawRect(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a      = 255;
@@ -891,9 +852,6 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSetPixel(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b, x, y;
 
@@ -909,9 +867,6 @@ PyObject* EffectModule::wrapImageSetPixel(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageGetPixel(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int x, y;
 
@@ -925,9 +880,6 @@ PyObject* EffectModule::wrapImageGetPixel(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSave(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	QImage img(getEffect()->_image.copy());
 	getEffect()->_imageStack.append(img);
 
@@ -936,9 +888,6 @@ PyObject* EffectModule::wrapImageSave(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageMinSize(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int w, h;
 	int width   = getEffect()->_imageSize.width();
@@ -961,25 +910,16 @@ PyObject* EffectModule::wrapImageMinSize(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageWidth(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	return Py_BuildValue("i", getEffect()->_imageSize.width());
 }
 
 PyObject* EffectModule::wrapImageHeight(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	return Py_BuildValue("i", getEffect()->_imageSize.height());
 }
 
 PyObject* EffectModule::wrapImageCRotate(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int angle;
 
@@ -994,9 +934,6 @@ PyObject* EffectModule::wrapImageCRotate(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageCOffset(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int offsetX = 0;
 	int offsetY = 0;
 	int argCount = PyTuple_Size(args);
@@ -1012,9 +949,6 @@ PyObject* EffectModule::wrapImageCOffset(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageCShear(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int sh,sv;
 	int argCount = PyTuple_Size(args);
 
@@ -1028,9 +962,6 @@ PyObject* EffectModule::wrapImageCShear(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageResetT(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	getEffect()->_painter->resetTransform();
 	Py_RETURN_NONE;
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix https://github.com/hyperion-project/hyperion.ng/commit/9475b93d9fbc192fbb33a6dac83c8163e1d46f76#commitcomment-47646390

This is a follow up to PR #1181: since, before this PR, effects would never stop, fixing this uncovered another bug: when aborting an effect, the `EffectModule` was written to return `None` on any Python method call. This means that the return type of those methods could change mid-execution, if an effect was considered to have aborted before `hyperion.abort()` was checked again.

By *not* changing the behavior depending on the abort status, the effect scripts don't crash when an abort is requested. We still have to check if this fixes launching effects from the tray, but I currently don't have access to the hardware setup to check that.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
