### PR TITLE
Autoupdate github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This will keep stuff like `- uses: actions/checkout@v2` updated (v3 is latest) in Github Actions, e.g. in the [nightly workflow](https://github.com/hyperion-project/hyperion.ng/blob/master/.github/workflows/nightly.yml#L14)

> Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file are kept up to date.
~ https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

See above

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated
*I'm not clear on this - won't the changelog get update later on, if this is merged?*

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
