### PR TITLE
Fix V4L2 BGR24 handling

### DIFF
--- a/libsrc/grabber/video/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/video/v4l2/V4L2Grabber.cpp
@@ -54,7 +54,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(ControlIDPropertyMap, _controlIDPropertyMap, (initCont
 static PixelFormat GetPixelFormat(const unsigned int format)
 {
 	if (format == V4L2_PIX_FMT_RGB32) return PixelFormat::RGB32;
-	if (format == V4L2_PIX_FMT_RGB24) return PixelFormat::BGR24;
+	if (format == V4L2_PIX_FMT_BGR24) return PixelFormat::BGR24;
 	if (format == V4L2_PIX_FMT_YUYV) return PixelFormat::YUYV;
 	if (format == V4L2_PIX_FMT_UYVY) return PixelFormat::UYVY;
 	if (format == V4L2_PIX_FMT_NV12) return  PixelFormat::NV12;
@@ -558,7 +558,7 @@ void V4L2Grabber::init_device(VideoStandard videoStandard)
 		break;
 
 		case PixelFormat::BGR24:
-			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB24;
+			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_BGR24;
 		break;
 
 		case PixelFormat::YUYV:
@@ -691,7 +691,7 @@ void V4L2Grabber::init_device(VideoStandard videoStandard)
 		}
 		break;
 
-		case V4L2_PIX_FMT_RGB24:
+		case V4L2_PIX_FMT_BGR24:
 		{
 			_pixelFormat = PixelFormat::BGR24;
 			_frameByteSize = _width * _height * 3;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Hi,

this is a small bugfix for V4L2 grabber, a (virtual-)device with pixelformat set to BGR3 (=BGR24) wasn't usable because of mixup RGB24/BGR24 in code.

wbr

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
