### PR TITLE
Fix - Selected Hyperion instance isn't running (#1357)

### DIFF
--- a/assets/webconfig/js/content_index.js
+++ b/assets/webconfig/js/content_index.js
@@ -208,7 +208,10 @@ $(document).ready(function () {
       removeStorage("loginToken", true);
       requestRequiresAdminAuth();
     }
-    else {
+    else if (event.reason == "Selected Hyperion instance isn't running") {
+      //Switch to default instance
+      instanceSwitch(0);
+    } else {
       showInfoDialog("error", "Error", event.reason);
     }
   });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

- Fixed "Selected Hyperion instance isn't running" issue which happens, if backend instance definitions do not fit to the UI
(caused by new/deleted database). Now there is automatic fall-back to the default instance rather than an error presented.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes #1357 