### PR TITLE
Store a list of arrays at each location so duplicates aren't lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,6 +388,7 @@ To run Hyperion with root privileges (e.g. for WS281x) execute <br> `sudo update
   - Fixed: Nanoleaf does not turn on
   - Fixed LED layout - Additional parameters for classic layout were not saved (#1314)
   - Fixed Network LED-Device UI: Trigger getProperties for the configured host, when no hosts were discovered
+  - Fixed Nanoleaf error if LEDs in strip overlap
 
 ### Removed:
 

--- a/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
+++ b/libsrc/leddevice/dev_net/LedDeviceNanoleaf.cpp
@@ -272,7 +272,7 @@ bool LedDeviceNanoleaf::initLedsConfiguration()
 		int panelNum = jsonLayout[PANEL_NUM].toInt();
 		const QJsonArray positionData = jsonLayout[PANEL_POSITIONDATA].toArray();
 
-		std::map<int, std::map<int, int>> panelMap;
+		std::map<int, std::map<int, std::vector<int>>> panelMap;
 
 		// Loop over all children.
 		for (const QJsonValue& value : positionData)
@@ -299,8 +299,14 @@ bool LedDeviceNanoleaf::initLedsConfiguration()
 
 			if (hasLEDs(static_cast<SHAPETYPES>(panelshapeType)))
 			{
-				panelMap[panelY][panelX] = panelId;
-				DebugIf(verbose, _log, "Use  Panel [%d] (%d,%d) - Type: [%d]", panelId, panelX, panelY, panelshapeType);
+				panelMap[panelY][panelX];
+				panelMap[panelY][panelX].push_back(panelId);
+				if (panelMap[panelY][panelX].size() > 1) {
+					DebugIf(verbose, _log, "Use  Panel [%d] (%d,%d) - Type: [%d] (Ovarlapping %d other Panels)", panelId, panelX, panelY, panelshapeType, panelMap[panelY][panelX].size() - 1);
+				} else {
+					DebugIf(verbose, _log, "Use  Panel [%d] (%d,%d) - Type: [%d]", panelId, panelX, panelY, panelshapeType);
+				}
+
 			}
 			else
 			{
@@ -317,15 +323,18 @@ bool LedDeviceNanoleaf::initLedsConfiguration()
 			{
 				for (auto posX = posY->second.cbegin(); posX != posY->second.cend(); ++posX)
 				{
-					DebugIf(verbose, _log, "panelMap[%d][%d]=%d", posY->first, posX->first, posX->second);
+					for (auto ledId = posX->second.cbegin(); ledId != posX->second.cend(); ++ledId)
+					{
+						DebugIf(verbose, _log, "panelMap[%d][%d]=%d", posY->first, posX->first, ledId);
 
-					if (_topDown)
-					{
-						_panelIds.push_back(posX->second);
-					}
-					else
-					{
-						_panelIds.push_front(posX->second);
+						if (_topDown)
+						{
+							_panelIds.push_back(*ledId);
+						}
+						else
+						{
+							_panelIds.push_front(*ledId);
+						}
 					}
 				}
 			}
@@ -334,15 +343,18 @@ bool LedDeviceNanoleaf::initLedsConfiguration()
 				// Sort panels right to left
 				for (auto posX = posY->second.crbegin(); posX != posY->second.crend(); ++posX)
 				{
-					DebugIf(verbose, _log, "panelMap[%d][%d]=%d", posY->first, posX->first, posX->second);
+					for (auto ledId = posX->second.cbegin(); ledId != posX->second.cend(); ++ledId)
+					{
+						DebugIf(verbose, _log, "panelMap[%d][%d]=%d", posY->first, posX->first, ledId);
 
-					if (_topDown)
-					{
-						_panelIds.push_back(posX->second);
-					}
-					else
-					{
-						_panelIds.push_front(posX->second);
+						if (_topDown)
+						{
+							_panelIds.push_back(*ledId);
+						}
+						else
+						{
+							_panelIds.push_front(*ledId);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Some Nanoleaf LEDs are in a strip
The Nanoleaf code calculates a position for each LED and stores each LED ID in a map, keying of X,Y.
With the layouts provided, LEDs have "overlapping" positions in X,Y in the corners.
This means that multiple LEDs land in the same map entry, overwriting existing IDs in the map.

At the end of the Nanoleaf init function is code to check the size of the map matches the number of LEDs.
In my setup, this was failing because of the 'overwritten' IDs aren't counted.

To fix this I've changed the value of the Map to be a vector of IDs, which allows for duplicates to be tracked correctly.
I've also improved the logging slightly to show that duplicates have been found.

This change is expected to have zero impact on any previously working configuration, as all the vectors will have size 1

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
