### PR TITLE
Fix flipmode for BGR24 special handling

### DIFF
--- a/libsrc/grabber/video/EncoderThread.cpp
+++ b/libsrc/grabber/video/EncoderThread.cpp
@@ -125,13 +125,13 @@ void EncoderThread::process()
 			if (_pixelFormat == PixelFormat::BGR24)
 			{
 				if (_flipMode == FlipMode::NO_CHANGE)
-					_imageResampler.setFlipMode(FlipMode::HORIZONTAL);
-				else if (_flipMode == FlipMode::HORIZONTAL)
 					_imageResampler.setFlipMode(FlipMode::NO_CHANGE);
+				else if (_flipMode == FlipMode::HORIZONTAL)
+					_imageResampler.setFlipMode(FlipMode::HORIZONTAL);
 				else if (_flipMode == FlipMode::VERTICAL)
-					_imageResampler.setFlipMode(FlipMode::BOTH);
-				else if (_flipMode == FlipMode::BOTH)
 					_imageResampler.setFlipMode(FlipMode::VERTICAL);
+				else if (_flipMode == FlipMode::BOTH)
+					_imageResampler.setFlipMode(FlipMode::BOTH);
 			}
 
 			Image<ColorRgb> image = Image<ColorRgb>();

--- a/libsrc/grabber/video/EncoderThread.cpp
+++ b/libsrc/grabber/video/EncoderThread.cpp
@@ -122,18 +122,6 @@ void EncoderThread::process()
 		else
 #endif
 		{
-			if (_pixelFormat == PixelFormat::BGR24)
-			{
-				if (_flipMode == FlipMode::NO_CHANGE)
-					_imageResampler.setFlipMode(FlipMode::NO_CHANGE);
-				else if (_flipMode == FlipMode::HORIZONTAL)
-					_imageResampler.setFlipMode(FlipMode::HORIZONTAL);
-				else if (_flipMode == FlipMode::VERTICAL)
-					_imageResampler.setFlipMode(FlipMode::VERTICAL);
-				else if (_flipMode == FlipMode::BOTH)
-					_imageResampler.setFlipMode(FlipMode::BOTH);
-			}
-
 			Image<ColorRgb> image = Image<ColorRgb>();
 			_imageResampler.processImage(
 				_localData,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

If pixelfomat BGR24 is selected in V4L2 grabber, the image is flipped horizontally (with flipmode set to None). This PR will fix that. However, in my opinion this special treatment is not necessary for BGR24 and can be removed completely. But I'm not 100% sure, maybe a developer can take a look.

wbr

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
