### PR TITLE
Implemented 16Bit HD108-Leds in HyperionNG

### DIFF
--- a/assets/webconfig/js/content_leds.js
+++ b/assets/webconfig/js/content_leds.js
@@ -18,7 +18,7 @@ var bottomRight2bottomLeft = null;
 var bottomLeft2topLeft = null;
 var toggleKeystoneCorrectionArea = false;
 
-var devSPI = ['apa102', 'apa104', 'ws2801', 'lpd6803', 'lpd8806', 'p9813', 'sk6812spi', 'sk6822spi', 'sk9822', 'ws2812spi'];
+var devSPI = ['apa102', 'apa104', 'hd108', 'lpd6803', 'lpd8806', 'p9813', 'sk6812spi', 'sk6822spi', 'sk9822', 'ws2801', 'ws2812spi'];
 var devFTDI = ['apa102_ftdi', 'sk6812_ftdi', 'ws2812_ftdi'];
 var devRPiPWM = ['ws281x'];
 var devRPiGPIO = ['piblaster'];
@@ -1115,6 +1115,7 @@ $(document).ready(function () {
         case "ws2812spi":
         case "piblaster":
         case "ws281x":
+	case "hd108":
 
         //Serial devices
         case "adalight":
@@ -1480,6 +1481,7 @@ $(document).ready(function () {
           case "apa102_ftdi":
           case "sk6812_ftdi":
           case "ws2812_ftdi":
+	  case "hd108":
           default:
         }
 
@@ -1962,6 +1964,7 @@ function saveLedConfig(genDefLayout = false) {
     case "apa102_ftdi":
     case "sk6812_ftdi":
     case "ws2812_ftdi":
+    case "hd108":
     default:
       if (genDefLayout === true) {
         ledConfig = {
@@ -2219,6 +2222,7 @@ var updateOutputSelectList = function (ledType, discoveryInfo) {
           case "sk6822spi":
           case "sk9822":
           case "ws2812spi":
+	  case "hd108":
           case "piblaster":
             for (const device of discoveryInfo.devices) {
               enumVals.push(device.systemLocation);

--- a/assets/webconfig/js/content_leds.js
+++ b/assets/webconfig/js/content_leds.js
@@ -1115,7 +1115,7 @@ $(document).ready(function () {
         case "ws2812spi":
         case "piblaster":
         case "ws281x":
-	case "hd108":
+	      case "hd108":
 
         //Serial devices
         case "adalight":
@@ -1481,7 +1481,7 @@ $(document).ready(function () {
           case "apa102_ftdi":
           case "sk6812_ftdi":
           case "ws2812_ftdi":
-	  case "hd108":
+	        case "hd108":
           default:
         }
 
@@ -2222,7 +2222,7 @@ var updateOutputSelectList = function (ledType, discoveryInfo) {
           case "sk6822spi":
           case "sk9822":
           case "ws2812spi":
-	  case "hd108":
+	        case "hd108":
           case "piblaster":
             for (const device of discoveryInfo.devices) {
               enumVals.push(device.systemLocation);

--- a/libsrc/leddevice/LedDeviceSchemas.qrc
+++ b/libsrc/leddevice/LedDeviceSchemas.qrc
@@ -42,6 +42,7 @@
 		<file alias="schema-ws2812_ftdi">schemas/schema-ws2812_ftdi.json</file>
 		<file alias="schema-apa102_ftdi">schemas/schema-apa102_ftdi.json</file>
 		<file alias="schema-sk6812_ftdi">schemas/schema-sk6812_ftdi.json</file>
-		<file alias="schema-skydimo">schemas/schema-skydimo.json</file>		
+		<file alias="schema-skydimo">schemas/schema-skydimo.json</file>
+                <file alias="schema-hd108">schemas/schema-hd108.json</file>		
 	</qresource>
 </RCC>

--- a/libsrc/leddevice/dev_spi/LedDeviceHD108.cpp
+++ b/libsrc/leddevice/dev_spi/LedDeviceHD108.cpp
@@ -1,0 +1,73 @@
+#include "LedDeviceHD108.h"
+
+// Constructor
+LedDeviceHD108::LedDeviceHD108(const QJsonObject &deviceConfig)
+    : ProviderSpi(deviceConfig)
+{
+    // Overwrite non supported/required features
+	_latchTime_ms = 0;
+	// Initialize _global_brightness
+	_global_brightness = 0xFFFF;
+}
+
+LedDevice* LedDeviceHD108::construct(const QJsonObject &deviceConfig)
+{
+	return new LedDeviceHD108(deviceConfig);
+}
+
+// Initialization method
+bool LedDeviceHD108::init(const QJsonObject &deviceConfig)
+{
+	bool isInitOK = false;
+
+	if ( ProviderSpi::init(deviceConfig) )
+	{
+		_brightnessControlMaxLevel = deviceConfig["brightnessControlMaxLevel"].toInt(HD108_BRIGHTNESS_MAX_LEVEL);
+		Info(_log, "[%s] Setting maximum brightness to [%d] = %d%%", QSTRING_CSTR(_activeDeviceType), _brightnessControlMaxLevel, _brightnessControlMaxLevel * 100 / HD108_BRIGHTNESS_MAX_LEVEL);
+
+		// Set the global brightness or control byte based on the provided formula
+    	_global_brightness = (1 << 15) | (_brightnessControlMaxLevel << 10) | (_brightnessControlMaxLevel << 5) | _brightnessControlMaxLevel;
+
+		isInitOK = true;
+	}
+
+	return isInitOK;
+}
+
+// Write method to update the LED colors
+int LedDeviceHD108::write(const std::vector<ColorRgb> & ledValues)
+{
+    std::vector<uint8_t> hd108Data;
+
+    // Start frame - 64 bits of 0 (8 bytes of 0)
+    hd108Data.insert(hd108Data.end(), 8, 0x00);
+
+    // Adapted logic from your HD108 library's "show" and "setPixelColor8Bit" methods
+    for (const ColorRgb &color : ledValues)
+    {
+        // Convert 8-bit to 16-bit colors
+        uint16_t red16 = (color.red << 8) | color.red;
+        uint16_t green16 = (color.green << 8) | color.green;
+        uint16_t blue16 = (color.blue << 8) | color.blue;
+
+        // Push global and color components into hd108Data
+		// Brightness
+        hd108Data.push_back(_global_brightness >> 8);
+		hd108Data.push_back(_global_brightness & 0xFF);
+		// Color - Red
+        hd108Data.push_back(red16 >> 8);
+		hd108Data.push_back(red16 & 0xFF);
+		// Color - Green
+        hd108Data.push_back(green16 >> 8);
+		hd108Data.push_back(green16 & 0xFF);
+		// Color - Blue
+        hd108Data.push_back(blue16 >> 8);
+		hd108Data.push_back(blue16 & 0xFF);
+    }
+
+    // End frame - write "1"s equal to at least how many pixels are in the string
+    hd108Data.insert(hd108Data.end(), ledValues.size() / 16 + 1, 0xFF);
+
+    // Use ProviderSpi's writeBytes method to send the data
+    return writeBytes(hd108Data.size(), hd108Data.data());
+}

--- a/libsrc/leddevice/dev_spi/LedDeviceHD108.cpp
+++ b/libsrc/leddevice/dev_spi/LedDeviceHD108.cpp
@@ -1,73 +1,133 @@
 #include "LedDeviceHD108.h"
 
-// Constructor
+/**
+ * @brief Constructor for the HD108 LED device.
+ *
+ * @param deviceConfig JSON configuration object for this device.
+ */
 LedDeviceHD108::LedDeviceHD108(const QJsonObject &deviceConfig)
     : ProviderSpi(deviceConfig)
 {
-    // Overwrite non supported/required features
-	_latchTime_ms = 0;
-	// Initialize _global_brightness
-	_global_brightness = 0xFFFF;
+    // By default, set the global brightness register to full (16-bit max)
+    _global_brightness = 0xFFFF;
 }
 
+/**
+ * @brief Factory method: creates an instance of LedDeviceHD108.
+ *
+ * @param deviceConfig The JSON configuration for the device.
+ * @return A pointer to the newly constructed LedDeviceHD108 instance.
+ */
 LedDevice* LedDeviceHD108::construct(const QJsonObject &deviceConfig)
 {
-	return new LedDeviceHD108(deviceConfig);
+    return new LedDeviceHD108(deviceConfig);
 }
 
-// Initialization method
+/**
+ * @brief Initializes the HD108 device using the given JSON configuration.
+ *
+ * This reads certain device-specific parameters, such as the maximum brightness
+ * level, and configures the global brightness register accordingly.
+ *
+ * @param deviceConfig The JSON object containing device parameters.
+ * @return True if initialization succeeded, false otherwise.
+ */
 bool LedDeviceHD108::init(const QJsonObject &deviceConfig)
 {
-	bool isInitOK = false;
+    bool isInitOK = false;
 
-	if ( ProviderSpi::init(deviceConfig) )
-	{
-		_brightnessControlMaxLevel = deviceConfig["brightnessControlMaxLevel"].toInt(HD108_BRIGHTNESS_MAX_LEVEL);
-		Info(_log, "[%s] Setting maximum brightness to [%d] = %d%%", QSTRING_CSTR(_activeDeviceType), _brightnessControlMaxLevel, _brightnessControlMaxLevel * 100 / HD108_BRIGHTNESS_MAX_LEVEL);
-
-		// Set the global brightness or control byte based on the provided formula
-    	_global_brightness = (1 << 15) | (_brightnessControlMaxLevel << 10) | (_brightnessControlMaxLevel << 5) | _brightnessControlMaxLevel;
-
-		isInitOK = true;
-	}
-
-	return isInitOK;
-}
-
-// Write method to update the LED colors
-int LedDeviceHD108::write(const std::vector<ColorRgb> & ledValues)
-{
-    std::vector<uint8_t> hd108Data;
-
-    // Start frame - 64 bits of 0 (8 bytes of 0)
-    hd108Data.insert(hd108Data.end(), 8, 0x00);
-
-    // Adapted logic from your HD108 library's "show" and "setPixelColor8Bit" methods
-    for (const ColorRgb &color : ledValues)
+    // First, let the base SPI provider perform its initialization
+    if (ProviderSpi::init(deviceConfig))
     {
-        // Convert 8-bit to 16-bit colors
-        uint16_t red16 = (color.red << 8) | color.red;
-        uint16_t green16 = (color.green << 8) | color.green;
-        uint16_t blue16 = (color.blue << 8) | color.blue;
+        // Read brightnessControlMaxLevel from the config, falling back to a default if absent
+        _brightnessControlMaxLevel = deviceConfig["brightnessControlMaxLevel"].toInt(HD108_BRIGHTNESS_MAX_LEVEL);
 
-        // Push global and color components into hd108Data
-		// Brightness
-        hd108Data.push_back(_global_brightness >> 8);
-		hd108Data.push_back(_global_brightness & 0xFF);
-		// Color - Red
-        hd108Data.push_back(red16 >> 8);
-		hd108Data.push_back(red16 & 0xFF);
-		// Color - Green
-        hd108Data.push_back(green16 >> 8);
-		hd108Data.push_back(green16 & 0xFF);
-		// Color - Blue
-        hd108Data.push_back(blue16 >> 8);
-		hd108Data.push_back(blue16 & 0xFF);
+        // Log the brightness info
+        Info(_log,
+             "[%s] Setting maximum brightness to [%d] = %d%%",
+             QSTRING_CSTR(_activeDeviceType),
+             _brightnessControlMaxLevel,
+             _brightnessControlMaxLevel * 100 / HD108_BRIGHTNESS_MAX_LEVEL);
+
+        // Combine the brightness levels into the HD108's 16-bit brightness field.
+        // According to the HD108 spec, this is composed of a control bit plus
+        // the brightness level split into three segments for R, G, B.
+        _global_brightness = (1 << 15)
+                           | (_brightnessControlMaxLevel << 10)
+                           | (_brightnessControlMaxLevel << 5)
+                           | _brightnessControlMaxLevel;
+
+        isInitOK = true;
     }
 
-    // End frame - write "1"s equal to at least how many pixels are in the string
-    hd108Data.insert(hd108Data.end(), ledValues.size() / 16 + 1, 0xFF);
+    return isInitOK;
+}
 
-    // Use ProviderSpi's writeBytes method to send the data
+/**
+ * @brief Writes a vector of RGB colors to the HD108 LEDs.
+ *
+ * The HD108 protocol requires:
+ * - A start frame of 64 bits (8 bytes) all set to 0x00.
+ * - For each LED, 64 bits:
+ *   - 16 bits of global brightness
+ *   - 16 bits for red
+ *   - 16 bits for green
+ *   - 16 bits for blue
+ * - An end frame of at least (ledCount / 16 + 1) bytes of 0xFF.
+ *
+ * Each 8-bit color value is expanded to 16 bits by copying it into both the high
+ * and low byte (e.g. 0x7F -> 0x7F7F). This ensures a correct mapping to the HD108's
+ * internal 16-bit color resolution and allows for a true "off" state at 0x0000.
+ *
+ * @param ledValues A vector of ColorRgb (red, green, blue) structures.
+ * @return The result of the SPI write operation (0 for success, or an error code).
+ */
+int LedDeviceHD108::write(const std::vector<ColorRgb> & ledValues)
+{
+    // Calculate how much space we need in total:
+    //  - 8 bytes for the start frame
+    //  - 8 bytes per LED (16 bits global brightness + 16 bits R + G + B)
+    //  - end frame: ledCount / 16 + 1 bytes of 0xFF
+    const size_t ledCount = ledValues.size();
+    const size_t totalSize = 8                        // start frame
+                          + (ledCount * 8)            // LED data (8 bytes each)
+                          + (ledCount / 16 + 1);      // end frame bytes
+
+    // Reserve enough space to avoid multiple allocations
+    std::vector<uint8_t> hd108Data;
+    hd108Data.reserve(totalSize);
+
+    // 1) Start frame: 64 bits of 0x00
+    hd108Data.insert(hd108Data.end(), 8, 0x00);
+
+    // 2) For each LED, insert 8 bytes: 16 bits brightness, 16 bits R, 16 bits G, 16 bits B
+    for (const ColorRgb &color : ledValues)
+    {
+        // Expand 8-bit color components to 16 bits each
+        uint16_t red16   = (static_cast<uint16_t>(color.red)   << 8) | color.red;
+        uint16_t green16 = (static_cast<uint16_t>(color.green) << 8) | color.green;
+        uint16_t blue16  = (static_cast<uint16_t>(color.blue)  << 8) | color.blue;
+
+        // Global brightness (16 bits)
+        hd108Data.push_back(_global_brightness >> 8);
+        hd108Data.push_back(_global_brightness & 0xFF);
+
+        // Red (16 bits)
+        hd108Data.push_back(red16 >> 8);
+        hd108Data.push_back(red16 & 0xFF);
+
+        // Green (16 bits)
+        hd108Data.push_back(green16 >> 8);
+        hd108Data.push_back(green16 & 0xFF);
+
+        // Blue (16 bits)
+        hd108Data.push_back(blue16 >> 8);
+        hd108Data.push_back(blue16 & 0xFF);
+    }
+
+    // 3) End frame: at least (ledCount / 16 + 1) bytes of 0xFF
+    hd108Data.insert(hd108Data.end(), (ledCount / 16) + 1, 0xFF);
+
+    // Finally, transmit the assembled data via SPI
     return writeBytes(hd108Data.size(), hd108Data.data());
 }

--- a/libsrc/leddevice/dev_spi/LedDeviceHD108.h
+++ b/libsrc/leddevice/dev_spi/LedDeviceHD108.h
@@ -1,0 +1,53 @@
+#ifndef LEDDEVICEHD108_H
+#define LEDDEVICEHD108_H
+
+#include "ProviderSpi.h"
+
+/// The maximal level supported by the HD108 brightness control field, 31
+const int HD108_BRIGHTNESS_MAX_LEVEL = 31;
+
+
+class LedDeviceHD108 : public ProviderSpi
+{
+
+public:
+
+	///
+	/// @brief Constructs an HD108 LED-device
+	///
+	/// @param deviceConfig Device's configuration as JSON-Object
+	///
+    explicit LedDeviceHD108(const QJsonObject &deviceConfig);
+
+	///
+	/// @brief Constructs the LED-device
+	///
+	/// @param[in] deviceConfig Device's configuration as JSON-Object
+	/// @return LedDevice constructed
+	///
+	static LedDevice* construct(const QJsonObject &deviceConfig);
+
+private:
+
+	///
+	/// @brief Initialise the device's configuration
+	///
+	/// @param[in] deviceConfig the JSON device configuration
+	/// @return True, if success
+	///
+	bool init(const QJsonObject &deviceConfig) override;
+
+	///
+	/// @brief Writes the RGB-Color values to the LEDs.
+	///
+	/// @param[in] ledValues The RGB-color per LED
+	/// @return Zero on success, else negative
+	///
+    int write(const std::vector<ColorRgb> & ledValues) override;
+
+	/// The brighness level. Possibile values 1 .. 31.
+	int _brightnessControlMaxLevel;
+	uint16_t _global_brightness;
+};
+
+#endif // LEDDEVICEHD108_H

--- a/libsrc/leddevice/schemas/schema-hd108.json
+++ b/libsrc/leddevice/schemas/schema-hd108.json
@@ -1,0 +1,41 @@
+{
+	"type":"object",
+	"required":true,
+	"properties":{
+		"output": {
+			"type": "string",
+			"title":"edt_dev_spec_spipath_title",
+			"propertyOrder" : 1
+		},
+		"rate": {
+			"type": "integer",
+			"title":"edt_dev_spec_baudrate_title",
+			"default": 1000000,
+			"propertyOrder" : 2
+		},
+		"invert": {
+			"type": "boolean",
+			"title":"edt_dev_spec_invert_title",
+			"default": false,
+			"propertyOrder" : 3
+		},
+		"brightnessControlMaxLevel": {
+			"type": "integer",
+			"title":"edt_conf_color_brightness_title",
+			"default": 31,
+			"minimum": 1,
+			"maximum": 31,
+			"propertyOrder" : 4
+		},
+		"rewriteTime": {
+			"type": "integer",
+			"title":"edt_dev_general_rewriteTime_title",
+			"default": 0,
+			"append" : "edt_append_ms",
+			"minimum": 0,
+			"access" : "expert",
+			"propertyOrder" : 5
+		}		
+	},
+	"additionalProperties": true
+}

--- a/libsrc/leddevice/schemas/schema-hd108.json
+++ b/libsrc/leddevice/schemas/schema-hd108.json
@@ -10,14 +10,8 @@
 		"rate": {
 			"type": "integer",
 			"title":"edt_dev_spec_baudrate_title",
-			"default": 1000000,
+			"default": 3000000,
 			"propertyOrder" : 2
-		},
-		"invert": {
-			"type": "boolean",
-			"title":"edt_dev_spec_invert_title",
-			"default": false,
-			"propertyOrder" : 3
 		},
 		"brightnessControlMaxLevel": {
 			"type": "integer",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**  
This PR implements support for 16-bit HD108 LEDs in HyperionNG. It makes it possible to use the highspeed LEDs and adds new configuration options for HD108 LEDs.

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature
- [ ] Bugfix
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:  
N/A

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:  
N/A

**The PR fulfills these requirements:**  
<!-- Github will close properly linked issues automatically on PR merge -->
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**  
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**  
This feature includes the following changes:
- Added `LedDeviceHD108.cpp` and `LedDeviceHD108.h` for HD108 LED support.
- Created a new JSON schema for HD108 configurations (`schema-hd108.json`).
- Implemented HD108 into (`content_leds.js`).