### PR TITLE
Hue - Fix self-signed certificate handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note: The wizard will configure an APIv2 capable bridge always with Entertainmen
 - Changed default build from Stretch to Buster
 - Support Qt 6.7, Update to Protobuf 23.4.0, Update mbedTLS to v3.4.0, Update flatbuffers to v23.5.26
 - Use C++17 standard as default
+- Added Pull Request (PR) installation script, allowing users to test development builds savely on Linux
 - Fixed missing include limits in QJsonSchemaChecker - Thanks @Portisch
 - Fixed dependencies for deb packages in Debian Bookworm (#1579) - Thanks @hg42, @Psirus
 - Fixed git version identification when run in docker and local code

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -584,11 +584,7 @@ int LedDevicePhilipsHueBridge::close()
 bool LedDevicePhilipsHueBridge::configureSsl()
 {
 	_restApi->setAlternateServerIdentity(_deviceBridgeId);
-
-	if (_isDiyHue)
-	{
-		_restApi->acceptSelfSignedCertificates(true);
-	}
+	_restApi->acceptSelfSignedCertificates(true);
 
 	bool success = _restApi->setCaCertificate(API_SSL_CA_CERTIFICATE_RESSOURCE);
 	if (!success)

--- a/libsrc/leddevice/dev_net/ProviderRestApi.h
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.h
@@ -444,6 +444,8 @@ private:
 
 	bool checkServerIdentity(const QSslConfiguration& sslConfig) const;
 
+	bool matchesPinnedCertificate(const QSslCertificate& certificate);
+
 	Logger* _log;
 
 	/// QNetworkAccessManager object for sending REST-requests.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fixed self-signed certificate handling.
Implemented “trust on first use” certificate handling as per Philip Hues developer guidance.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes #1637