### PR TITLE
also look for the shared qmdnsengine library

### DIFF
--- a/cmake/Findqmdnsengine.cmake
+++ b/cmake/Findqmdnsengine.cmake
@@ -8,7 +8,7 @@ find_path(QMDNS_INCLUDE_DIR
 )
 
 find_library(QMDNS_LIBRARIES
-    NAMES libqmdnsengine.a
+    NAMES libqmdnsengine.a libqmdnsengine.so
     PATHS /usr/local /usr
     PATH_SUFFIXES lib64 lib
 )


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When trying to build with USE_SYSTEM_QMDNS_LIBS=ON, only the static library is looked for and the shared library is not found. This problem should be solved by this PR.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
