### PR TITLE
Ensure grabber default  hardware contols are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 
 - Hue Bridge - Wizard updates to support bridge-ids, overall code refactoring
+- USB Grabber - Default hardware control properties are now applied when a new USB grabber is selected (avoids black images)
 
 - **Fixes:**
   - UI - Language is not selectable (#1877)

--- a/assets/webconfig/js/ui_utils.js
+++ b/assets/webconfig/js/ui_utils.js
@@ -865,8 +865,12 @@ function updateJsonEditorRange(rootEditor, path, key, minimum, maximum, defaultV
   delete editor.cached_editors[key];
   editor.addObjectProperty(key);
 
-  // Restore the current value after updating the range
-  rootEditor.getEditor(path + "." + key).setValue(currentValue);
+  // restore the current value, if no default value given
+  if (typeof defaultValue === "undefined") {
+    rootEditor.getEditor(path + "." + key).setValue(currentValue);
+  } else {
+    rootEditor.getEditor(path + "." + key).setValue(defaultValue);
+  }
 }
 
 // Add custom host validation to JSON Editor


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

### 🔧 Changed

- USB Grabber - Default hardware control properties are now applied when a new USB grabber is selected
This should avoid that grabbers are perceived as not working, while a default zero brightness just result in back images streamed.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
