### PR TITLE
Oklab: Fix rollover error

### DIFF
--- a/libsrc/utils/ColorSys.cpp
+++ b/libsrc/utils/ColorSys.cpp
@@ -60,9 +60,9 @@ void ColorSys::yuv2rgb(uint8_t y, uint8_t u, uint8_t v, uint8_t &r, uint8_t &g, 
 
 void ColorSys::rgb2okhsv(uint8_t red, uint8_t green, uint8_t blue, double & hue, double & saturation, double & value)
 {
-	ok_color::HSV color = ok_color::srgb_to_okhsv({ static_cast<float>(red)   / 255.F,
-													static_cast<float>(green) / 255.F,
-													static_cast<float>(blue)  / 255.F
+	ok_color::HSV color = ok_color::srgb_to_okhsv({ static_cast<double>(red)   / 255.0,
+													static_cast<double>(green) / 255.0,
+													static_cast<double>(blue)  / 255.0
 	});
 	hue = color.h;
 	saturation = color.s;
@@ -71,8 +71,8 @@ void ColorSys::rgb2okhsv(uint8_t red, uint8_t green, uint8_t blue, double & hue,
 
 void ColorSys::okhsv2rgb(double hue, double saturation, double value, uint8_t & red, uint8_t & green, uint8_t & blue)
 {
-	ok_color::RGB color = ok_color::okhsv_to_srgb({ static_cast<float>(hue), static_cast<float>(saturation), static_cast<float>(value) });
-	red = static_cast<uint8_t>(std::lround(color.r * 255));
-	green = static_cast<uint8_t>(std::lround(color.g * 255));
-	blue = static_cast<uint8_t>(std::lround(color.b * 255));
+	ok_color::RGB color = ok_color::okhsv_to_srgb({ hue, saturation, value });
+	red = static_cast<uint8_t>(std::lround(color.r * 255.0));
+	green = static_cast<uint8_t>(std::lround(color.g * 255.0));
+	blue = static_cast<uint8_t>(std::lround(color.b * 255.0));
 }

--- a/libsrc/utils/ColorSys.cpp
+++ b/libsrc/utils/ColorSys.cpp
@@ -8,6 +8,11 @@ inline uint8_t clamp(int x)
 	return (x<0) ? 0 : ((x>255) ? 255 : uint8_t(x));
 }
 
+inline double clamp(double x)
+{
+	return std::max(0.0, std::min(x, 1.0));
+}
+
 void ColorSys::rgb2hsl(uint8_t red, uint8_t green, uint8_t blue, uint16_t & hue, float & saturation, float & luminance)
 {
 	QColor color(red,green,blue);
@@ -72,7 +77,8 @@ void ColorSys::rgb2okhsv(uint8_t red, uint8_t green, uint8_t blue, double & hue,
 void ColorSys::okhsv2rgb(double hue, double saturation, double value, uint8_t & red, uint8_t & green, uint8_t & blue)
 {
 	ok_color::RGB color = ok_color::okhsv_to_srgb({ hue, saturation, value });
-	red = static_cast<uint8_t>(std::lround(color.r * 255.0));
-	green = static_cast<uint8_t>(std::lround(color.g * 255.0));
-	blue = static_cast<uint8_t>(std::lround(color.b * 255.0));
+	// okhsv_to_srgb can output rgb colors with slightly negative components. Clamping them before casting prevents rollover errors
+	red = static_cast<uint8_t>(std::lround(clamp(color.r) * 255.0));
+	green = static_cast<uint8_t>(std::lround(clamp(color.g) * 255.0));
+	blue = static_cast<uint8_t>(std::lround(clamp(color.b) * 255.0));
 }

--- a/libsrc/utils/OkhsvTransform.cpp
+++ b/libsrc/utils/OkhsvTransform.cpp
@@ -4,7 +4,7 @@
 #include <utils/ColorSys.h>
 
 /// Clamps between 0.f and 1.f. Should generally be branchless
-double clamp(double value)
+inline double clamp(double value)
 {
 	return std::max(0.0, std::min(value, 1.0));
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
The Oklab reference implementation (#1477) can under some circumstances output RGB colors (components of type double) with slightly negative values. (I'm not sure if this is due to imprecise operations or just the nature of the internal gamut mapping.)

When converting those double components back to bytes a rollover could occur leaving the affected component with a value of `255` instead of the intended `0`.

This PR fixes that issue by clamping the components just before type conversion happens.

And sorry for not catching this with the initial PR.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated
- [x] Kinda, CHANGELOG.md has an entry, for the feature this is fixing (#1477), still pending

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
