### PR TITLE
CMake: build-time test - backwards compatibility with older glibc

### DIFF
--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -139,6 +139,21 @@ if (ENABLE_DEV_USB_HID)
 	else()
 		target_link_libraries(leddevice ${LIBUSB_1_LIBRARIES} hidapi-libusb)
 	endif()
+	if(NOT WIN32)
+		# Glibc compatibilty check
+		check_c_source_compiles("
+			#include <time.h>
+			#include <sys/time.h>
+
+			int main() {
+    			struct timespec t;
+    			return clock_gettime(CLOCK_REALTIME, &t);
+			}
+			" GLIBC_HAS_CLOCK_GETTIME)
+		IF(NOT GLIBC_HAS_CLOCK_GETTIME)
+			target_link_libraries(leddevice rt)
+		endif()
+	endif()
 endif()
 
 if(ENABLE_MDNS)

--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -140,6 +140,7 @@ if (ENABLE_DEV_USB_HID)
 		target_link_libraries(leddevice ${LIBUSB_1_LIBRARIES} hidapi-libusb)
 	endif()
 	if(NOT WIN32)
+		include(CheckCSourceCompiles)
 		# Glibc compatibilty check
 		check_c_source_compiles("
 			#include <time.h>


### PR DESCRIPTION
 * Checks whether glibc has former librt function 'clock_gettime' included (that's since glibc 2.17).
 * glibc <2.17 requires linking with 'librt' explicitly.

Reference: https://github.com/bminor/glibc/blob/b92a49359f33a461db080a33940d73f47c756126/time/clock_gettime.c#L32-L37

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [X] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No