### PR TITLE
Fixes:  #1229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LED-Hue: Proper black in Entertainement mode if min brightness is set
 - LED-Hue: Minor fix of setColor command
 - Nanoleaf: Fix,if external control mode cannot be set
+- Fix issue #1229: "LED Test" effect description is in wrong order
 
 ### Removed
 

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -580,7 +580,7 @@
     "edt_eff_knightrider_header_desc": "K.I.T.T is back! The front-scanner of the well known car, this time not just in red.",
     "edt_eff_ledlist": "Led List",
     "edt_eff_ledtest_header": "Led Test",
-    "edt_eff_ledtest_header_desc": "Rotating output: Red, Blue, Green, White, Black",
+    "edt_eff_ledtest_header_desc": "Rotating output: Red, Green, Blue, White, Black",
     "edt_eff_length": "Length",
     "edt_eff_lightclock_header": "Light Clock",
     "edt_eff_lightclock_header_desc": "A real clock as light! Adjust the colors of hours, minute, seconds. A optional 3/6/9/12 o'clock marker is also available. In case the clock is wrong, you need to check your system clock.",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Modify description of the "LED Test" effect
See #1229 - "LED Test" effect description is in wrong order

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**before**
![image](https://user-images.githubusercontent.com/2406013/114691885-a7c57680-9d07-11eb-89b6-3c38000d0100.png)

**after**
![image](https://user-images.githubusercontent.com/2406013/114692631-51a50300-9d08-11eb-850c-660727f13990.png)



**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [X] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
