### PR TITLE
add missing ENABLE_MDNS in hyperiond.cpp

### DIFF
--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -294,8 +294,9 @@ void HyperionDaemon::startNetworkServices()
 	_jsonServer->thread()->start();
 	_webserver->thread()->start();
 	_sslWebserver->thread()->start();
-
+#if defined(ENABLE_MDNS)
 	_mDNSProvider->thread()->start();
+#endif
 	_ssdp->thread()->start();
 
 #if defined(ENABLE_FLATBUF_SERVER)
@@ -314,8 +315,9 @@ void HyperionDaemon::stopNetworkServices()
 #if defined(ENABLE_FLATBUF_SERVER)
 	_flatBufferServer.reset(nullptr);
 #endif
-
+#if defined(ENABLE_MDNS)
 	_mDNSProvider.reset(nullptr);
+#endif
 	_ssdp.reset(nullptr);
 
 	_sslWebserver.reset(nullptr);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

build with out MDNS does not work:

```
hyperion.ng-git/src/hyperion.ng/src/hyperiond/hyperiond.cpp:298:9: error: ‘_mDNSProvider’ was not declared in this scope; did you mean ‘RRProvider’?
  298 |         _mDNSProvider->thread()->start();
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
