### PR TITLE
Limit maximum LEDs number for WLED and UDP-Raw

### DIFF
--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -57,6 +57,7 @@
     "conf_leds_device_intro": "Hyperion supports a lot of controllers to transmit data to your target device. Select a LED controller out of the sorted list and configure it. We have chosen the best default settings for each device.",
     "conf_leds_error_hwled_gt_layout": "The hardware LED count ($1) is greater than LEDs configured via layout ($2),<br>$3 {{plural:$3|LED|LEDs}} will stay black if you continue.",
     "conf_leds_error_hwled_lt_layout": "The hardware LED count ($1) is less than LEDs configured via layout ($2). <br> The number of LEDs configured in the layout must not exceed the available LEDs",
+    "conf_leds_error_hwled_gt_maxled": "The hardware LED count ($1) is greater than the maximum number of LEDs supported by the device ($2). <br> The hardware LED count is set to ($3).",
     "conf_leds_info_ws281x": "Hyperion must run with 'root' privileges for this controller type!",
     "conf_leds_layout_advanced": "Advanced Settings",
     "conf_leds_layout_blacklist_num_title": "Number of LEDs",

--- a/assets/webconfig/js/content_leds.js
+++ b/assets/webconfig/js/content_leds.js
@@ -931,6 +931,11 @@ $(document).ready(function () {
             params = { host: host, filter: "info" };
             getProperties_device(ledType, host, params);
             break;
+
+          case "udpraw":
+            getProperties_device(ledType, host, params);
+            break;
+
           default:
         }
       }
@@ -1580,6 +1585,10 @@ function updateElements(ledType, key) {
       case "wled":
         var ledProperties = devicesProperties[ledType][key];
 
+        if (ledProperties && ledProperties.maxLedCount) {
+          updateJsonEditorRange(conf_editor, "root.generalOptions", "hardwareLedCount", 1, ledProperties.maxLedCount);
+        }
+
         if (ledProperties && ledProperties.leds) {
           hardwareLedCount = ledProperties.leds.count;
         }
@@ -1601,6 +1610,14 @@ function updateElements(ledType, key) {
         }
         conf_editor.getEditor("root.generalOptions.hardwareLedCount").setValue(hardwareLedCount);
 
+        break;
+
+      case "udpraw":
+        var ledProperties = devicesProperties[ledType][key];
+
+        if (ledProperties && ledProperties.maxLedCount) {
+          updateJsonEditorRange(conf_editor, "root.generalOptions", "hardwareLedCount", 1, ledProperties.maxLedCount);
+        }
         break;
 
       case "atmo":

--- a/assets/webconfig/js/content_leds.js
+++ b/assets/webconfig/js/content_leds.js
@@ -1572,11 +1572,11 @@ async function identify_device(type, params) {
 
 function updateElements(ledType, key) {
   if (devicesProperties[ledType][key]) {
+    var hardwareLedCount = 1;
     switch (ledType) {
       case "cololight":
         var ledProperties = devicesProperties[ledType][key];
 
-        var hardwareLedCount = 1;
         if (ledProperties) {
           hardwareLedCount = ledProperties.ledCount;
         }
@@ -1585,12 +1585,14 @@ function updateElements(ledType, key) {
       case "wled":
         var ledProperties = devicesProperties[ledType][key];
 
-        if (ledProperties && ledProperties.maxLedCount) {
-          updateJsonEditorRange(conf_editor, "root.generalOptions", "hardwareLedCount", 1, ledProperties.maxLedCount);
-        }
-
-        if (ledProperties && ledProperties.leds) {
+        if (ledProperties && ledProperties.leds && ledProperties.maxLedCount) {
           hardwareLedCount = ledProperties.leds.count;
+          var maxLedCount = ledProperties.maxLedCount
+          if (hardwareLedCount > maxLedCount)
+          {
+	        showInfoDialog('warning', $.i18n("conf_leds_config_warning"), $.i18n('conf_leds_error_hwled_gt_maxled', hardwareLedCount, maxLedCount, maxLedCount));
+            hardwareLedCount = maxLedCount;
+          }
         }
         conf_editor.getEditor("root.generalOptions.hardwareLedCount").setValue(hardwareLedCount);
         break;
@@ -1616,7 +1618,14 @@ function updateElements(ledType, key) {
         var ledProperties = devicesProperties[ledType][key];
 
         if (ledProperties && ledProperties.maxLedCount) {
-          updateJsonEditorRange(conf_editor, "root.generalOptions", "hardwareLedCount", 1, ledProperties.maxLedCount);
+          hardwareLedCount = conf_editor.getEditor("root.generalOptions.hardwareLedCount").getValue();
+          var maxLedCount = ledProperties.maxLedCount
+          if (hardwareLedCount > maxLedCount)
+          {
+            showInfoDialog('warning', $.i18n("conf_leds_config_warning"), $.i18n('conf_leds_error_hwled_gt_maxled', hardwareLedCount, maxLedCount, maxLedCount));
+            hardwareLedCount = maxLedCount;
+          }
+          updateJsonEditorRange(conf_editor, "root.generalOptions", "hardwareLedCount", 1, maxLedCount, hardwareLedCount);
         }
         break;
 

--- a/libsrc/leddevice/dev_net/LedDeviceUdpRaw.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpRaw.cpp
@@ -1,6 +1,14 @@
 #include "LedDeviceUdpRaw.h"
 
+// Constants
+namespace {
+
+const bool verbose = false;
+
 const ushort RAW_DEFAULT_PORT=5568;
+const int UDP_MAX_LED_NUM = 490;
+
+} //End of constants
 
 LedDeviceUdpRaw::LedDeviceUdpRaw(const QJsonObject &deviceConfig)
 	: ProviderUdp(deviceConfig)
@@ -16,8 +24,28 @@ bool LedDeviceUdpRaw::init(const QJsonObject &deviceConfig)
 {
 	_port = RAW_DEFAULT_PORT;
 
-	// Initialise sub-class
-	bool isInitOK = ProviderUdp::init(deviceConfig);
+	bool isInitOK = false;
+	if ( LedDevice::init(deviceConfig) )
+	{
+		// Initialise LedDevice configuration and execution environment
+		int configuredLedCount = this->getLedCount();
+		Debug(_log, "DeviceType   : %s", QSTRING_CSTR( this->getActiveDeviceType() ));
+		Debug(_log, "LedCount     : %d", configuredLedCount);
+		Debug(_log, "ColorOrder   : %s", QSTRING_CSTR( this->getColorOrder() ));
+		Debug(_log, "LatchTime    : %d", this->getLatchTime());
+
+		if (configuredLedCount > UDP_MAX_LED_NUM)
+		{
+			QString errorReason = QString("Device type %1 can only be run with maximum %2 LEDs!").arg(this->getActiveDeviceType()).arg(UDP_MAX_LED_NUM);
+			this->setInError ( errorReason );
+			isInitOK = false;
+		}
+		else
+		{
+			// Initialise sub-class
+			isInitOK = ProviderUdp::init(deviceConfig);
+		}
+	}
 	return isInitOK;
 }
 
@@ -26,4 +54,19 @@ int LedDeviceUdpRaw::write(const std::vector<ColorRgb> &ledValues)
 	const uint8_t * dataPtr = reinterpret_cast<const uint8_t *>(ledValues.data());
 
 	return writeBytes(_ledRGBCount, dataPtr);
+}
+
+QJsonObject LedDeviceUdpRaw::getProperties(const QJsonObject& params)
+{
+	DebugIf(verbose, _log, "params: [%s]", QString(QJsonDocument(params).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+	QJsonObject properties;
+
+	QJsonObject propertiesDetails;
+	propertiesDetails.insert("maxLedCount", UDP_MAX_LED_NUM);
+
+	properties.insert("properties", propertiesDetails);
+
+	DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData() );
+
+	return properties;
 }

--- a/libsrc/leddevice/dev_net/LedDeviceUdpRaw.h
+++ b/libsrc/leddevice/dev_net/LedDeviceUdpRaw.h
@@ -26,6 +26,14 @@ public:
 	///
 	static LedDevice* construct(const QJsonObject &deviceConfig);
 
+	///
+	/// @brief Get a UDP-Raw device's resource properties
+	///
+	/// @param[in] params Parameters to query device
+	/// @return A JSON structure holding the device's properties
+	///
+	QJsonObject getProperties(const QJsonObject& params) override;
+
 protected:
 
 	///

--- a/libsrc/leddevice/dev_net/LedDeviceWled.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceWled.cpp
@@ -10,7 +10,7 @@
 // Constants
 namespace {
 
-const bool verbose = true;
+const bool verbose = false;
 
 // Configuration settings
 const char CONFIG_ADDRESS[] = "host";
@@ -21,6 +21,7 @@ const char CONFIG_SYNC_OVERWRITE[] = "overwriteSync";
 
 // UDP elements
 const quint16 STREAM_DEFAULT_PORT = 19446;
+const int UDP_MAX_LED_NUM = 490;
 
 // WLED JSON-API elements
 const int API_DEFAULT_PORT = -1; //Use default port per communication scheme
@@ -80,6 +81,13 @@ bool LedDeviceWled::init(const QJsonObject &deviceConfig)
 		Debug(_log, "LedCount     : %d", configuredLedCount);
 		Debug(_log, "ColorOrder   : %s", QSTRING_CSTR( this->getColorOrder() ));
 		Debug(_log, "LatchTime    : %d", this->getLatchTime());
+
+		if (configuredLedCount > UDP_MAX_LED_NUM)
+		{
+			QString errorReason = QString("Device type %1 can only be run with maximum %2 LEDs!").arg(this->getActiveDeviceType()).arg(UDP_MAX_LED_NUM);
+			this->setInError ( errorReason );
+			return false;
+		}
 
 		_isRestoreOrigState = _devConfig[CONFIG_RESTORE_STATE].toBool(DEFAULT_IS_RESTORE_STATE);
 		_isSyncOverwrite = _devConfig[CONFIG_SYNC_OVERWRITE].toBool(DEFAULT_IS_SYNC_OVERWRITE);
@@ -348,7 +356,10 @@ QJsonObject LedDeviceWled::getProperties(const QJsonObject& params)
 			Warning (_log, "%s get properties failed with error: '%s'", QSTRING_CSTR(_activeDeviceType), QSTRING_CSTR(response.getErrorReason()));
 		}
 
-		properties.insert("properties", response.getBody().object());
+		QJsonObject propertiesDetails = response.getBody().object();
+		propertiesDetails.insert("maxLedCount", UDP_MAX_LED_NUM);
+
+		properties.insert("properties", propertiesDetails);
 
 		DebugIf(verbose, _log, "properties: [%s]", QString(QJsonDocument(properties).toJson(QJsonDocument::Compact)).toUtf8().constData() );
 	}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- Limit maximum LEDs numberfor WLED to 490 
- Limit maximum LEDs number for UDP-Raw to 490 

Background: The current UDP-raw protocol  is not capable of handling loss of fragmented packages.
Therefore the number of LEDs is limited to have only one package per update.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

![image](https://user-images.githubusercontent.com/48840279/133643027-532a0344-6237-480b-90b1-1ee66ad3dff3.png)

![image](https://user-images.githubusercontent.com/48840279/133643082-ee2feb13-0dde-4dcf-8b9e-8dbb96da30d4.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Addresses issue: https://github.com/hyperion-project/hyperion.docs/issues/11