### PR TITLE
LEDDevices - WLED enhancements and minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- WLED: Support of ["live" property] (https://github.com/Aircoookie/WLED/issues/1308), addresses #1095
+- WLED: Support storing/restoring state, fixes #1101
+- LED-Devices: Allow to get properties for Atmo and Karatedevices to limit LED numbers configurable
+- LED-Devices: Add timeouts for REST-API calls
+
 ### Changed
 - Updated dependency rpi_ws281x to latest upstream
 - Fix High CPU load (RPI3B+) (#1013)
+- Nanoleaf: Consider Nanoleaf-Shape Controlers
+- LED-Devices: Show HW-Ledcount in all setting levels
 
 - Documentation: Add link to [Hyperion-py](https://github.com/dermotduffy/hyperion-py)
 
@@ -20,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issue #1127: LED-Devices: Correct total packet count in tpm2net implementation
 - LED-Hue: Proper black in Entertainement mode if min brightness is set
+- LED-Hue: Minor fix of setColor command
+- Nanoleaf: Fix,if external control mode cannot be set
 
 ### Removed
 

--- a/include/utils/WaitTime.h
+++ b/include/utils/WaitTime.h
@@ -1,0 +1,27 @@
+#ifndef WAITTIME_H
+#define WAITTIME_H
+
+#include <QEventLoop>
+#include <QTimer>
+
+#include <chrono>
+
+inline void wait(std::chrono::milliseconds millisecondsWait)
+{
+	QEventLoop loop;
+	QTimer t;
+	t.connect(&t, &QTimer::timeout, &loop, &QEventLoop::quit);
+	t.start(millisecondsWait.count());
+	loop.exec();
+}
+
+inline void wait(int millisecondsWait)
+{
+	QEventLoop loop;
+	QTimer t;
+	t.connect(&t, &QTimer::timeout, &loop, &QEventLoop::quit);
+	t.start(millisecondsWait);
+	loop.exec();
+}
+
+#endif // WAITTIME_H

--- a/libsrc/hyperion/schema/schema-device.json
+++ b/libsrc/hyperion/schema/schema-device.json
@@ -16,7 +16,6 @@
 			"title" : "edt_dev_general_hardwareLedCount_title",
 			"minimum" : 1,
 			"default" : 1,
-			"access" : "expert",
 			"propertyOrder" : 2
 		},
 		"colorOrder" :
@@ -25,9 +24,11 @@
 			"title" : "edt_dev_general_colorOrder_title",
 			"enum" : ["rgb", "bgr", "rbg", "brg", "gbr", "grb"],
 			"default" : "rgb",
-			"options" : {
-				"enum_titles" : ["edt_conf_enum_rgb", "edt_conf_enum_bgr", "edt_conf_enum_rbg", "edt_conf_enum_brg", "edt_conf_enum_gbr", "edt_conf_enum_grb"]
+			"required" : true,
+			"options": {
+				"enum_titles": [ "edt_conf_enum_rgb", "edt_conf_enum_bgr", "edt_conf_enum_rbg", "edt_conf_enum_brg", "edt_conf_enum_gbr", "edt_conf_enum_grb" ]
 			},
+			"access" : "expert",
 			"propertyOrder" : 3
 		}
 	},

--- a/libsrc/leddevice/LedDevice.cpp
+++ b/libsrc/leddevice/LedDevice.cpp
@@ -265,12 +265,13 @@ bool LedDevice::switchOn()
 	{
 		if ( _isEnabled &&_isDeviceInitialised )
 		{
-			storeState();
-
-			if ( powerOn() )
+			if ( storeState() )
 			{
-				_isOn = true;
-				rc = true;
+				if ( powerOn() )
+				{
+					_isOn = true;
+					rc = true;
+				}
 			}
 		}
 	}

--- a/libsrc/leddevice/dev_net/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceAtmoOrb.cpp
@@ -13,6 +13,8 @@
 // Constants
 namespace {
 
+const bool verbose = false;
+const bool verbose3 = false;
 const QString MULTICAST_GROUP_DEFAULT_ADDRESS = "239.255.255.250";
 const quint16 MULTICAST_GROUP_DEFAULT_PORT = 49692;
 
@@ -272,13 +274,13 @@ void LedDeviceAtmoOrb::setColor(int orbId, const ColorRgb &color, int commandTyp
 
 void LedDeviceAtmoOrb::sendCommand(const QByteArray &bytes)
 {
-	//Debug ( _log, "command: [%s] -> %s:%u", QSTRING_CSTR( QString(bytes.toHex())), QSTRING_CSTR(_groupAddress.toString()), _multiCastGroupPort );
+	DebugIf(verbose3, _log, "command: [%s] -> %s:%u", QSTRING_CSTR( QString(bytes.toHex())), QSTRING_CSTR(_groupAddress.toString()), _multiCastGroupPort );
 	_udpSocket->writeDatagram(bytes.data(), bytes.size(), _groupAddress, _multiCastGroupPort);
 }
 
 QJsonObject LedDeviceAtmoOrb::discover(const QJsonObject& params)
 {
-	//Debug(_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
 	QJsonObject devicesDiscovered;
 	devicesDiscovered.insert("ledDeviceType", _activeDeviceType );
@@ -353,14 +355,14 @@ QJsonObject LedDeviceAtmoOrb::discover(const QJsonObject& params)
 	}
 
 	devicesDiscovered.insert("devices", deviceList);
-	Debug(_log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+	DebugIf(verbose, _log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 
 	return devicesDiscovered;
 }
 
 void LedDeviceAtmoOrb::identify(const QJsonObject& params)
 {
-	//Debug(_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
 	int orbId = 0;
 	if ( params["id"].isString() )

--- a/libsrc/leddevice/dev_net/LedDeviceCololight.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceCololight.cpp
@@ -1,50 +1,50 @@
 #include "LedDeviceCololight.h"
 
 #include <utils/QStringUtils.h>
+#include <utils/WaitTime.h>
 #include <QUdpSocket>
 #include <QHostInfo>
 #include <QtEndian>
-#include <QEventLoop>
 
 #include <chrono>
 
 // Constants
 namespace {
-const bool verbose = false;
-const bool verbose3 = false;
+	const bool verbose = false;
+	const bool verbose3 = false;
 
-// Configuration settings
+	// Configuration settings
 
-const char CONFIG_HW_LED_COUNT[] = "hardwareLedCount";
+	const char CONFIG_HW_LED_COUNT[] = "hardwareLedCount";
 
-const int COLOLIGHT_BEADS_PER_MODULE = 19;
+	const int COLOLIGHT_BEADS_PER_MODULE = 19;
 
-// Cololight discovery service
+	// Cololight discovery service
 
-const int API_DEFAULT_PORT = 8900;
+	const int API_DEFAULT_PORT = 8900;
 
-const char DISCOVERY_ADDRESS[] = "255.255.255.255";
-const quint16 DISCOVERY_PORT = 12345;
-const char DISCOVERY_MESSAGE[] = "Z-SEARCH * \r\n";
-constexpr std::chrono::milliseconds DEFAULT_DISCOVERY_TIMEOUT{ 2000 };
-constexpr std::chrono::milliseconds DEFAULT_READ_TIMEOUT{ 1000 };
-constexpr std::chrono::milliseconds DEFAULT_IDENTIFY_TIME{ 2000 };
+	const char DISCOVERY_ADDRESS[] = "255.255.255.255";
+	const quint16 DISCOVERY_PORT = 12345;
+	const char DISCOVERY_MESSAGE[] = "Z-SEARCH * \r\n";
+	constexpr std::chrono::milliseconds DEFAULT_DISCOVERY_TIMEOUT{ 2000 };
+	constexpr std::chrono::milliseconds DEFAULT_READ_TIMEOUT{ 1000 };
+	constexpr std::chrono::milliseconds DEFAULT_IDENTIFY_TIME{ 2000 };
 
-const char COLOLIGHT_MODEL[] = "mod";
-const char COLOLIGHT_MODEL_TYPE[] = "subkey";
-const char COLOLIGHT_MAC[] = "sn";
-const char COLOLIGHT_NAME[] = "name";
+	const char COLOLIGHT_MODEL[] = "mod";
+	const char COLOLIGHT_MODEL_TYPE[] = "subkey";
+	const char COLOLIGHT_MAC[] = "sn";
+	const char COLOLIGHT_NAME[] = "name";
 
-const char COLOLIGHT_MODEL_IDENTIFIER[] = "OD_WE_QUAN";
+	const char COLOLIGHT_MODEL_IDENTIFIER[] = "OD_WE_QUAN";
 } //End of constants
 
 LedDeviceCololight::LedDeviceCololight(const QJsonObject& deviceConfig)
 	: ProviderUdp(deviceConfig)
-	  , _modelType(-1)
-	  , _ledLayoutType(-1)
-	  , _ledBeadCount(0)
-	  , _distance(0)
-	  , _sequenceNumber(1)
+	, _modelType(-1)
+	, _ledLayoutType(-1)
+	, _ledBeadCount(0)
+	, _distance(0)
+	, _sequenceNumber(1)
 {
 	_packetFixPart.append(reinterpret_cast<const char*>(PACKET_HEADER), sizeof(PACKET_HEADER));
 	_packetFixPart.append(reinterpret_cast<const char*>(PACKET_SECU), sizeof(PACKET_SECU));
@@ -186,7 +186,7 @@ bool LedDeviceCololight::getInfo()
 		QByteArray response;
 		if (readResponse(response))
 		{
-			DebugIf(verbose, _log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
+			DebugIf(verbose,_log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
 
 			quint16 ledNum = qFromBigEndian<quint16>(response.data() + 1);
 
@@ -267,7 +267,7 @@ bool LedDeviceCololight::setColor(const uint32_t color)
 		QByteArray response;
 		if (readResponse(response))
 		{
-			DebugIf(verbose, _log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
+			DebugIf(verbose,_log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
 			isCmdOK = true;
 		}
 	}
@@ -303,7 +303,7 @@ bool LedDeviceCololight::setState(bool isOn)
 		QByteArray response;
 		if (readResponse(response))
 		{
-			DebugIf(verbose, _log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
+			DebugIf(verbose,_log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
 			isCmdOK = true;
 		}
 	}
@@ -327,7 +327,7 @@ bool LedDeviceCololight::setStateDirect(bool isOn)
 		QByteArray response;
 		if (readResponse(response))
 		{
-			DebugIf(verbose, _log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
+			DebugIf(verbose,_log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
 			isCmdOK = true;
 		}
 	}
@@ -381,7 +381,7 @@ bool LedDeviceCololight::setTL1CommandMode(bool isOn)
 		QByteArray response;
 		if (readResponse(response))
 		{
-			DebugIf(verbose, _log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
+			DebugIf(verbose,_log, "#[0x%x], Data returned: [%s]", _sequenceNumber, QSTRING_CSTR(toHex(response)));
 			isCmdOK = true;
 		}
 	}
@@ -498,7 +498,7 @@ bool LedDeviceCololight::readResponse(QByteArray& response)
 							}
 							else
 							{
-								DebugIf(verbose, _log, "No additional data returned");
+								DebugIf(verbose,_log, "No additional data returned");
 							}
 						}
 						isRequestOK = true;
@@ -605,7 +605,7 @@ QJsonArray LedDeviceCololight::discover()
 	{
 		QJsonObject obj;
 
-		QString ipAddress = i.key();
+		const QString& ipAddress = i.key();
 		obj.insert("ip", ipAddress);
 		obj.insert("model", i.value().value(COLOLIGHT_MODEL));
 		obj.insert("type", i.value().value(COLOLIGHT_MODEL_TYPE));
@@ -661,26 +661,27 @@ QJsonObject LedDeviceCololight::discover(const QJsonObject& /*params*/)
 	devicesDiscovered.insert("discoveryMethod", discoveryMethod);
 	devicesDiscovered.insert("devices", deviceList);
 
-	//Debug(_log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose,_log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
 	return devicesDiscovered;
 }
 
 QJsonObject LedDeviceCololight::getProperties(const QJsonObject& params)
 {
-	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose,_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
 	QJsonObject properties;
 
-	QString apiHostname = params["host"].toString("");
+	QString hostName = params["host"].toString("");
 	quint16 apiPort = static_cast<quint16>(params["port"].toInt(API_DEFAULT_PORT));
 
 	QJsonObject propertiesDetails;
-	if (!apiHostname.isEmpty())
+	if (!hostName.isEmpty())
 	{
 		QJsonObject deviceConfig;
 
-		deviceConfig.insert("host", apiHostname);
+		deviceConfig.insert("host", hostName);
 		deviceConfig.insert("port", apiPort);
+
 		if (ProviderUdp::init(deviceConfig))
 		{
 			if (getInfo())
@@ -708,23 +709,23 @@ QJsonObject LedDeviceCololight::getProperties(const QJsonObject& params)
 
 	properties.insert("properties", propertiesDetails);
 
-	DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose,_log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
 	return properties;
 }
 
 void LedDeviceCololight::identify(const QJsonObject& params)
 {
-	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose,_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
-	QString apiHostname = params["host"].toString("");
+	QString hostName = params["host"].toString("");
 	quint16 apiPort = static_cast<quint16>(params["port"].toInt(API_DEFAULT_PORT));
 
-	if (!apiHostname.isEmpty())
+	if (!hostName.isEmpty())
 	{
 		QJsonObject deviceConfig;
 
-		deviceConfig.insert("host", apiHostname);
+		deviceConfig.insert("host", hostName);
 		deviceConfig.insert("port", apiPort);
 		if (ProviderUdp::init(deviceConfig))
 		{
@@ -732,9 +733,7 @@ void LedDeviceCololight::identify(const QJsonObject& params)
 			{
 				setEffect(THE_CIRCUS);
 
-				QEventLoop loop;
-				QTimer::singleShot(DEFAULT_IDENTIFY_TIME.count(), &loop, &QEventLoop::quit);
-				loop.exec();
+				wait(DEFAULT_IDENTIFY_TIME);
 
 				setColor(ColorRgb::BLACK);
 			}

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.h
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.h
@@ -149,9 +149,15 @@ private:
 	///
 	/// @brief Change Nanoleaf device to External Control (UDP) mode
 	///
-	/// @return Response from device
-	///@brief
-	QJsonDocument changeToExternalControlMode();
+	/// @return True, if success
+	bool changeToExternalControlMode();
+	///
+	/// @brief Change Nanoleaf device to External Control (UDP) mode
+	///
+	/// @param[out] response from device
+	///
+	/// @return True, if success
+	bool changeToExternalControlMode(QJsonDocument& resp);
 
 	///
 	/// @brief Get command to power Nanoleaf device on or off
@@ -161,10 +167,18 @@ private:
 	///
 	QString getOnOffRequest(bool isOn) const;
 
+	///
+	/// @brief Discover Nanoleaf devices available (for configuration).
+	/// Nanoleaf specific ssdp discovery
+	///
+	/// @return A JSON structure holding a list of devices found
+	///
+	QJsonArray discover();
+
 	///REST-API wrapper
 	ProviderRestApi* _restApi;
 
-	QString _hostname;
+	QString _hostName;
 	int  _apiPort;
 	QString _authToken;
 

--- a/libsrc/leddevice/dev_net/LedDeviceWled.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceWled.cpp
@@ -1,14 +1,20 @@
 // Local-Hyperion includes
 #include "LedDeviceWled.h"
 
-#include <ssdp/SSDPDiscover.h>
 #include <utils/QStringUtils.h>
+#include <utils/WaitTime.h>
+#include <QThread>
+
+#include <chrono>
 
 // Constants
 namespace {
 
+const bool verbose = false;
+
 // Configuration settings
 const char CONFIG_ADDRESS[] = "host";
+const char CONFIG_RESTORE_STATE[] = "restoreOriginalState";
 
 // UDP elements
 const quint16 STREAM_DEFAULT_PORT = 19446;
@@ -24,12 +30,11 @@ const char API_PATH_STATE[] = "state";
 const char STATE_ON[] = "on";
 const char STATE_VALUE_TRUE[] = "true";
 const char STATE_VALUE_FALSE[] = "false";
+const char STATE_LIVE[] = "live";
 
-// WLED ssdp services
-// TODO: WLED - Update ssdp discovery parameters when available
-const char SSDP_ID[] = "ssdp:all";
-const char SSDP_FILTER[] = "(.*)";
-const char SSDP_FILTER_HEADER[] = "ST";
+const int BRI_MAX = 255;
+
+constexpr std::chrono::milliseconds DEFAULT_IDENTIFY_TIME{ 2000 };
 
 } //End of constants
 
@@ -53,7 +58,6 @@ LedDevice* LedDeviceWled::construct(const QJsonObject &deviceConfig)
 
 bool LedDeviceWled::init(const QJsonObject &deviceConfig)
 {
-	Debug(_log, "");
 	bool isInitOK = false;
 
 	// Initialise LedDevice sub-class, ProviderUdp::init will be executed later, if connectivity is defined
@@ -66,18 +70,21 @@ bool LedDeviceWled::init(const QJsonObject &deviceConfig)
 		Debug(_log, "ColorOrder   : %s", QSTRING_CSTR( this->getColorOrder() ));
 		Debug(_log, "LatchTime    : %d", this->getLatchTime());
 
+		_isRestoreOrigState     = _devConfig[CONFIG_RESTORE_STATE].toBool(false);
+		Debug(_log, "RestoreOrigState  : %d", _isRestoreOrigState);
+
 		//Set hostname as per configuration
-		QString address = deviceConfig[ CONFIG_ADDRESS ].toString();
+		QString hostName = deviceConfig[ CONFIG_ADDRESS ].toString();
 
 		//If host not configured the init fails
-		if ( address.isEmpty() )
+		if ( hostName.isEmpty() )
 		{
 			this->setInError("No target hostname nor IP defined");
 			return false;
 		}
 		else
 		{
-			QStringList addressparts = QStringUtils::split(address,":", QStringUtils::SplitBehavior::SkipEmptyParts);
+			QStringList addressparts = QStringUtils::split(hostName,":", QStringUtils::SplitBehavior::SkipEmptyParts);
 			_hostname = addressparts[0];
 			if ( addressparts.size() > 1 )
 			{
@@ -100,13 +107,11 @@ bool LedDeviceWled::init(const QJsonObject &deviceConfig)
 			}
 		}
 	}
-	Debug(_log, "[%d]", isInitOK);
 	return isInitOK;
 }
 
 bool LedDeviceWled::initRestAPI(const QString &hostname, int port)
 {
-	Debug(_log, "");
 	bool isInitOK = false;
 
 	if ( _restApi == nullptr )
@@ -116,30 +121,61 @@ bool LedDeviceWled::initRestAPI(const QString &hostname, int port)
 
 		isInitOK = true;
 	}
-
-	Debug(_log, "[%d]", isInitOK);
 	return isInitOK;
 }
 
 QString LedDeviceWled::getOnOffRequest(bool isOn) const
 {
 	QString state = isOn ? STATE_VALUE_TRUE : STATE_VALUE_FALSE;
-	return QString( "{\"%1\":%2}" ).arg( STATE_ON, state);
+	return QString( "\"%1\":%2,\"%3\":%4" ).arg( STATE_ON, state).arg( STATE_LIVE, state);
 }
 
+QString LedDeviceWled::getBrightnessRequest(int bri) const
+{
+	return QString( "\"bri\":%1" ).arg(bri);
+}
+
+QString LedDeviceWled::getEffectRequest(int effect, int speed) const
+{
+	return QString( "\"seg\":{\"fx\":%1,\"sx\":%2}" ).arg(effect).arg(speed);
+}
+
+QString LedDeviceWled::getLorRequest(int lor) const
+{
+	return QString( "\"lor\":%1" ).arg(lor);
+}
+
+bool LedDeviceWled::sendStateUpdateRequest(const QString &request)
+{
+	bool rc = true;
+
+	_restApi->setPath(API_PATH_STATE);
+
+	httpResponse response1 = _restApi->put(QString("{%1}").arg(request));
+	if ( response1.error() )
+	{
+		rc = false;
+	}
+	return rc;
+}
 bool LedDeviceWled::powerOn()
 {
-	Debug(_log, "");
-	bool on = true;
+	bool on = false;
 	if ( _isDeviceReady)
 	{
 		//Power-on WLED device
 		_restApi->setPath(API_PATH_STATE);
-		httpResponse response = _restApi->put(getOnOffRequest(true));
+
+		httpResponse response = _restApi->put(QString("{%1,%2}").arg(getOnOffRequest(true)).arg(getBrightnessRequest(BRI_MAX)));
 		if ( response.error() )
 		{
-			this->setInError ( response.getErrorReason() );
+			QString errorReason = QString("Power-on request failed with error: '%1'").arg(response.getErrorReason());
+			this->setInError ( errorReason );
 			on = false;
+		}
+		else
+		{
+			on = true;
 		}
 	}
 	return on;
@@ -147,7 +183,6 @@ bool LedDeviceWled::powerOn()
 
 bool LedDeviceWled::powerOff()
 {
-	Debug(_log, "");
 	bool off = true;
 	if ( _isDeviceReady)
 	{
@@ -156,14 +191,62 @@ bool LedDeviceWled::powerOff()
 
 		//Power-off the WLED device physically
 		_restApi->setPath(API_PATH_STATE);
-		httpResponse response = _restApi->put(getOnOffRequest(false));
+		httpResponse response = _restApi->put(QString("{%1}").arg(getOnOffRequest(false)));
 		if ( response.error() )
 		{
-			this->setInError ( response.getErrorReason() );
+			QString errorReason = QString("Power-off request failed with error: '%1'").arg(response.getErrorReason());
+			this->setInError ( errorReason );
 			off = false;
 		}
 	}
 	return off;
+}
+
+bool LedDeviceWled::storeState()
+{
+	bool rc = true;
+
+	if ( _isRestoreOrigState )
+	{
+		_restApi->setPath(API_PATH_STATE);
+
+		httpResponse response = _restApi->get();
+		if ( response.error() )
+		{
+			QString errorReason = QString("Storing device state failed with error: '%1'").arg(response.getErrorReason());
+			setInError(errorReason);
+			rc = false;
+		}
+		else
+		{
+			_originalStateProperties = response.getBody().object();
+			DebugIf(verbose, _log, "state: [%s]", QString(QJsonDocument(_originalStateProperties).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+		}
+	}
+
+	return rc;
+}
+
+bool LedDeviceWled::restoreState()
+{
+	bool rc = true;
+
+	if ( _isRestoreOrigState )
+	{
+		//powerOff();
+		_restApi->setPath(API_PATH_STATE);
+
+		_originalStateProperties[STATE_LIVE] = false;
+
+		httpResponse response = _restApi->put(QString(QJsonDocument(_originalStateProperties).toJson(QJsonDocument::Compact)).toUtf8().constData());
+
+		if ( response.error() )
+		{
+			Warning (_log, "%s restoring state failed with error: '%s'", QSTRING_CSTR(_activeDeviceType), QSTRING_CSTR(response.getErrorReason()));
+		}
+	}
+
+	return rc;
 }
 
 QJsonObject LedDeviceWled::discover(const QJsonObject& /*params*/)
@@ -172,37 +255,25 @@ QJsonObject LedDeviceWled::discover(const QJsonObject& /*params*/)
 	devicesDiscovered.insert("ledDeviceType", _activeDeviceType );
 
 	QJsonArray deviceList;
-
-	// Discover WLED Devices
-	SSDPDiscover discover;
-	discover.skipDuplicateKeys(true);
-	discover.setSearchFilter(SSDP_FILTER, SSDP_FILTER_HEADER);
-	QString searchTarget = SSDP_ID;
-
-	if ( discover.discoverServices(searchTarget) > 0 )
-	{
-		deviceList = discover.getServicesDiscoveredJson();
-	}
-
 	devicesDiscovered.insert("devices", deviceList);
-	Debug(_log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+	DebugIf(verbose, _log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 
 	return devicesDiscovered;
 }
 
 QJsonObject LedDeviceWled::getProperties(const QJsonObject& params)
 {
-	Debug(_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 	QJsonObject properties;
 
-	// Get Nanoleaf device properties
-	QString host = params["host"].toString("");
-	if ( !host.isEmpty() )
+	QString hostName = params["host"].toString("");
+
+	if ( !hostName.isEmpty() )
 	{
 		QString filter = params["filter"].toString("");
 
 		// Resolve hostname and port (or use default API port)
-		QStringList addressparts = QStringUtils::split(host,":", QStringUtils::SplitBehavior::SkipEmptyParts);
+		QStringList addressparts = QStringUtils::split(hostName,":", QStringUtils::SplitBehavior::SkipEmptyParts);
 		QString apiHost = addressparts[0];
 		int apiPort;
 
@@ -226,49 +297,45 @@ QJsonObject LedDeviceWled::getProperties(const QJsonObject& params)
 
 		properties.insert("properties", response.getBody().object());
 
-		Debug(_log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+		DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 	}
 	return properties;
 }
 
-void LedDeviceWled::identify(const QJsonObject& /*params*/)
+void LedDeviceWled::identify(const QJsonObject& params)
 {
-#if 0
-	Debug(_log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
 
-	QString host = params["host"].toString("");
-	if ( !host.isEmpty() )
+	QString hostName = params["host"].toString("");
+
+	if ( !hostName.isEmpty() )
 	{
 		// Resolve hostname and port (or use default API port)
-		QStringList addressparts = QStringUtils::split(host,":", QStringUtils::SplitBehavior::SkipEmptyParts);
+		QStringList addressparts = QStringUtils::split(hostName,":", QStringUtils::SplitBehavior::SkipEmptyParts);
 		QString apiHost = addressparts[0];
 		int apiPort;
 
 		if ( addressparts.size() > 1)
+		{
 			apiPort = addressparts[1].toInt();
+		}
 		else
+		{
 			apiPort   = API_DEFAULT_PORT;
+		}
 
-		// TODO: WLED::identify - Replace with valid identification code
+		initRestAPI(apiHost, apiPort);
 
-		//		initRestAPI(apiHost, apiPort);
+		_isRestoreOrigState = true;
+		storeState();
 
-		//		QString resource = QString("%1/%2/%3").arg( API_LIGHTS ).arg( lightId ).arg( API_STATE);
-		//		_restApi->setPath(resource);
+		QString request = getOnOffRequest(true) + "," + getLorRequest(1) + "," + getEffectRequest(25);
+		sendStateUpdateRequest(request);
 
-		//		QString stateCmd;
-		//		stateCmd += QString("\"%1\":%2,").arg( API_STATE_ON ).arg( API_STATE_VALUE_TRUE );
-		//		stateCmd += QString("\"%1\":\"%2\"").arg( "alert" ).arg( "select" );
-		//		stateCmd = "{" + stateCmd + "}";
+		wait(DEFAULT_IDENTIFY_TIME);
 
-		//		// Perform request
-		//		httpResponse response = _restApi->put(stateCmd);
-		//		if ( response.error() )
-		//		{
-		//			Warning (_log, "%s identification failed with error: '%s'", QSTRING_CSTR(_activeDeviceType), QSTRING_CSTR(response.getErrorReason()));
-		//		}
+		restoreState();
 	}
-#endif
 }
 
 int LedDeviceWled::write(const std::vector<ColorRgb> &ledValues)

--- a/libsrc/leddevice/dev_net/LedDeviceWled.h
+++ b/libsrc/leddevice/dev_net/LedDeviceWled.h
@@ -8,8 +8,6 @@
 
 ///
 /// Implementation of a WLED-device
-/// ...
-///
 ///
 class LedDeviceWled : public ProviderUdp
 {
@@ -105,6 +103,25 @@ protected:
 	///
 	bool powerOff() override;
 
+	///
+	/// @brief Store the device's original state.
+	///
+	/// Save the device's state before hyperion color streaming starts allowing to restore state during switchOff().
+	///
+	/// @return True if success
+	///
+	bool storeState() override;
+
+	///
+	/// @brief Restore the device's original state.
+	///
+	/// Restore the device's state as before hyperion color streaming started.
+	/// This includes the on/off state of the device.
+	///
+	/// @return True, if success
+	///
+	bool restoreState() override;
+
 private:
 
 	///
@@ -123,12 +140,20 @@ private:
 	/// @return Command to switch device on/off
 	///
 	QString getOnOffRequest (bool isOn ) const;
+	QString getBrightnessRequest (int bri ) const;
+	QString getEffectRequest(int effect, int speed=128) const;
+	QString getLorRequest(int lor) const;
+
+	bool sendStateUpdateRequest(const QString &request);
 
 	///REST-API wrapper
 	ProviderRestApi* _restApi;
 
 	QString _hostname;
 	int		_apiPort;
+
+	QJsonObject _originalStateProperties;
+
 };
 
 #endif // LEDDEVICEWLED_H

--- a/libsrc/leddevice/dev_net/LedDeviceYeelight.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceYeelight.cpp
@@ -234,12 +234,12 @@ int YeelightLight::writeCommand( const QJsonDocument &command, QJsonArray &resul
 			if ( ! _tcpSocket->waitForBytesWritten(WRITE_TIMEOUT.count()) )
 			{
 				QString errorReason = QString ("(%1) %2").arg(_tcpSocket->error()).arg( _tcpSocket->errorString());
-				log ( 2, "Error:", "bytesWritten: [%ll], %s", bytesWritten, QSTRING_CSTR(errorReason));
+				log ( 2, "Error:", "bytesWritten: [%d], %s", bytesWritten, QSTRING_CSTR(errorReason));
 				this->setInError ( errorReason );
 			}
 			else
 			{
-				log ( 3, "Success:", "Bytes written   [%ll]", bytesWritten );
+				log ( 3, "Success:", "Bytes written   [%d]", bytesWritten );
 
 				// Avoid to overrun the Yeelight Command Quota
 				qint64 elapsedTime = QDateTime::currentMSecsSinceEpoch() - _lastWriteTime;
@@ -258,7 +258,7 @@ int YeelightLight::writeCommand( const QJsonDocument &command, QJsonArray &resul
 			{
 				do
 				{
-					log ( 3, "Reading:", "Bytes available [%ll]", _tcpSocket->bytesAvailable() );
+					log ( 3, "Reading:", "Bytes available [%d]", _tcpSocket->bytesAvailable() );
 					while ( _tcpSocket->canReadLine() )
 					{
 						QByteArray response = _tcpSocket->readLine();
@@ -338,7 +338,7 @@ bool YeelightLight::streamCommand( const QJsonDocument &command )
 			{
 				int error = _tcpStreamSocket->error();
 				QString errorReason = QString ("(%1) %2").arg(error).arg( _tcpStreamSocket->errorString());
-				log ( 1, "Error:", "bytesWritten: [%ll], %s", bytesWritten, QSTRING_CSTR(errorReason));
+				log ( 1, "Error:", "bytesWritten: [%d], %s", bytesWritten, QSTRING_CSTR(errorReason));
 
 				if ( error == QAbstractSocket::RemoteHostClosedError )
 				{
@@ -353,7 +353,7 @@ bool YeelightLight::streamCommand( const QJsonDocument &command )
 			}
 			else
 			{
-				log ( 3, "Success:", "Bytes written   [%ll]", bytesWritten );
+				log ( 3, "Success:", "Bytes written   [%d]", bytesWritten );
 				rc = true;
 			}
 		}
@@ -956,7 +956,10 @@ void YeelightLight::log(int logLevel, const char* msg, const char* type, ...)
 		va_end(args);
 		std::string s = msg;
 		uint max = 20;
-		s.append(max - s.length(), ' ');
+		if (max > s.length())
+		{
+			s.append(max - s.length(), ' ');
+		}
 
 		Debug( _log, "%d|%15.15s| %s: %s", logLevel, QSTRING_CSTR(_name), s.c_str(), val);
 	}

--- a/libsrc/leddevice/dev_net/LedDeviceYeelight.h
+++ b/libsrc/leddevice/dev_net/LedDeviceYeelight.h
@@ -591,6 +591,14 @@ private:
 	///
 	uint getLightsCount() const { return _lightsCount; }
 
+	///
+	/// @brief Discover Yeelight devices available (for configuration).
+	/// Yeelight specific UDP Broadcast discovery
+	///
+	/// @return A JSON structure holding a list of devices found
+	///
+	QJsonArray discover();
+
 	/// Array of the Yeelight addresses handled by the LED-device
 	QVector<yeelightAddress> _lightsAddressList;
 

--- a/libsrc/leddevice/dev_serial/LedDeviceAtmo.cpp
+++ b/libsrc/leddevice/dev_serial/LedDeviceAtmo.cpp
@@ -1,6 +1,10 @@
 // hyperion local includes
 #include "LedDeviceAtmo.h"
 
+namespace {
+	const bool verbose = false;
+} //End of constants
+
 LedDeviceAtmo::LedDeviceAtmo(const QJsonObject &deviceConfig)
 	: ProviderRs232(deviceConfig)
 {
@@ -42,4 +46,21 @@ int LedDeviceAtmo::write(const std::vector<ColorRgb> &ledValues)
 {
 	memcpy(4 + _ledBuffer.data(), ledValues.data(), _ledCount * sizeof(ColorRgb));
 	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}
+
+QJsonObject LedDeviceAtmo::getProperties(const QJsonObject& params)
+{
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	QJsonObject properties;
+
+	QString serialPort = params["serialPort"].toString("");
+
+	QJsonObject propertiesDetails;
+	QJsonArray possibleLedCounts = { 5 };
+	propertiesDetails.insert("ledCount", possibleLedCounts);
+
+	properties.insert("properties", propertiesDetails);
+
+	DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	return properties;
 }

--- a/libsrc/leddevice/dev_serial/LedDeviceAtmo.h
+++ b/libsrc/leddevice/dev_serial/LedDeviceAtmo.h
@@ -23,6 +23,14 @@ public:
 	///
 	static LedDevice* construct(const QJsonObject &deviceConfig);
 
+	///
+	/// @brief Get a Atmo device's resource properties
+	///
+	/// @param[in] params Parameters to query device
+	/// @return A JSON structure holding the device's properties
+	///
+	QJsonObject getProperties(const QJsonObject& params) override;
+
 private:
 
 	///

--- a/libsrc/leddevice/dev_serial/LedDeviceKarate.cpp
+++ b/libsrc/leddevice/dev_serial/LedDeviceKarate.cpp
@@ -1,27 +1,31 @@
 // hyperion local includes
 #include "LedDeviceKarate.h"
 
-LedDeviceKarate::LedDeviceKarate(const QJsonObject &deviceConfig)
+namespace {
+	const bool verbose = false;
+} //End of constants
+
+LedDeviceKarate::LedDeviceKarate(const QJsonObject& deviceConfig)
 	: ProviderRs232(deviceConfig)
 {
 }
 
-LedDevice* LedDeviceKarate::construct(const QJsonObject &deviceConfig)
+LedDevice* LedDeviceKarate::construct(const QJsonObject& deviceConfig)
 {
 	return new LedDeviceKarate(deviceConfig);
 }
 
-bool LedDeviceKarate::init(const QJsonObject &deviceConfig)
+bool LedDeviceKarate::init(const QJsonObject& deviceConfig)
 {
 	bool isInitOK = false;
 
 	// Initialise sub-class
-	if ( ProviderRs232::init(deviceConfig) )
+	if (ProviderRs232::init(deviceConfig))
 	{
 		if (_ledCount != 8 && _ledCount != 16)
 		{
 			//Error( _log, "%d channels configured. This should always be 16!", _ledCount);
-			QString errortext = QString ("%1 channels configured. This should always be 8 or 16!").arg(_ledCount);
+			QString errortext = QString("%1 channels configured. This should always be 8 or 16!").arg(_ledCount);
 			this->setInError(errortext);
 			isInitOK = false;
 		}
@@ -33,8 +37,8 @@ bool LedDeviceKarate::init(const QJsonObject &deviceConfig)
 			_ledBuffer[2] = 0x00;				  // Checksum
 			_ledBuffer[3] = _ledCount * 3;        // Number of Databytes send
 
-			Debug( _log, "Karatelight header for %d leds: 0x%02x 0x%02x 0x%02x 0x%02x", _ledCount,
-				  _ledBuffer[0], _ledBuffer[1], _ledBuffer[2], _ledBuffer[3] );
+			Debug(_log, "Karatelight header for %d leds: 0x%02x 0x%02x 0x%02x 0x%02x", _ledCount,
+				_ledBuffer[0], _ledBuffer[1], _ledBuffer[2], _ledBuffer[3]);
 
 			isInitOK = true;
 		}
@@ -42,20 +46,37 @@ bool LedDeviceKarate::init(const QJsonObject &deviceConfig)
 	return isInitOK;
 }
 
-int LedDeviceKarate::write(const std::vector<ColorRgb> &ledValues)
+int LedDeviceKarate::write(const std::vector<ColorRgb>& ledValues)
 {
-	for (signed iLed=0; iLed< static_cast<int>(_ledCount); iLed++)
-        {
-       		const ColorRgb& rgb = ledValues[iLed];
-                _ledBuffer[iLed*3+4] = rgb.green;
-                _ledBuffer[iLed*3+5] = rgb.blue;
-                _ledBuffer[iLed*3+6] = rgb.red;
-        }
+	for (signed iLed = 0; iLed < static_cast<int>(_ledCount); iLed++)
+	{
+		const ColorRgb& rgb = ledValues[iLed];
+		_ledBuffer[iLed * 3 + 4] = rgb.green;
+		_ledBuffer[iLed * 3 + 5] = rgb.blue;
+		_ledBuffer[iLed * 3 + 6] = rgb.red;
+	}
 
 	// Calc Checksum
-	_ledBuffer[2] =  _ledBuffer[0] ^ _ledBuffer[1];
-    	for (unsigned int i = 3; i < _ledBuffer.size(); i++)
-      		_ledBuffer[2] ^= _ledBuffer[i];
+	_ledBuffer[2] = _ledBuffer[0] ^ _ledBuffer[1];
+	for (unsigned int i = 3; i < _ledBuffer.size(); i++)
+		_ledBuffer[2] ^= _ledBuffer[i];
 
 	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}
+
+QJsonObject LedDeviceKarate::getProperties(const QJsonObject& params)
+{
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	QJsonObject properties;
+
+	QString serialPort = params["serialPort"].toString("");
+
+	QJsonObject propertiesDetails;
+	QJsonArray possibleLedCounts = { 16, 8 };
+	propertiesDetails.insert("ledCount", possibleLedCounts);
+
+	properties.insert("properties", propertiesDetails);
+
+	DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData());
+	return properties;
 }

--- a/libsrc/leddevice/dev_serial/LedDeviceKarate.h
+++ b/libsrc/leddevice/dev_serial/LedDeviceKarate.h
@@ -26,6 +26,14 @@ public:
 	/// @return LedDevice constructed
 	static LedDevice* construct(const QJsonObject &deviceConfig);
 
+	///
+	/// @brief Get a Karate device's resource properties
+	///
+	/// @param[in] params Parameters to query device
+	/// @return A JSON structure holding the device's properties
+	///
+	QJsonObject getProperties(const QJsonObject& params) override;
+
 private:
 
 	///

--- a/libsrc/leddevice/schemas/schema-wled.json
+++ b/libsrc/leddevice/schemas/schema-wled.json
@@ -4,8 +4,16 @@
 	"properties":{
 		"host" : {
 			"type": "string",
-			"title":"edt_dev_spec_targetIpHost_title",
-			"propertyOrder" : 1
+			"title": "edt_dev_spec_targetIpHost_title",
+			"required": true,
+			"propertyOrder": 1
+		},
+		"restoreOriginalState": {
+			"type": "boolean",
+			"title": "edt_dev_spec_restoreOriginalState_title",
+			"default": false,
+			"required": true,
+			"propertyOrder": 2
 		},
 		"latchTime": {
 			"type": "integer",
@@ -15,7 +23,7 @@
 			"minimum": 0,
 			"maximum": 1000,
 			"access" : "expert",
-			"propertyOrder" : 2
+			"propertyOrder" : 3
 		}
 	},
 	"additionalProperties": true


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

### Added

- WLED: Support of ["live" property] (https://github.com/Aircoookie/WLED/issues/1308), addresses #1095
- WLED: Support storing/restoring state, fixes #1101 
- LED-Devices: Allow to get properties for Atmo and Karatedevices to limit LED numbers configurable
- LED-Devices: Add timeouts for REST-API calls

### Changed

- Nanoleaf: Consider Nanoleaf-Shape Controlers
- LED-Devices: Show HW-Ledcount in all setting levels

### Fixed

- LED-Hue: Minor fix of setColor command
- Nanoleaf: Fix,if external control mode cannot be set


**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [X] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Fixes #1101, #1095
