### PR TITLE
Fix Philip Hue APIv2 support without Entertainment group defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround to address Web UI keeps forcing browser to download the html instead (#1692)
 - Fixed: Kodi Color Calibration, Refactor Wizards (#1674)
 - Fixed: Token Dialog not closing
+- Fixed: Philip Hue APIv2 support without Entertainment group defined (#1742)
 
 **JSON-API**
 - Refactored JSON-API to ensure consistent authorization behaviour across sessions and single requests with token authorization.

--- a/assets/webconfig/js/wizards/LedDevice_philipshue.js
+++ b/assets/webconfig/js/wizards/LedDevice_philipshue.js
@@ -502,7 +502,9 @@ const philipshueWizard = (() => {
 
           let serviceID;
           if (isAPIv2Ready) {
-            serviceID = lightLocation.service.rid;
+            if (lightLocation) {
+              serviceID = lightLocation.service.rid;
+            }
           }
 
           if (position.startsWith("entertainment")) {
@@ -531,7 +533,7 @@ const philipshueWizard = (() => {
             // Layout per manual settings
             let maxSegments = 1;
 
-            if (isAPIv2Ready) {
+            if (isAPIv2Ready && serviceID) {
               const service = hueEntertainmentServices.find(service => service.id === serviceID);
               maxSegments = service.segments.max_segments;
             }
@@ -593,10 +595,10 @@ const philipshueWizard = (() => {
       d.enableAttempts = parseInt(conf_editor.getEditor("root.generalOptions.enableAttempts").getValue());
       d.enableAttemptsInterval = parseInt(conf_editor.getEditor("root.generalOptions.enableAttemptsInterval").getValue());
 
-      d.useEntertainmentAPI = isEntertainmentReady;
+      d.useEntertainmentAPI = isEntertainmentReady && (d.groupId !== "");
       d.useAPIv2 = isAPIv2Ready;
 
-      if (isEntertainmentReady) {
+      if (d.useEntertainmentAPI) {
         d.hardwareLedCount = channelNumber;
         if (window.serverConfig.device.type !== d.type) {
           //smoothing on, if new device
@@ -803,12 +805,18 @@ const philipshueWizard = (() => {
           "lightPosBottomLeft112", "lightPosBottomLeftNewMid", "lightPosBottomLeft121"
         ];
 
-        if (isEntertainmentReady) {
+        if (isEntertainmentReady && hueEntertainmentConfigs.length > 0) {
           lightOptions.unshift("entertainment_center");
           lightOptions.unshift("entertainment");
         } else {
           lightOptions.unshift("disabled");
-          groupLights = Object.keys(hueLights);
+          if (isAPIv2Ready) {
+            for (const light in hueLights) {
+              groupLights.push(hueLights[light].id);
+            }
+          } else {
+            groupLights = Object.keys(hueLights);
+          }
         }
 
         $('.lidsb').html("");

--- a/libsrc/leddevice/LedDeviceWrapper.cpp
+++ b/libsrc/leddevice/LedDeviceWrapper.cpp
@@ -65,7 +65,7 @@ void LedDeviceWrapper::createLedDevice(const QJsonObject& config)
 	connect(thread, &QThread::started, _ledDevice, &LedDevice::start);
 
 	// further signals
-	connect(this, &LedDeviceWrapper::updateLeds, _ledDevice, &LedDevice::updateLeds, Qt::QueuedConnection);
+	connect(this, &LedDeviceWrapper::updateLeds, _ledDevice, &LedDevice::updateLeds, Qt::BlockingQueuedConnection);
 
 	connect(this, &LedDeviceWrapper::switchOn, _ledDevice, &LedDevice::switchOn, Qt::BlockingQueuedConnection);
 	connect(this, &LedDeviceWrapper::switchOff, _ledDevice, &LedDevice::switchOff, Qt::BlockingQueuedConnection);

--- a/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
+++ b/libsrc/leddevice/dev_net/LedDevicePhilipsHue.cpp
@@ -895,6 +895,7 @@ void LedDevicePhilipsHueBridge::setBridgeDetails(const QJsonDocument &doc, bool 
 		log( "API-Version", "%u.%u.%u", _api_major, _api_minor, _api_patch );
 		log( "API v2 ready", "%s", _isAPIv2Ready ? "Yes" : "No" );
 		log( "Entertainment ready", "%s", _isHueEntertainmentReady ? "Yes" : "No" );
+		log( "Use Entertainment API", "%s", _useEntertainmentAPI ? "Yes" : "No" );
 		log( "DIYHue", "%s", _isDiyHue ? "Yes" : "No" );
 	}
 }
@@ -1799,11 +1800,11 @@ bool LedDevicePhilipsHue::init(const QJsonObject &deviceConfig)
 
 	if (LedDevicePhilipsHueBridge::init(_devConfig))
 	{
-		log( "Off on Black", "%s", _switchOffOnBlack ? "Yes" : "No" );
-		log( "Brightness Factor", "%f", _brightnessFactor );
-		log( "Transition Time", "%d", _transitionTime );
-		log( "Restore Original State", "%s", _isRestoreOrigState ? "Yes" : "No" );
-		log( "Use Hue Entertainment API", "%s", _useEntertainmentAPI ? "Yes" : "No" );
+		log("Off on Black", "%s", _switchOffOnBlack ? "Yes" : "No" );
+		log("Brightness Factor", "%f", _brightnessFactor );
+		log("Transition Time", "%d", _transitionTime );
+		log("Restore Original State", "%s", _isRestoreOrigState ? "Yes" : "No" );
+		log("Use Hue Entertainment API", "%s", _useEntertainmentAPI ? "Yes" : "No" );
 		log("Brightness Threshold", "%f", _blackLevel);
 		log("CandyGamma", "%s", _candyGamma ? "Yes" : "No" );
 		log("Time powering off when black", "%s", _onBlackTimeToPowerOff ? "Yes" : "No" );
@@ -1864,7 +1865,7 @@ bool LedDevicePhilipsHue::setLights()
 		Debug(_log, "Lights configured: %d", configuredLightsCount );
 		if (updateLights( getLightMap()))
 		{
-			if (_useApiV2)
+			if (_useApiV2 && _useEntertainmentAPI)
 			{
 				_channelsCount = getGroupChannelsCount (_groupId);
 
@@ -2208,14 +2209,13 @@ int LedDevicePhilipsHue::write(const std::vector<ColorRgb> & ledValues)
 	int rc {0};
 	if (_isOn)
 	{
-		if (!_useApiV2)
-		{
-			rc = writeSingleLights( ledValues );
-		}
-
 		if (_useEntertainmentAPI && _isInitLeds)
 		{
 			rc= writeStreamData(ledValues);
+		}
+		else
+		{
+			rc = writeSingleLights( ledValues );
 		}
 	}
 	return rc;
@@ -2482,7 +2482,7 @@ void LedDevicePhilipsHue::setColor(PhilipsHueLight& light, CiColor& color)
 					QJsonObject colorXY;
 					colorXY[API_X_COORDINATE] = color.x;
 					colorXY[API_Y_COORDINATE] = color.y;
-					cmd.insert(API_COLOR, QJsonObject {{API_DURATION, colorXY }});
+					cmd.insert(API_COLOR, QJsonObject {{API_XY_COORDINATES, colorXY }});
 					cmd.insert(API_DIMMING, QJsonObject {{API_BRIGHTNESS, bri }});
 				}
 				else
@@ -2556,7 +2556,7 @@ void LedDevicePhilipsHue::setState(PhilipsHueLight& light, bool on, const CiColo
 					QJsonObject colorXY;
 					colorXY[API_X_COORDINATE] = color.x;
 					colorXY[API_Y_COORDINATE] = color.y;
-					cmd.insert(API_COLOR, QJsonObject {{API_DURATION, colorXY }});
+					cmd.insert(API_COLOR, QJsonObject {{API_XY_COORDINATES, colorXY }});
 					cmd.insert(API_DIMMING, QJsonObject {{API_BRIGHTNESS, bri }});
 				}
 				else

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -30,7 +30,8 @@ enum HttpStatusCode {
 	BadRequest   = 400,
 	UnAuthorized = 401,
 	Forbidden    = 403,
-	NotFound     = 404
+	NotFound     = 404,
+	TooManyRequests = 429
 };
 
 } //End of constants
@@ -336,6 +337,15 @@ httpResponse ProviderRestApi::getResponse(QNetworkReply* const& reply)
 				case HttpStatusCode::NotFound:
 					advise = "Check Resource given";
 					break;
+				case HttpStatusCode::TooManyRequests:
+				{
+					QString retryAfterTime = response.getHeader("Retry-After");
+					if (!retryAfterTime.isEmpty())
+					{
+						advise = "Retry-After: " + response.getHeader("Retry-After");
+					}
+				}
+				break;
 				default:
 					advise = httpReason;
 					break;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fixed: Philip Hue APIv2 support without Entertainment group defined (#1742)

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
fixes: #1742