### PR TITLE
Fix 1181 - Effects were not started from tray

### DIFF
--- a/include/effectengine/Effect.h
+++ b/include/effectengine/Effect.h
@@ -21,6 +21,9 @@ class Effect : public QThread
 	Q_OBJECT
 
 public:
+
+	static const int ENDLESS;
+
 	friend class EffectModule;
 
 	Effect(Hyperion *hyperion
@@ -53,12 +56,11 @@ public:
 	bool isInterruptionRequested();
 
 	///
-	/// @brief Get the remaining timeout, or 0 if there
-	///        is no timeout for this effect.
+	/// @brief Get the remaining timeout, or indication it is endless
 	///
 	/// @return    The flag state
 	///
-	int getRemaining();
+	int getRemaining() const;
 
 
 	QString getScript() const { return _script; }
@@ -88,7 +90,7 @@ private:
 	const QJsonObject _args;
 	const QString _imageData;
 
-	int64_t _endTime;
+	qint64 _endTime;
 
 	/// Buffer for colorData
 	QVector<ColorRgb> _colors;

--- a/include/effectengine/EffectEngine.h
+++ b/include/effectengine/EffectEngine.h
@@ -13,6 +13,7 @@
 
 // Effect engine includes
 #include <effectengine/EffectDefinition.h>
+#include <effectengine/Effect.h>
 #include <effectengine/ActiveEffectDefinition.h>
 #include <effectengine/EffectSchema.h>
 #include <utils/Logger.h>
@@ -69,13 +70,13 @@ signals:
 
 public slots:
 	/// Run the specified effect on the given priority channel and optionally specify a timeout
-	int runEffect(const QString &effectName, int priority, int timeout = -1, const QString &origin="System");
+	int runEffect(const QString &effectName, int priority, int timeout = Effect::ENDLESS, const QString &origin="System");
 
 	/// Run the specified effect on the given priority channel and optionally specify a timeout
 	int runEffect(const QString &effectName
 				, const QJsonObject &args
 				, int priority
-				, int timeout = -1
+				, int timeout = Effect::ENDLESS
 				, const QString &pythonScript = ""
 				, const QString &origin = "System"
 				, unsigned smoothCfg=0
@@ -102,7 +103,7 @@ private:
 				,const QString &name
 				, const QJsonObject &args
 				, int priority
-				, int timeout = -1
+				, int timeout = Effect::ENDLESS
 				, const QString &origin="System"
 				, unsigned smoothCfg=0
 				, const QString &imageData = ""

--- a/include/hyperion/BGEffectHandler.h
+++ b/include/hyperion/BGEffectHandler.h
@@ -3,6 +3,7 @@
 #include <utils/Logger.h>
 #include <hyperion/Hyperion.h>
 #include <utils/settings.h>
+#include <effectengine/Effect.h>
 
 ///
 /// @brief Handle the background Effect settings, reacts on runtime to settings changes
@@ -37,7 +38,7 @@ private slots:
 
 			#define BGCONFIG_ARRAY bgColorConfig.toArray()
 			// clear background priority
-			_hyperion->clear(254);
+			_hyperion->clear(PriorityMuxer::BG_PRIORITY);
 			// initial background effect/color
 			if (BGEffectConfig["enable"].toBool(true))
 			{
@@ -53,12 +54,12 @@ private slots:
 							static_cast<uint8_t>(BGCONFIG_ARRAY.at(2).toInt(0))
 						}
 					};
-					_hyperion->setColor(254, bg_color);
+					_hyperion->setColor(PriorityMuxer::BG_PRIORITY, bg_color);
 					Info(Logger::getInstance("HYPERION"),"Initial background color set (%d %d %d)",bg_color.at(0).red, bg_color.at(0).green, bg_color.at(0).blue);
 				}
 				else
 				{
-					int result = _hyperion->setEffect(bgEffectConfig, 254);
+					int result = _hyperion->setEffect(bgEffectConfig, PriorityMuxer::BG_PRIORITY, Effect::ENDLESS);
 					Info(Logger::getInstance("HYPERION"),"Initial background effect '%s' %s", QSTRING_CSTR(bgEffectConfig), ((result == 0) ? "started" : "failed"));
 				}
 			}

--- a/include/hyperion/Hyperion.h
+++ b/include/hyperion/Hyperion.h
@@ -26,6 +26,7 @@
 
 // Effect engine includes
 #include <effectengine/EffectDefinition.h>
+#include <effectengine/Effect.h>
 #include <effectengine/ActiveEffectDefinition.h>
 #include <effectengine/EffectSchema.h>
 
@@ -217,7 +218,7 @@ public slots:
 	/// @param effectName Name of the effec to run
 	///	@param priority The priority channel of the effect
 	/// @param timeout The timeout of the effect (after the timout, the effect will be cleared)
-	int setEffect(const QString & effectName, int priority, int timeout = -1, const QString & origin="System");
+	int setEffect(const QString & effectName, int priority, int timeout = Effect::ENDLESS, const QString & origin="System");
 
 	/// Run the specified effect on the given priority channel and optionally specify a timeout
 	/// @param effectName Name of the effec to run
@@ -227,7 +228,7 @@ public slots:
 	int setEffect(const QString &effectName
 				, const QJsonObject &args
 				, int priority
-				, int timeout = -1
+				, int timeout = Effect::ENDLESS
 				, const QString &pythonScript = ""
 				, const QString &origin="System"
 				, const QString &imageData = ""

--- a/include/hyperion/PriorityMuxer.h
+++ b/include/hyperion/PriorityMuxer.h
@@ -54,6 +54,9 @@ public:
 		QString owner;
 	};
 
+	//Foreground and Background priorities
+	const static int FG_PRIORITY;
+	const static int BG_PRIORITY;
 	/// The lowest possible priority, which is used when no priority channels are active
 	const static int LOWEST_PRIORITY;
 

--- a/include/utils/hyperion.h
+++ b/include/utils/hyperion.h
@@ -7,6 +7,7 @@
 #include <hyperion/LedString.h>
 // fg effect
 #include <hyperion/Hyperion.h>
+#include <hyperion/PriorityMuxer.h>
 
 ///
 /// @brief Provide utility methods for Hyperion class
@@ -16,7 +17,6 @@ namespace hyperion {
 	void handleInitialEffect(Hyperion* hyperion, const QJsonObject& FGEffectConfig)
 	{
 		#define FGCONFIG_ARRAY fgColorConfig.toArray()
-		const int FG_PRIORITY = 0;
 		const int DURATION_INFINITY = 0;
 
 		// initial foreground effect/color
@@ -41,12 +41,12 @@ namespace hyperion {
 						static_cast<uint8_t>(FGCONFIG_ARRAY.at(2).toInt(0))
 					}
 				};
-				hyperion->setColor(FG_PRIORITY, fg_color, fg_duration_ms);
+				hyperion->setColor(PriorityMuxer::FG_PRIORITY, fg_color, fg_duration_ms);
 				Info(Logger::getInstance("HYPERION"),"Initial foreground color set (%d %d %d)",fg_color.at(0).red,fg_color.at(0).green,fg_color.at(0).blue);
 			}
 			else
 			{
-				int result = hyperion->setEffect(fgEffectConfig, FG_PRIORITY, fg_duration_ms);
+				int result = hyperion->setEffect(fgEffectConfig, PriorityMuxer::FG_PRIORITY, fg_duration_ms);
 				Info(Logger::getInstance("HYPERION"),"Initial foreground effect '%s' %s", QSTRING_CSTR(fgEffectConfig), ((result == 0) ? "started" : "failed"));
 			}
 		}

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -12,6 +12,8 @@
 // python utils
 #include <python/PythonProgram.h>
 
+const int Effect::ENDLESS = -1;
+
 Effect::Effect(Hyperion *hyperion, int priority, int timeout, const QString &script, const QString &name, const QJsonObject &args, const QString &imageData)
 	: QThread()
 	, _hyperion(hyperion)
@@ -22,7 +24,7 @@ Effect::Effect(Hyperion *hyperion, int priority, int timeout, const QString &scr
 	, _args(args)
 	, _imageData(imageData)
 	, _endTime(-1)
-	, _colors()
+	, _interupt(false)
 	, _imageSize(hyperion->getLedGridSize())
 	, _image(_imageSize,QImage::Format_ARGB32_Premultiplied)
 {
@@ -49,21 +51,20 @@ Effect::~Effect()
 
 bool Effect::isInterruptionRequested()
 {
-	return _interupt || getRemaining() < 0;
+	return _interupt || getRemaining() < ENDLESS;
 }
 
-int Effect::getRemaining()
+int Effect::getRemaining() const
 {
 	// determine the timeout
 	int timeout = _timeout;
 
 	if (timeout > 0)
 	{
-		timeout = _endTime - QDateTime::currentMSecsSinceEpoch();
+		timeout = static_cast<int>( _endTime - QDateTime::currentMSecsSinceEpoch());
 		return timeout;
 	}
-
-	return timeout;
+	return ENDLESS;
 }
 
 void Effect::setModuleParameters()

--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -19,8 +19,6 @@
 
 EffectEngine::EffectEngine(Hyperion * hyperion)
 	: _hyperion(hyperion)
-	, _availableEffects()
-	, _activeEffects()
 	, _log(Logger::getInstance("EFFECTENGINE"))
 	, _effectFileHandler(EffectFileHandler::getInstance())
 {
@@ -202,7 +200,7 @@ void EffectEngine::allChannelsCleared()
 {
 	for (Effect * effect : _activeEffects)
 	{
-		if (effect->getPriority() != 254 && !effect->isInterruptionRequested())
+		if (effect->getPriority() != PriorityMuxer::BG_PRIORITY && !effect->isInterruptionRequested())
 		{
 			effect->requestInterruption();
 		}

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -121,9 +121,6 @@ PyMethodDef EffectModule::effectMethods[] = {
 
 PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	// check the number of arguments
 	int argCount = PyTuple_Size(args);
 	if (argCount == 3)
@@ -182,9 +179,6 @@ PyObject* EffectModule::wrapSetColor(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	// bytearray of values
 	int width, height;
 	PyObject * bytearray = nullptr;
@@ -225,9 +219,6 @@ PyObject* EffectModule::wrapSetImage(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapGetImage(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	QString file;
 	QBuffer buffer;
 	QImageReader reader;
@@ -309,9 +300,6 @@ PyObject* EffectModule::wrapAbort(PyObject *self, PyObject *)
 
 PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int imgId = -1;
 	bool argsOk = (argCount == 0);
@@ -352,9 +340,6 @@ PyObject* EffectModule::wrapImageShow(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageLinearGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int startRX = 0;
@@ -422,9 +407,6 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageConicalGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int centerX, centerY, angle;
@@ -491,9 +473,6 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageRadialGradient(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	PyObject * bytearray = nullptr;
 	int centerX, centerY, radius, focalX, focalY, focalRadius, spread;
@@ -572,9 +551,6 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPolygon(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	PyObject * bytearray = nullptr;
 
 	int argCount = PyTuple_Size(args);
@@ -633,9 +609,6 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPie(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	PyObject * bytearray = nullptr;
 
 	QString brush;
@@ -730,9 +703,6 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSolidFill(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a = 255;
@@ -772,9 +742,6 @@ PyObject* EffectModule::wrapImageSolidFill(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawLine(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a      = 255;
@@ -813,9 +780,6 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawPoint(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b, x, y;
 	int a      = 255;
@@ -849,9 +813,6 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageDrawRect(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b;
 	int a      = 255;
@@ -891,9 +852,6 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSetPixel(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int r, g, b, x, y;
 
@@ -909,9 +867,6 @@ PyObject* EffectModule::wrapImageSetPixel(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageGetPixel(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int x, y;
 
@@ -925,9 +880,6 @@ PyObject* EffectModule::wrapImageGetPixel(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageSave(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	QImage img(getEffect()->_image.copy());
 	getEffect()->_imageStack.append(img);
 
@@ -936,9 +888,6 @@ PyObject* EffectModule::wrapImageSave(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageMinSize(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int w, h;
 	int width   = getEffect()->_imageSize.width();
@@ -961,25 +910,16 @@ PyObject* EffectModule::wrapImageMinSize(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageWidth(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	return Py_BuildValue("i", getEffect()->_imageSize.width());
 }
 
 PyObject* EffectModule::wrapImageHeight(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	return Py_BuildValue("i", getEffect()->_imageSize.height());
 }
 
 PyObject* EffectModule::wrapImageCRotate(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int argCount = PyTuple_Size(args);
 	int angle;
 
@@ -994,9 +934,6 @@ PyObject* EffectModule::wrapImageCRotate(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageCOffset(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int offsetX = 0;
 	int offsetY = 0;
 	int argCount = PyTuple_Size(args);
@@ -1012,9 +949,6 @@ PyObject* EffectModule::wrapImageCOffset(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageCShear(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	int sh,sv;
 	int argCount = PyTuple_Size(args);
 
@@ -1028,9 +962,6 @@ PyObject* EffectModule::wrapImageCShear(PyObject *self, PyObject *args)
 
 PyObject* EffectModule::wrapImageResetT(PyObject *self, PyObject *args)
 {
-	// check if we have aborted already
-	if (getEffect()->isInterruptionRequested()) Py_RETURN_NONE;
-
 	getEffect()->_painter->resetTransform();
 	Py_RETURN_NONE;
 }

--- a/libsrc/hyperion/PriorityMuxer.cpp
+++ b/libsrc/hyperion/PriorityMuxer.cpp
@@ -13,6 +13,8 @@
 // utils
 #include <utils/Logger.h>
 
+const int PriorityMuxer::FG_PRIORITY = 1;
+const int PriorityMuxer::BG_PRIORITY = 254;
 const int PriorityMuxer::LOWEST_PRIORITY = std::numeric_limits<uint8_t>::max();
 
 PriorityMuxer::PriorityMuxer(int ledCount, QObject * parent)
@@ -322,7 +324,7 @@ void PriorityMuxer::setCurrentTime()
 				newPriority = qMin(newPriority, infoIt->priority);
 
 			// call timeTrigger when effect or color is running with timeout > 0, blacklist prio 255
-			if(infoIt->priority < 254 && infoIt->timeoutTime_ms > 0 && (infoIt->componentId == hyperion::COMP_EFFECT || infoIt->componentId == hyperion::COMP_COLOR  || infoIt->componentId == hyperion::COMP_IMAGE))
+			if(infoIt->priority < BG_PRIORITY && infoIt->timeoutTime_ms > 0 && (infoIt->componentId == hyperion::COMP_EFFECT || infoIt->componentId == hyperion::COMP_COLOR  || infoIt->componentId == hyperion::COMP_IMAGE))
 				emit signalTimeTrigger(); // as signal to prevent Threading issues
 
 			++infoIt;

--- a/src/hyperiond/systray.cpp
+++ b/src/hyperiond/systray.cpp
@@ -15,7 +15,9 @@
 
 #include <utils/ColorRgb.h>
 #include <effectengine/EffectDefinition.h>
+#include <effectengine/Effect.h>
 #include <webserver/WebServer.h>
+#include <hyperion/PriorityMuxer.h>
 
 #include "hyperiond.h"
 #include "systray.h"
@@ -165,7 +167,7 @@ void SysTray::closeEvent(QCloseEvent *event)
 	event->ignore();
 }
 
-void SysTray::settings()
+void SysTray::settings() const
 {
 	#ifndef _WIN32
 	// Hide error messages when opening webbrowser
@@ -201,7 +203,7 @@ void SysTray::settings()
 void SysTray::setEffect()
 {
 	QString efxName = qobject_cast<QAction*>(sender())->text();
-	_hyperion->setEffect(efxName, 1);
+	_hyperion->setEffect(efxName, PriorityMuxer::FG_PRIORITY, Effect::ENDLESS);
 }
 
 void SysTray::clearEfxColor()
@@ -209,7 +211,7 @@ void SysTray::clearEfxColor()
 	_hyperion->clear(1);
 }
 
-void SysTray::handleInstanceStateChange(InstanceState state, quint8 instance, const QString& name)
+void SysTray::handleInstanceStateChange(InstanceState state, quint8 instance, const QString& /*name*/)
 {
 	switch(state){
 		case InstanceState::H_STARTED:

--- a/src/hyperiond/systray.h
+++ b/src/hyperiond/systray.h
@@ -24,7 +24,7 @@ public slots:
 	void showColorDialog();
 	void setColor(const QColor & color);
 	void closeEvent(QCloseEvent *event);
-	void settings();
+	void settings() const;
 	void setEffect();
 	void clearEfxColor();
 	void setAutorunState();


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- Fixes#1181, where Effects were did not start when trigger from from tray
- Have named constants Fore-/Background priorities and no timeouts for effects 
- Populate setEffect parameters to have a clearly defined behaviour

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Fixes #1181 
