### PR TITLE
Fixing configuration migration issues

### DIFF
--- a/assets/webconfig/js/ui_utils.js
+++ b/assets/webconfig/js/ui_utils.js
@@ -255,7 +255,12 @@ function updateUiOnInstance(inst) {
 
     // Show menue items according to instance's running state
     if (isInstanceRunning(window.currentHyperionInstance)) {
-      $("#MenuItemRemoteControl, #MenuItemEffectsConfig, #NavMenuWizards, #btn_open_ledsim").show();
+      $("#MenuItemRemoteControl, #NavMenuWizards, #btn_open_ledsim").show();
+      
+      //Show effectsconfigurator menu entry, only if effectengine is available
+      if (jQuery.inArray("effectengine", window.serverInfo.services) !== -1) {
+        $("#MenuItemEffectsConfig").show();
+      }
 
       const isMediaStreamingSupported = getStorage('mediaStreamingSupported');
       if (isMediaStreamingSupported) {

--- a/doc/development/JSON-API _Commands_Overview.md
+++ b/doc/development/JSON-API _Commands_Overview.md
@@ -45,7 +45,7 @@ _http/s Support_
 | clear          |                         | Yes           | Multi        | Yes               | Yes            |
 | clearall       |                         | Yes           | Multi        | Yes               | Yes            |
 | color          |                         | Yes           | Multi        | Yes               | Yes            |
-| componentstate |                         | Yes           | Multi        | Yes               | Yes            |
+| componentstate |                         | Yes           | No or Multi  | Yes               | Yes            |
 | config         | getconfig               | Admin         | No           | No                | Yes            |
 | config         | getschema               | Admin         | No           | No                | Yes            |
 | config         | reload                  | Admin         | No           | No                | Yes            |

--- a/include/api/JsonApiCommand.h
+++ b/include/api/JsonApiCommand.h
@@ -309,7 +309,7 @@ public:
 			{ {"clear", ""},                             { Command::Clear,          SubCommand::Empty,                   Authorization::Yes,    InstanceCmd::Multi,        InstanceCmd::MustRun_Yes,    NoListenerCmd::Yes } },
 			{ {"clearall", ""},                          { Command::ClearAll,       SubCommand::Empty,                   Authorization::Yes,    InstanceCmd::Multi,        InstanceCmd::MustRun_Yes,    NoListenerCmd::Yes } },
 			{ {"color", ""},                             { Command::Color,          SubCommand::Empty,                   Authorization::Yes,    InstanceCmd::Multi,        InstanceCmd::MustRun_Yes,    NoListenerCmd::Yes } },
-			{ {"componentstate", ""},                    { Command::ComponentState, SubCommand::Empty,                   Authorization::Yes,    InstanceCmd::Multi,        InstanceCmd::MustRun_Yes,    NoListenerCmd::Yes } },
+			{ {"componentstate", ""},                    { Command::ComponentState, SubCommand::Empty,                   Authorization::Yes,    InstanceCmd::No_or_Multi,  InstanceCmd::MustRun_Yes,    NoListenerCmd::Yes } },
 			{ {"config", "getconfig"},                   { Command::Config,         SubCommand::GetConfig,               Authorization::Admin,  InstanceCmd::No,           InstanceCmd::MustRun_No,     NoListenerCmd::Yes } },
 			{ {"config", "getschema"},                   { Command::Config,         SubCommand::GetSchema,               Authorization::Admin,  InstanceCmd::No,           InstanceCmd::MustRun_No,     NoListenerCmd::Yes } },
 			{ {"config", "reload"},                      { Command::Config,         SubCommand::Reload,                  Authorization::Admin,  InstanceCmd::No,           InstanceCmd::MustRun_No,     NoListenerCmd::Yes } },

--- a/include/db/SettingsTable.h
+++ b/include/db/SettingsTable.h
@@ -12,7 +12,7 @@
 
 #include <QJsonDocument>
 
-const int GLOABL_INSTANCE_ID = std::numeric_limits<quint8>::max();;
+const int NO_INSTANCE_ID = std::numeric_limits<quint8>::max();;
 const char DEFAULT_CONFIG_VERSION[] = "2.0.0-alpha.8";
 
 ///
@@ -23,7 +23,7 @@ class SettingsTable : public DBManager
 
 public:
 	/// construct wrapper with settings table
-	SettingsTable(quint8 instance = GLOABL_INSTANCE_ID, QObject* parent = nullptr);
+	SettingsTable(quint8 instance = NO_INSTANCE_ID, QObject* parent = nullptr);
 
 	///
 	/// @brief      Create or update a settings record

--- a/include/hyperion/SettingsManager.h
+++ b/include/hyperion/SettingsManager.h
@@ -23,7 +23,7 @@ public:
 	/// @params  instance   Instance index of HyperionInstanceManager
 	/// @params  parent    The parent hyperion instance
 	///
-	SettingsManager(quint8 instance = GLOABL_INSTANCE_ID, QObject* parent = nullptr);
+	SettingsManager(quint8 instance = NO_INSTANCE_ID, QObject* parent = nullptr);
 
 	///
 	/// @brief Save a complete JSON configuration

--- a/libsrc/api/API.cpp
+++ b/libsrc/api/API.cpp
@@ -40,7 +40,7 @@ const int IMAGE_SCALE = 2000;
 
 API::API(Logger *log, bool localConnection, QObject *parent)
 	: QObject(parent),
-	_currInstanceIndex (GLOABL_INSTANCE_ID)
+	_currInstanceIndex (NO_INSTANCE_ID)
 	, _hyperion (nullptr)
 	, _authorized (false)
 	, _adminAuthorized (false)

--- a/libsrc/api/JsonAPI.cpp
+++ b/libsrc/api/JsonAPI.cpp
@@ -956,20 +956,28 @@ void JsonAPI::handleConfigGetCommand(const QJsonObject &message, const JsonApiCo
 	{
 		QStringList globalFilterTypes;
 
-		const QJsonObject globalConfig = filter["global"].toObject();
-		if (!globalConfig.isEmpty())
+		const QJsonValue globalConfig = filter["global"];
+		if (globalConfig.isNull())
 		{
-			QJsonValue const globalTypes = globalConfig["types"];
-			if (globalTypes.isNull())
+			globalFilterTypes.append("__none__");
+		}
+		else
+		{
+			const QJsonObject globalConfigObject = globalConfig.toObject();
+			if (!globalConfigObject.isEmpty())
 			{
-				globalFilterTypes.append("__none__");
-			}
-			else
-			{
-				QJsonArray const globalTypesList = globalTypes.toArray();
-				for (const auto &type : globalTypesList) {
-					if (type.isString()) {
-						globalFilterTypes.append(type.toString());
+				QJsonValue const globalTypes = globalConfig["types"];
+				if (globalTypes.isNull())
+				{
+					globalFilterTypes.append("__none__");
+				}
+				else
+				{
+					QJsonArray const globalTypesList = globalTypes.toArray();
+					for (const auto &type : globalTypesList) {
+						if (type.isString()) {
+							globalFilterTypes.append(type.toString());
+						}
 					}
 				}
 			}
@@ -978,43 +986,51 @@ void JsonAPI::handleConfigGetCommand(const QJsonObject &message, const JsonApiCo
 		QList<quint8> instanceListFilter;
 		QStringList instanceFilterTypes;
 
-		const QJsonObject instances = filter["instances"].toObject();
-		if (!instances.isEmpty())
+		const QJsonValue instances = filter["instances"];
+		if (instances.isNull())
 		{
-			QSet<quint8> const configuredInstanceIds = _instanceManager->getInstanceIds();
-			QJsonValue const instanceIds = instances["ids"];
-			if (instanceIds.isNull())
+			instanceListFilter.append(NO_INSTANCE_ID);
+		}
+		else
+		{
+			const QJsonObject instancesObject = instances.toObject();
+			if (!instancesObject.isEmpty())
 			{
-				instanceListFilter.append(NO_INSTANCE_ID);
-			}
-			else
-			{
-				QJsonArray const instaceIdsList = instanceIds.toArray();
-				for (const auto &idx : instaceIdsList) {
-					if (idx.isDouble()) {
-						quint8 const instanceId = static_cast<quint8>(idx.toInt());
-						if (configuredInstanceIds.contains(instanceId))
-						{
-							instanceListFilter.append(instanceId);
-						}
-						else
-						{
-							errorDetails.append(QString("Given instance number '%1' does not exist.").arg(instanceId));
-						}
-					}
-				}
-
-				QJsonValue const instanceTypes = instances["types"];
-				if (instanceTypes.isNull())
+				QSet<quint8> const configuredInstanceIds = _instanceManager->getInstanceIds();
+				QJsonValue const instanceIds = instances["ids"];
+				if (instanceIds.isNull())
 				{
-					instanceFilterTypes.append("__none__");
+					instanceListFilter.append(NO_INSTANCE_ID);
 				}
 				else
 				{
-					QJsonArray const instaceTypesList = instanceTypes.toArray();
-					for (const auto &type : instaceTypesList) {
-						if (type.isString()) {
-							instanceFilterTypes.append(type.toString());
+					QJsonArray const instaceIdsList = instanceIds.toArray();
+					for (const auto &idx : instaceIdsList) {
+						if (idx.isDouble()) {
+							quint8 const instanceId = static_cast<quint8>(idx.toInt());
+							if (configuredInstanceIds.contains(instanceId))
+							{
+								instanceListFilter.append(instanceId);
+							}
+							else
+							{
+								errorDetails.append(QString("Given instance number '%1' does not exist.").arg(instanceId));
+							}
+						}
+					}
+
+					QJsonValue const instanceTypes = instances["types"];
+					if (instanceTypes.isNull())
+					{
+						instanceFilterTypes.append("__none__");
+					}
+					else
+					{
+						QJsonArray const instaceTypesList = instanceTypes.toArray();
+						for (const auto &type : instaceTypesList) {
+							if (type.isString()) {
+								instanceFilterTypes.append(type.toString());
+							}
 						}
 					}
 				}

--- a/libsrc/api/JsonCallbacks.cpp
+++ b/libsrc/api/JsonCallbacks.cpp
@@ -340,7 +340,7 @@ void JsonCallbacks::doCallback(Subscription::Type cmd, const QJsonArray& data)
 
 	if (Subscription::isInstanceSpecific(cmd))
 	{
-		if (_instanceID != GLOABL_INSTANCE_ID)
+		if (_instanceID != NO_INSTANCE_ID)
 		{
 			obj.insert("instance", _instanceID);
 		}
@@ -357,7 +357,7 @@ void JsonCallbacks::doCallback(Subscription::Type cmd, const QJsonObject& data)
 
 	if (Subscription::isInstanceSpecific(cmd))
 	{
-		if (_instanceID != GLOABL_INSTANCE_ID)
+		if (_instanceID != NO_INSTANCE_ID)
 		{
 			obj.insert("instance", _instanceID);
 		}

--- a/libsrc/api/JsonInfo.cpp
+++ b/libsrc/api/JsonInfo.cpp
@@ -314,7 +314,7 @@ QJsonObject JsonInfo::getGrabbers(const Hyperion* hyperion)
 {
 	QJsonObject grabbers;
 
-	quint8 idx { GLOABL_INSTANCE_ID };
+	quint8 idx { NO_INSTANCE_ID };
 	if (hyperion != nullptr)
 	{
 		idx = hyperion->getInstanceIndex();

--- a/libsrc/db/DBMigrationManager.cpp
+++ b/libsrc/db/DBMigrationManager.cpp
@@ -397,7 +397,7 @@ bool DBMigrationManager::upgradeGlobalSettings_2_0_16(semver::version& currentVe
 bool DBMigrationManager::upgradeGlobalSettings_2_1_0(semver::version& currentVersion, QJsonObject& config)
 {
 	bool migrated = false;
-	const semver::version targetVersion{ "2.0.17-beta.2" };
+	const semver::version targetVersion{ "2.0.17-beta.3" };
 
 	if (currentVersion < targetVersion)
 	{
@@ -411,7 +411,6 @@ bool DBMigrationManager::upgradeGlobalSettings_2_1_0(semver::version& currentVer
 			config.insert("effects", effectsSettings.value("effects"));
 
 			Debug(_log, "Effect settings migrated");
-			migrated = true;
 		}
 
 		if (config.contains("general"))
@@ -421,7 +420,6 @@ bool DBMigrationManager::upgradeGlobalSettings_2_1_0(semver::version& currentVer
 			config.insert("general", newGeneralConfig);
 
 			Debug(_log, "General settings migrated");
-			migrated = true;
 		}
 
 		if (config.contains("network"))
@@ -432,7 +430,6 @@ bool DBMigrationManager::upgradeGlobalSettings_2_1_0(semver::version& currentVer
 			config.insert("network", newNetworkConfig);
 
 			Debug(_log, "Network settings migrated");
-			migrated = true;
 		}
 	}
 
@@ -789,7 +786,7 @@ bool DBMigrationManager::upgradeInstanceSettings_2_1_0(semver::version& currentV
 	{
 		config.remove("effects");
 
-		Debug(_log, "Instance [%u] - Effects settings migrated", instance);
+		Debug(_log, "Instance [%u] - Effects settings deleted", instance);
 		migrated = true;
 	}
 	return migrated;

--- a/libsrc/db/SettingsTable.cpp
+++ b/libsrc/db/SettingsTable.cpp
@@ -183,12 +183,17 @@ QJsonObject SettingsTable::getSettings(const QStringList& filteredTypes ) const
 
 QJsonObject SettingsTable::getSettings(const QVariant& instance, const QStringList& filteredTypes ) const
 {
+	if (filteredTypes.contains("__none__"))
+	{
+		return {};
+	}
+
 	QJsonObject settingsObject;
 	QStringList settingsKeys({ "type", "config" });
 	QString settingsCondition;
 	QVariantList conditionValues;
 
-	if (instance.isNull() || instance == GLOABL_INSTANCE_ID )
+	if (instance.isNull() || instance == NO_INSTANCE_ID )
 	{
 		settingsCondition = "hyperion_inst IS NULL";
 	}
@@ -240,7 +245,7 @@ QStringList SettingsTable::nonExtingTypes() const
 {
 	QStringList testTypes;
 	QString condition {"hyperion_inst"};
-	if(_instance == GLOABL_INSTANCE_ID)
+	if(_instance == NO_INSTANCE_ID)
 	{
 		condition += " IS NULL";
 		testTypes = getGlobalSettingTypes().toList();
@@ -269,7 +274,7 @@ QPair<bool, QStringList> SettingsTable::addMissingDefaults()
 	QStringList errorList;
 
 	QJsonObject defaultSettings;
-	if (_instance == GLOABL_INSTANCE_ID)
+	if (_instance == NO_INSTANCE_ID)
 	{
 		defaultSettings = getDefaultSettings().value("global").toObject();
 	}
@@ -281,7 +286,7 @@ QPair<bool, QStringList> SettingsTable::addMissingDefaults()
 	const QStringList missingTypes = nonExtingTypes();
 	if (missingTypes.empty())
 	{
-		Debug(_log, "%s settings: No missing configuration items identified", _instance == GLOABL_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)) );
+		Debug(_log, "%s settings: No missing configuration items identified", _instance == NO_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)) );
 		return qMakePair (true, errorList );
 	}
 
@@ -294,7 +299,7 @@ QPair<bool, QStringList> SettingsTable::addMissingDefaults()
 
 	bool errorOccured {false};
 
-	Info(_log, "%s settings: Add default settings for %d missing configuration items", _instance == GLOABL_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)), missingTypes.size() );
+	Info(_log, "%s settings: Add default settings for %d missing configuration items", _instance == NO_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)), missingTypes.size() );
 	for (const auto &missingType: missingTypes)
 	{
 		if (!createSettingsRecord(missingType, JsonUtils::jsonValueToQString(defaultSettings.value(missingType))))
@@ -321,7 +326,7 @@ QPair<bool, QStringList> SettingsTable::addMissingDefaults()
 
 	if(errorList.isEmpty())
 	{
-		Debug(_log, "%s settings: Successfully defaulted settings for %d missing configuration items", _instance == GLOABL_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)), missingTypes.size() );
+		Debug(_log, "%s settings: Successfully defaulted settings for %d missing configuration items", _instance == NO_INSTANCE_ID ? "Global" : QSTRING_CSTR(QString("Instance [%1]").arg(_instance)), missingTypes.size() );
 	}
 
 	return qMakePair (errorList.isEmpty(), errorList );

--- a/libsrc/forwarder/MessageForwarder.cpp
+++ b/libsrc/forwarder/MessageForwarder.cpp
@@ -44,7 +44,7 @@ MessageForwarder::MessageForwarder(const QJsonDocument& config)
 	, _isActive(false)
 	, _priority(DEFAULT_FORWARDER_FLATBUFFFER_PRIORITY)
 	, _isEnabled(false)
-	, _toBeForwardedInstanceID(GLOABL_INSTANCE_ID)
+	, _toBeForwardedInstanceID(NO_INSTANCE_ID)
 	, _hyperion(nullptr)
 	, _muxer(nullptr)
 	, _messageForwarderFlatBufHelper(nullptr)
@@ -137,7 +137,7 @@ void MessageForwarder::handleSettingsUpdate(settings::type type, const QJsonDocu
 {
 	if (type != settings::NETFORWARD) return;
 
-	quint8 const newInstanceID = config["instance"].toInt(GLOABL_INSTANCE_ID);
+	quint8 const newInstanceID = config["instance"].toInt(NO_INSTANCE_ID);
 	if (newInstanceID != _toBeForwardedInstanceID)
 	{
 		disconnect(_toBeForwardedInstanceID);

--- a/libsrc/hyperion/HyperionIManager.cpp
+++ b/libsrc/hyperion/HyperionIManager.cpp
@@ -35,7 +35,7 @@ QSharedPointer<Hyperion> HyperionIManager::getHyperionInstance(quint8 instanceId
 
 	if (!_runningInstances.isEmpty())
 	{
-		if (instanceId != GLOABL_INSTANCE_ID )
+		if (instanceId != NO_INSTANCE_ID )
 		{
 			Warning(_log,"The requested instance index '%d' with name '%s' isn't running", instanceId, QSTRING_CSTR(_instanceTable->getNamebyIndex(instanceId)));
 		}

--- a/libsrc/hyperion/schema/schema-effects.json
+++ b/libsrc/hyperion/schema/schema-effects.json
@@ -13,6 +13,7 @@
 				"title" : "edt_conf_effp_paths_itemtitle"
 			},
 			"minItems" : 1,
+			"required" : true,
 			"propertyOrder" : 1
 		},
 		"disable" :

--- a/libsrc/hyperion/schema/schema-forwarder.json
+++ b/libsrc/hyperion/schema/schema-forwarder.json
@@ -42,12 +42,12 @@
 	"jsonapi": {
 	  "type": "array",
 	  "title": "edt_conf_forwarder_json_title",
-	  "allowEmptyArray": true,
 	  "uniqueItems": true,
 	  "access": "expert",
 	  "items": {
 		"type": "object",
 		"title": "edt_conf_forwarder_json_itemtitle",
+		"allowEmptyArray": true,
 		"properties": {
 		  "name": {
 			"type": "string",

--- a/libsrc/hyperion/schema/schema-ledConfig.json
+++ b/libsrc/hyperion/schema/schema-ledConfig.json
@@ -177,6 +177,7 @@
 			"items": {
 				"type": "object",
 				"title": "conf_leds_layout_blacklist_rule_title",
+				"allowEmptyArray": true,
 				"required": true,
 				"properties": {
 					"start": {

--- a/libsrc/utils/jsonschema/QJsonSchemaChecker.cpp
+++ b/libsrc/utils/jsonschema/QJsonSchemaChecker.cpp
@@ -7,6 +7,7 @@
 // Utils-Jsonschema includes
 #include <utils/jsonschema/QJsonSchemaChecker.h>
 #include <utils/jsonschema/QJsonUtils.h>
+#include <utils/JsonUtils.h>
 
 QJsonSchemaChecker::QJsonSchemaChecker() :
 	_ignoreRequired(false),
@@ -231,7 +232,7 @@ void QJsonSchemaChecker::checkProperties(const QJsonObject& value, const QJsonOb
 {
 	for (QJsonObject::const_iterator i = schema.begin(); i != schema.end(); ++i)
 	{
-		QString property = i.key();
+		QString const property = i.key();
 
 		const QJsonValue& propertyValue = *i;
 
@@ -243,26 +244,27 @@ void QJsonSchemaChecker::checkProperties(const QJsonObject& value, const QJsonOb
 		}
 		else if (!verifyDeps(property, value, schema))
 		{
-			bool isRequired = propertyValue.toObject().value("required").toBool(false);
+			bool const isRequired = propertyValue.toObject().value("required").toBool(false);
 			if (isRequired && !_ignoreRequired)
 			{
 				_error = true;
 
 				if (_correct == "create")
 				{
-					QString workingProperty = property;
-					setMessage("Create property: " + workingProperty + " with value: " + QJsonUtils::getDefaultValue(propertyValue));
-					QJsonUtils::modify(_autoCorrected, _currentPath, QJsonUtils::create(propertyValue, _ignoreRequired), workingProperty);
+					QJsonValue const createdValue = QJsonUtils::create(propertyValue, _ignoreRequired);
+					QJsonUtils::modify(_autoCorrected, _currentPath, createdValue, property);
+					setMessage("Create property with value: " + JsonUtils::jsonValueToQString(createdValue));
 				}
 
-				if (_correct == "")
+				if (_correct.isEmpty())
 				{
 					setMessage("missing member");
 				}
 			}
 			else if (_correct == "create" && _ignoreRequired)
 			{
-				QJsonUtils::modify(_autoCorrected, _currentPath, QJsonUtils::create(propertyValue, _ignoreRequired), property);
+				QJsonValue const createdValue = QJsonUtils::create(propertyValue, _ignoreRequired);
+				QJsonUtils::modify(_autoCorrected, _currentPath, createdValue, property);
 			}
 		}
 
@@ -580,7 +582,7 @@ void QJsonSchemaChecker::checkUniqueItems(const QJsonValue& value, const QJsonVa
 		return;
 	}
 
-	if (schema.toBool() == true)
+	if (schema.toBool())
 	{
 		// make sure no two items are identical
 

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -87,7 +87,7 @@ HyperionDaemon* HyperionDaemon::daemon = nullptr;
 HyperionDaemon::HyperionDaemon(const QString& rootPath, QObject* parent, bool logLvlOverwrite)
 	: QObject(parent), _log(Logger::getInstance("DAEMON"))
 	, _instanceManager(new HyperionIManager(this))
-	, _settingsManager(new SettingsManager(GLOABL_INSTANCE_ID, this)) // init settings, this settingsManager accesses global settings which are independent from instances
+	, _settingsManager(new SettingsManager(NO_INSTANCE_ID, this)) // init settings, this settingsManager accesses global settings which are independent from instances
 	#if defined(ENABLE_EFFECTENGINE)
 	, _pyInit(new PythonInit())
 	#endif

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -342,12 +342,6 @@ void HyperionDaemon::stopNetworkServices()
 	}
 #endif
 
-	if (_jsonServerThread->isRunning()) {
-		_jsonServerThread->quit();
-		_jsonServerThread->wait();
-	}
-	_jsonServer.reset(nullptr);
-
 	if (_webServerThread->isRunning()) {
 		_webServerThread->quit();
 		_webServerThread->wait();
@@ -358,6 +352,12 @@ void HyperionDaemon::stopNetworkServices()
 		_sslWebServerThread->quit();
 		_sslWebServerThread->wait();
 	}
+
+	if (_jsonServerThread->isRunning()) {
+		_jsonServerThread->quit();
+		_jsonServerThread->wait();
+	}
+	_jsonServer.reset(nullptr);
 
 	QMetaObject::invokeMethod(_ssdpHandler.get(), &SSDPHandler::stop, Qt::QueuedConnection);
 	if (_ssdpHandlerThread->isRunning()) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix - Correct JSON processing
Fix - Show effectsconfigurator menu entry, only if effectengine is available

Improvements
- JSON getconfig API - allow filter to exclude elements via "null" 
- Update schemas to accept empty arrays
- Stop WebServer before JSON API to avoid blocking calls by UI

hyperion.ng/commit/dbfc59a28c09ff3bd91fca81d588c1d0a1bba725)

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [X] Code style update
- [ ] Refactor
- [] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
