### PR TITLE
V4L2/ImageResampler: add support for pixelformats YUV422P and NV21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Added
 
+- V4L2/ImageResampler: add support for pixelformats YUV422P and NV21
 ---
 
 ### 🔧 Changed

--- a/include/utils/PixelFormat.h
+++ b/include/utils/PixelFormat.h
@@ -18,6 +18,7 @@ enum class PixelFormat {
 	NV21,
 	P030,
 	I420,
+	I422,
 	MJPEG,
 	NO_CHANGE
 };
@@ -59,9 +60,17 @@ inline PixelFormat parsePixelFormat(const QString& pixelFormat)
 	{
 		return PixelFormat::I420;
 	}
+	else if (format.compare("i422")  == 0)
+	{
+		return PixelFormat::I422;
+	}
 	else if (format.compare("nv12") == 0)
 	{
 		return PixelFormat::NV12;
+	}
+	else if (format.compare("nv21") == 0)
+	{
+		return PixelFormat::NV21;
 	}
 	else if (format.compare("mjpeg")  == 0)
 	{
@@ -107,9 +116,17 @@ inline QString pixelFormatToString(const PixelFormat& pixelFormat)
 	{
 		return "I420";
 	}
+	else if (pixelFormat == PixelFormat::I422)
+	{
+		return "I422";
+	}
 	else if (pixelFormat == PixelFormat::NV12)
 	{
 		return "NV12";
+	}
+	else if (pixelFormat == PixelFormat::NV21)
+	{
+		return "NV21";
 	}
 	else if (pixelFormat == PixelFormat::MJPEG)
 	{

--- a/libsrc/grabber/video/v4l2/V4L2Grabber.cpp
+++ b/libsrc/grabber/video/v4l2/V4L2Grabber.cpp
@@ -71,7 +71,9 @@ static PixelFormat GetPixelFormat(const unsigned int format)
 	if (format == V4L2_PIX_FMT_YUYV) return PixelFormat::YUYV;
 	if (format == V4L2_PIX_FMT_UYVY) return PixelFormat::UYVY;
 	if (format == V4L2_PIX_FMT_NV12) return  PixelFormat::NV12;
+	if (format == V4L2_PIX_FMT_NV21) return  PixelFormat::NV21;
 	if (format == V4L2_PIX_FMT_YUV420) return  PixelFormat::I420;
+	if (format == V4L2_PIX_FMT_YUV422P) return  PixelFormat::I422;
 #ifdef HAVE_TURBO_JPEG
 	if (format == V4L2_PIX_FMT_MJPEG) return  PixelFormat::MJPEG;
 #endif
@@ -683,8 +685,16 @@ void V4L2Grabber::init_device(VideoStandard videoStandard)
 			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_NV12;
 		break;
 
+		case PixelFormat::NV21:
+			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_NV21;
+		break;
+
 		case PixelFormat::I420:
 			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV420;
+		break;
+
+		case PixelFormat::I422:
+			fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV422P;
 		break;
 
 #ifdef HAVE_TURBO_JPEG
@@ -850,11 +860,27 @@ void V4L2Grabber::init_device(VideoStandard videoStandard)
 		}
 		break;
 
+		case V4L2_PIX_FMT_NV21:
+		{
+			_pixelFormat = PixelFormat::NV21;
+			_frameByteSize = (_width * _height * 6) / 4;
+			Debug(_log, "Pixel format=NV12");
+		}
+		break;
+
 		case V4L2_PIX_FMT_YUV420:
 		{
 			_pixelFormat = PixelFormat::I420;
 			_frameByteSize = (_width * _height * 6) / 4;
 			Debug(_log, "Pixel format=I420");
+		}
+		break;
+
+		case V4L2_PIX_FMT_YUV422P:
+		{
+			_pixelFormat = PixelFormat::I422;
+			_frameByteSize = _width * _height * 2;
+			Debug(_log, "Pixel format=I422");
 		}
 		break;
 
@@ -869,9 +895,9 @@ void V4L2Grabber::init_device(VideoStandard videoStandard)
 
 		default:
 #ifdef HAVE_TURBO_JPEG
-			throw_exception("Only pixel formats RGB32, BGR32, RGB24, BGR24, YUYV, UYVY, NV12, I420 and MJPEG are supported");
+			throw_exception("Only pixel formats RGB32, BGR32, RGB24, BGR24, YUYV, UYVY, NV12, NV21, I420, I422 and MJPEG are supported");
 #else
-			throw_exception("Only pixel formats RGB32, BGR32, RGB24, BGR24, YUYV, UYVY, NV12 and I420 are supported");
+			throw_exception("Only pixel formats RGB32, BGR32, RGB24, BGR24, YUYV, UYVY, NV12, NV21, I420 and I422 are supported");
 #endif
 		return;
 	}

--- a/libsrc/utils/ImageResampler.cpp
+++ b/libsrc/utils/ImageResampler.cpp
@@ -213,7 +213,24 @@ void ImageResampler::processImage(const uint8_t * data, int width, int height, s
 			break;
 		}
 
-		case PixelFormat::I420:
+		case PixelFormat::NV21:
+		{
+			for (int yDest = yDestStart, ySource = cropTop + (_verticalDecimation >> 1); yDest <= yDestEnd; ySource += _verticalDecimation, ++yDest)
+			{
+				size_t uOffset = (height + ySource / 2) * lineLength;
+				for (int xDest = xDestStart, xSource = cropLeft + (_horizontalDecimation >> 1); xDest <= xDestEnd; xSource += _horizontalDecimation, ++xDest)
+				{
+					ColorRgb & rgb = outputImage(abs(xDest), abs(yDest));
+					uint8_t y = data[lineLength * ySource + xSource];
+					uint8_t v = data[uOffset + ((xSource >> 1) << 1)];
+					uint8_t u = data[uOffset + ((xSource >> 1) << 1) + 1];
+					ColorSys::yuv2rgb(y, u, v, rgb.red, rgb.green, rgb.blue);
+				}
+			}
+			break;
+		}
+
+		case PixelFormat::I420: // YUV 4:2:0 Planar
 		{
 			for (int yDest = yDestStart, ySource = cropTop + (_verticalDecimation >> 1); yDest <= yDestEnd; ySource += _verticalDecimation, ++yDest)
 			{
@@ -230,9 +247,27 @@ void ImageResampler::processImage(const uint8_t * data, int width, int height, s
 			}
 			break;
 		}
+
+		case PixelFormat::I422: // YUV 4:2:2 Planar
+		{
+			for (int yDest = yDestStart, ySource = cropTop + (_verticalDecimation >> 1); yDest <= yDestEnd; ySource += _verticalDecimation, ++yDest)
+			{
+				int uOffset = width * height + ySource * (width/2);
+				int vOffset = (width * height) + (width * height / 2) + ySource * (width/2);
+				for (int xDest = xDestStart, xSource = _cropLeft + (_horizontalDecimation >> 1); xDest <= xDestEnd; xSource += _horizontalDecimation, ++xDest)
+				{
+					ColorRgb & rgb = outputImage(abs(xDest), abs(yDest));
+					uint8_t y = data[lineLength * ySource + xSource];
+					uint8_t u = data[uOffset + (xSource >> 1)];
+					uint8_t v = data[vOffset + (xSource >> 1)];
+					ColorSys::yuv2rgb(y, u, v, rgb.red, rgb.green, rgb.blue);
+				}
+			}
+			break;
+		}
+
 		case PixelFormat::MJPEG:
 		break;
-		case PixelFormat::NV21:
 		case PixelFormat::P030:
 			Warning(Logger::getInstance("ImageResampler"), "%s",
 					QSTRING_CSTR(QString("Pixel format %1 not supported yet").arg(pixelFormatToString(pixelFormat))));


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This PR will add support for pixelformats YUV422P (I422) and NV21 in ImageResampler and V4L2Grabber.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
