### PR TITLE
Stop background effect, when it gets out of scope

### DIFF
--- a/include/hyperion/BGEffectHandler.h
+++ b/include/hyperion/BGEffectHandler.h
@@ -4,6 +4,7 @@
 #include <hyperion/Hyperion.h>
 #include <utils/settings.h>
 #include <effectengine/Effect.h>
+#include <hyperion/PriorityMuxer.h>
 
 ///
 /// @brief Handle the background Effect settings, reacts on runtime to settings changes
@@ -14,11 +15,16 @@ class BGEffectHandler : public QObject
 
 public:
 	BGEffectHandler(Hyperion* hyperion)
-	: QObject(hyperion)
-	, _hyperion(hyperion)
+		: QObject(hyperion)
+		, _hyperion(hyperion)
+		, _prioMuxer(nullptr)
+		, _isBgEffectConfigured(false)
 	{
 		// listen for config changes
 		connect(_hyperion, &Hyperion::settingsChanged, this, &BGEffectHandler::handleSettingsUpdate);
+
+		_prioMuxer = _hyperion->getMuxerInstance();
+		connect(_prioMuxer,&PriorityMuxer::prioritiesChanged, this, &BGEffectHandler::handlePriorityUpdate);
 
 		// initialization
 		handleSettingsUpdate(settings::BGEFFECT, _hyperion->getSetting(settings::BGEFFECT));
@@ -34,14 +40,18 @@ private slots:
 	{
 		if(type == settings::BGEFFECT)
 		{
-			const QJsonObject& BGEffectConfig = config.object();
+			_isBgEffectConfigured = false;
+			_bgEffectConfig = config;
 
+			const QJsonObject& BGEffectConfig = _bgEffectConfig.object();
 			#define BGCONFIG_ARRAY bgColorConfig.toArray()
 			// clear background priority
 			_hyperion->clear(PriorityMuxer::BG_PRIORITY);
 			// initial background effect/color
 			if (BGEffectConfig["enable"].toBool(true))
 			{
+				_isBgEffectConfigured = true;
+
 				const QString bgTypeConfig = BGEffectConfig["type"].toString("effect");
 				const QString bgEffectConfig = BGEffectConfig["effect"].toString("Warm mood blobs");
 				const QJsonValue bgColorConfig = BGEffectConfig["color"];
@@ -63,12 +73,36 @@ private slots:
 					Info(Logger::getInstance("HYPERION"),"Initial background effect '%s' %s", QSTRING_CSTR(bgEffectConfig), ((result == 0) ? "started" : "failed"));
 				}
 			}
-
 			#undef BGCONFIG_ARRAY
+		}
+	}
+
+	///
+	/// @brief Handle priority updates.
+	/// In case the background effect is not current priority, stop BG-effect to save resources; otherwise start effect again.
+	///
+	void handlePriorityUpdate()
+	{
+		if (_prioMuxer->getCurrentPriority() != PriorityMuxer::BG_PRIORITY && _prioMuxer->hasPriority(PriorityMuxer::BG_PRIORITY))
+		{
+			Debug(Logger::getInstance("HYPERION"),"Stop background (color-) effect as it moved out of scope");
+			_hyperion->clear(PriorityMuxer::BG_PRIORITY);
+		}
+		else
+		{
+			if (_prioMuxer->getCurrentPriority() == PriorityMuxer::LOWEST_PRIORITY && _isBgEffectConfigured)
+			{
+				emit handleSettingsUpdate (settings::BGEFFECT, _bgEffectConfig);
+			}
 		}
 	}
 
 private:
 	/// Hyperion instance pointer
 	Hyperion* _hyperion;
+	/// priority muxer instance
+	PriorityMuxer* _prioMuxer;
+
+	QJsonDocument _bgEffectConfig;
+	bool _isBgEffectConfigured;
 };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Stop background effect, when it is overlaid by another priority.
Otherwise the background effect will  continuously run in the background and eats up resources unnecessarily.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
