### PR TITLE
libsrc/utils: Do not catch SIGILL signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Qt-Grabber: Fixed position handling of multiple monitors (#1320, #1403)
 - Fixed: Signal detection does not switch off all instances (#1281)
 - Reworked PriorityMuxer and Sub-scriptions
+- Do not kill application on SIGILL-signal (#1435)
 
 ## Removed
 

--- a/libsrc/utils/DefaultSignalHandler.cpp
+++ b/libsrc/utils/DefaultSignalHandler.cpp
@@ -26,7 +26,6 @@ const Signal ALL_SIGNALS[] = {
 	{ SIGABRT, "SIGABRT" },
 	{ SIGBUS,  "SIGBUS"  },
 	{ SIGFPE,  "SIGFPE"  },
-	{ SIGILL,  "SIGILL"  },
 	{ SIGSEGV, "SIGSEGV" },
 	{ SIGTERM, "SIGTERM" },
 	{ SIGHUP,  "SIGHUP"  },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

libcrypto performs cpu feature checks on ARM platforms, by calling `OPENSSL_cpuid_setup`.
In there, it tries to call various instructions and traps `illegal instructions` aka. non-existing instructions itself.

However, as hyperion.ng also tries to trap all signals, the call inside libcrypto is propagated and hyperiond gets killed by itself.

This patch lets execution proceed, even when `SIGILL` occurs.

References:
- libcrypto OPENSSL_cpuid_setup: https://github.com/openssl/openssl/blob/954f45ba4c504570206ff5bed811e512cf92dc8e/crypto/armcap.c#L183

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
