### PR TITLE
EffectEngine:  Refactoring, stabalizing and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixes:**
   - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incompatible setting. (#2002)
-  - EffectEngine: Fix Python C-API reference-counting and null-pointer bugs — null guards after allocations, version-aware `PyModule_AddObject` cleanup, and correct ownership on `PyList_SetItem`/`PyModule_AddObject` failures. (#2011)
+  - EffectModule - Reference Counting (Use-After-Free) bugs (#2010) - _Thanks to @wr-web
 
 ---
 ### Technical
 
 - EffectEngine: Refactor Python C-extension module to reduce nesting depth and cognitive complexity.
+- EffectModule - Refactor and stablising
+- EffectFileHandler: Refactor and fix path traversal vulnerabilities
 
 ## [2.2.1](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.1) - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Technical
 
 - EffectEngine: Refactor Python C-extension module to reduce nesting depth and cognitive complexity.
-- EffectModule - Refactor and stablising
+- EffectModule - Refactor and stabilising
 - EffectFileHandler: Refactor effect file management
 - EffectEngine: Added dedicated `hyperion.effect` debug logging category
 - Empty image consistency applied. 0×0 is now the canonical empty image; 1×1 is no longer treated as empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 
 - **Fixes:**
-- Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002) EffectEngine: Fix Python reference-counting bugs in effect module — null checks after `PyList_New`/`PyDict_New`, version-aware `PyModule_AddObject` cleanup, and null guard on `json2python` return before `PyObject_SetAttrString`.
-- EffectEngine: Fix silent null returns in Python C-API wrappers that caused `SystemError` when argument parsing failed due to incorrect argument counts.
-- EffectEngine: Fix missing null-guards on `Py_BuildValue` returns before calling `PyObject_SetAttrString` for `ledCount` and `latchTime`.
+  - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incompatible setting. (#2002)
+  - EffectEngine: Fix Python C-API reference-counting and null-pointer bugs — null guards after allocations, version-aware `PyModule_AddObject` cleanup, and correct ownership on `PyList_SetItem`/`PyModule_AddObject` failures. (#2011)
 
 ---
-
 ### Technical
+
+- EffectEngine: Refactor Python C-extension module to reduce nesting depth and cognitive complexity.
 
 ## [2.2.1](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.1) - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 
 - **Fixes:**
-- Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
-- EffectEngine: Fix Python reference-counting bugs in effect module — null checks after `PyList_New`/`PyDict_New`, version-aware `PyModule_AddObject` cleanup, and null guard on `json2python` return before `PyObject_SetAttrString`
+- Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002) EffectEngine: Fix Python reference-counting bugs in effect module — null checks after `PyList_New`/`PyDict_New`, version-aware `PyModule_AddObject` cleanup, and null guard on `json2python` return before `PyObject_SetAttrString`.
 - EffectEngine: Fix silent null returns in Python C-API wrappers that caused `SystemError` when argument parsing failed due to incorrect argument counts.
 - EffectEngine: Fix missing null-guards on `Py_BuildValue` returns before calling `PyObject_SetAttrString` for `ledCount` and `latchTime`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✨ Added
 
 - V4L2/ImageResampler: add support for pixelformats YUV422P and NV21
+- New Jugger Effect
 ---
 
 ### 🔧 Changed
 
 - **Fixes:**
   - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incompatible setting. (#2002)
-  - EffectModule - Reference Counting (Use-After-Free) bugs (#2010) - _Thanks to @wr-web
-
+  - EffectModule - Reference Counting (Use-After-Free) bugs (#2010) - _Thanks to @wr-web_
+  - EffectEngine - Follow-up Python C-API null-pointer and stability fixes (#2011)
+  - EffectFileHandler - Path traversal vulnerability when saving user-defined effects (#2011)
+  - Effect scripts: Minor stability and style fixes in `pacman.py`, `traces.py`, `trails.py`(#2011)
 ---
 ### Technical
 
 - EffectEngine: Refactor Python C-extension module to reduce nesting depth and cognitive complexity.
 - EffectModule - Refactor and stablising
-- EffectFileHandler: Refactor and fix path traversal vulnerabilities
+- EffectFileHandler: Refactor effect file management
+- EffectEngine: Added dedicated `hyperion.effect` debug logging category
+- Empty image consistency applied. An image sized 1x1 is not treated as an empty one any longer, only 0x0 is empty.
 
 ## [2.2.1](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.1) - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✨ Added
 
 - V4L2/ImageResampler: add support for pixelformats YUV422P and NV21
-- New Jugger Effect
+- New Juggler Effect
 ---
 
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixes:**
 - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
 - EffectEngine: Fix Python reference-counting bugs in effect module — null checks after `PyList_New`/`PyDict_New`, version-aware `PyModule_AddObject` cleanup, and null guard on `json2python` return before `PyObject_SetAttrString`
----
-
-### 🗑️ Removed
+- EffectEngine: Fix silent null returns in Python C-API wrappers that caused `SystemError` when argument parsing failed due to incorrect argument counts.
+- EffectEngine: Fix missing null-guards on `Py_BuildValue` returns before calling `PyObject_SetAttrString` for `ledCount` and `latchTime`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixes:**
 - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
+- EffectEngine: Fix Python reference-counting bugs in effect module — null checks after `PyList_New`/`PyDict_New`, version-aware `PyModule_AddObject` cleanup, and null guard on `json2python` return before `PyObject_SetAttrString`
 ---
 
 ### 🗑️ Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EffectModule - Refactor and stablising
 - EffectFileHandler: Refactor effect file management
 - EffectEngine: Added dedicated `hyperion.effect` debug logging category
-- Empty image consistency applied. An image sized 1x1 is not treated as an empty one any longer, only 0x0 is empty.
+- Empty image consistency applied. 0×0 is now the canonical empty image; 1×1 is no longer treated as empty
 
 ## [2.2.1](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.1) - 2026-04-06
 

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -833,7 +833,7 @@
   "edt_eff_initial_blink": "Flash for attention",
   "edt_eff_interval": "Interval",
   "edt_eff_juggler_header": "Juggler",
-  "edt_eff_juggler_header_desc": "Colored balls are juggled accross the screen",
+  "edt_eff_juggler_header_desc": "Colored balls are juggled across the screen",
   "edt_eff_knightrider_header": "Knight Rider",
   "edt_eff_knightrider_header_desc": "K.I.T.T is back! The front-scanner of the well-known car, this time not just in red.",
   "edt_eff_ledlist": "LED List",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -832,6 +832,8 @@
   "edt_eff_url": "Image adress",
   "edt_eff_initial_blink": "Flash for attention",
   "edt_eff_interval": "Interval",
+  "edt_eff_juggler_header": "Juggler",
+  "edt_eff_juggler_header_desc": "Colored balls are juggled accross the screen",
   "edt_eff_knightrider_header": "Knight Rider",
   "edt_eff_knightrider_header_desc": "K.I.T.T is back! The front-scanner of the well-known car, this time not just in red.",
   "edt_eff_ledlist": "LED List",

--- a/effects/collision.py
+++ b/effects/collision.py
@@ -6,9 +6,14 @@ trailLength   = max(3, int(hyperion.args.get('trailLength', 5)))
 explodeRadius = int(hyperion.args.get('explodeRadius', 8))
 
 # Ensure that the range for pixel indices stays within bounds
-maxPixelIndex = hyperion.ledCount - 1
-if trailLength > maxPixelIndex or explodeRadius > maxPixelIndex:
-    exit(f"Error: Color length ({trailLength}) and detonation range ({explodeRadius}) must be less than number of LEDs configured ({hyperion.ledCount})")
+# trailLength and explodeRadius must each be less than hyperion.ledCount
+minLedCount = max(trailLength, explodeRadius) + 1
+if hyperion.ledCount < minLedCount:
+    raise SystemExit(
+        f"Collision requires at least {minLedCount} LEDs (configured: {hyperion.ledCount}). "
+        f"'trailLength' must be < ledCount (currently {trailLength}, max allowed {hyperion.ledCount - 1}), "
+        f"'explodeRadius' must be < ledCount (currently {explodeRadius}, max allowed {hyperion.ledCount - 1})."
+    )
 
 # Create additional variables
 increment = None

--- a/effects/juggler.json
+++ b/effects/juggler.json
@@ -1,0 +1,8 @@
+{
+    "name" : "Juggler",
+    "script" : "juggler.py",
+    "args" :
+    {
+        "brightness" : 100
+    }
+}

--- a/effects/juggler.py
+++ b/effects/juggler.py
@@ -1,0 +1,78 @@
+import hyperion, time, math, colorsys
+
+# Parameter
+brightness = float(hyperion.args.get('brightness', 100)) / 100.0
+
+# Image setup
+hyperion.imageMinSize(64, 64)
+iW = hyperion.imageWidth()
+iH = hyperion.imageHeight()
+
+sleepTime = max(hyperion.lowestUpdateInterval(), 1.0 / 60.0)
+
+# Buffer
+buf = [[[0, 0, 0] for _ in range(iH)] for _ in range(iW)]
+
+# Constants
+numDots = 8
+dotR = max(2, min(iW, iH) // 20)
+dotRSq = dotR * dotR
+
+# Precompute the circular dot mask
+dotMask = []
+for ox in range(-dotR, dotR + 1):
+	for oy in range(-dotR, dotR + 1):
+		distSq = ox * ox + oy * oy
+		if distSq <= dotRSq:
+			dist = math.sqrt(distSq)
+			intensity = max(0, 255 - int(dist / dotR * 200))
+			dotMask.append((ox, oy, intensity))
+
+# Main loop
+startTime = time.time()
+while not hyperion.abort():
+	tMs = (time.time() - startTime) * 1000.0
+
+	# Fade buffer
+	scale = max(0.0, 1.0 - 25 / 256.0)
+	for x in range(iW):
+		for y in range(iH):
+			buf[x][y][0] = int(buf[x][y][0] * scale)
+			buf[x][y][1] = int(buf[x][y][1] * scale)
+			buf[x][y][2] = int(buf[x][y][2] * scale)
+
+	# Draw moving dots
+	for i in range(numDots):
+		angleX = (tMs / 60000.0) * (i + 5) * 2.0 * math.pi + i * 1.3
+		angleY = (tMs / 60000.0) * (i + 3) * 2.0 * math.pi + i * 0.9 + math.pi
+		dx = int((math.sin(angleX) + 1.0) * 0.5 * (iW - 1))
+		dy = int((math.sin(angleY) + 1.0) * 0.5 * (iH - 1))
+
+		r, g, b = colorsys.hsv_to_rgb(((i * 32) & 255) / 255.0, 200 / 255.0, 255 / 255.0)
+		r = int(r * 255)
+		g = int(g * 255)
+		b = int(b * 255)
+
+		for ox, oy, intensity in dotMask:
+			x = dx + ox
+			y = dy + oy
+			if 0 <= x < iW and 0 <= y < iH:
+				pr = r * intensity // 255
+				pg = g * intensity // 255
+				pb = b * intensity // 255
+				buf[x][y][0] = max(buf[x][y][0], pr)
+				buf[x][y][1] = max(buf[x][y][1], pg)
+				buf[x][y][2] = max(buf[x][y][2], pb)
+
+	# Push buffer to Hyperion image
+	for x in range(iW):
+		for y in range(iH):
+			r = int(buf[x][y][0] * brightness)
+			g = int(buf[x][y][1] * brightness)
+			b = int(buf[x][y][2] * brightness)
+			hyperion.imageSetPixel(x, y, r, g, b)
+
+	hyperion.imageShow()
+	hyperion.imageStackClear()
+
+	time.sleep(sleepTime)

--- a/effects/pacman.py
+++ b/effects/pacman.py
@@ -28,6 +28,12 @@ posBlueGuy = posPinkGuy + diffGuys
 posSlowGuy = posBlueGuy + diffGuys
 posRedGuy = posSlowGuy + diffGuys
 
+# minimum LEDs needed: randint(10, ledCount) requires ledCount >= 10,
+# and posRedGuy + 1 LEDs are needed to show all characters
+minLedCount = max(10, posRedGuy + 1)
+if hyperion.ledCount < minLedCount:
+	raise SystemExit(f"Pac-Man requires at least {minLedCount} LEDs (configured: {hyperion.ledCount}). Increase LED count or reduce 'margin-pos'.")
+
 # initialize the led data
 ledDataEscape = bytearray()
 for i in range(hyperion.ledCount):

--- a/effects/pacman.py
+++ b/effects/pacman.py
@@ -62,19 +62,19 @@ for i in range(hyperion.ledCount):
 # increment = 3, because LED-Color is defined by 3 Bytes
 increment = 3
 
-def shiftLED(ledData, increment, limit, lightPos=None):
+def shift_led(led_data, increment, limit, light_pos=None):
 	state = 0
 	while state < limit and not hyperion.abort():
-		ledData = ledData[increment:] + ledData[:increment]
+		led_data = led_data[increment:] + led_data[:increment]
 
-		if (lightPos):
-			tmp = ledData[lightPos]
-			ledData[lightPos] = light
+		if (light_pos):
+			tmp = led_data[light_pos]
+			led_data[light_pos] = light
 
-		hyperion.setColor(ledData)
+		hyperion.setColor(led_data)
 
-		if (lightPos):
-			ledData[lightPos] = tmp
+		if (light_pos):
+			led_data[light_pos] = tmp
 
 		time.sleep(sleepTime)
 		state += 1
@@ -84,17 +84,17 @@ while not hyperion.abort():
 
 	# escape mode
 	ledData = ledDataEscape
-	shiftLED(ledData, increment, hyperion.ledCount)
+	shift_led(ledData, increment, hyperion.ledCount)
 
 	random = randint(10,hyperion.ledCount)
 
 	# escape mode + power pellet
 	s = slice(3*random, 3*random+3)
-	shiftLED(ledData, increment, hyperion.ledCount - random, s)
+	shift_led(ledData, increment, hyperion.ledCount - random, s)
 
 	# chase mode
 	shift   = 3*(hyperion.ledCount - random)
 	ledData = ledDataChase[shift:]+ledDataChase[:shift]
-	shiftLED(ledData, -increment, 2*hyperion.ledCount-random)
+	shift_led(ledData, -increment, 2*hyperion.ledCount-random)
 	time.sleep(sleepTime)
 

--- a/effects/schema/juggler.schema.json
+++ b/effects/schema/juggler.schema.json
@@ -1,0 +1,18 @@
+{
+	"type": "object",
+	"script": "juggler.py",
+	"title": "edt_eff_juggler_header",
+	"required": true,
+	"properties": {
+		"brightness": {
+			"type": "number",
+			"title": "edt_eff_brightness",
+			"default": 100,
+			"minimum": 1,
+			"maximum": 100,
+			"append": "edt_append_percent",
+			"propertyOrder": 1
+		}
+	},
+	"additionalProperties": false
+}

--- a/effects/snake.py
+++ b/effects/snake.py
@@ -29,7 +29,8 @@ def lerp(a, b, t):
     return (a[0]*(1-t)+b[0]*t, a[1]*(1-t)+b[1]*t, a[2]*(1-t)+b[2]*t)
 
 for i in range(0, snakeLeds):
-	hsv = lerp(color_hsv, backgroundColor_hsv, 1.0/(snakeLeds-1)*i)
+	t = 0.0 if snakeLeds == 1 else (1.0 / (snakeLeds - 1) * i)
+	hsv = lerp(color_hsv, backgroundColor_hsv, t)
 	rgb = colorsys.hsv_to_rgb(hsv[0], hsv[1], hsv[2])
 	ledData += bytearray((int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)))
 

--- a/effects/traces.py
+++ b/effects/traces.py
@@ -1,5 +1,9 @@
 import hyperion, time, random, math
 
+# Traces requires at least 2 LEDs so runners can advance positions and ledData is non-empty
+if hyperion.ledCount < 2:
+	raise SystemExit(f"Traces requires at least 2 LEDs (configured: {hyperion.ledCount}). Increase LED count.")
+
 # Initialize the led data
 ledData = bytearray()
 for i in range(hyperion.ledCount):

--- a/effects/traces.py
+++ b/effects/traces.py
@@ -31,7 +31,6 @@ i = 0
 while not hyperion.abort():
 	for r in runners:
 		if r["c"] == 0:
-			#ledData[r["pos"]*3+r["i"]] = 0
 			r["c"] = r["step"]
 			r["pos"] = (r["pos"]+1)%hyperion.ledCount
 			ledData[r["pos"]*3+r["i"]] = int(r["lvl"]*(0.2+0.8*random.random()))

--- a/effects/trails.py
+++ b/effects/trails.py
@@ -34,7 +34,7 @@ class trail:
 
 		self.data.extend([(0,0,0)]*(_h-y))
 		if len(self.data) < _h:
-			for i in range (_h-len(self.data)):
+			for _ in range (_h-len(self.data)):
 				self.data.insert(0, (0,0,0))
 
 	def getdata(self):

--- a/effects/trails.py
+++ b/effects/trails.py
@@ -5,7 +5,6 @@ import random
 
 min_len = int(hyperion.args.get('min_len', 3))
 max_len = int(hyperion.args.get('max_len', 3))
-#iHeight = int(hyperion.args.get('iHeight', 8))
 trails = int(hyperion.args.get('int', 8))
 sleepTime = float(hyperion.args.get('speed', 1)) / 1000.0
 color = list(hyperion.args.get('color', (255,255,255)))
@@ -28,7 +27,7 @@ class trail:
 		self.data = []
 		brigtness = color[2]
 		step_brigtness = color[2] / _len
-		for i in range(0, _len):
+		for _ in range(0, _len):
 			rgb = colorsys.hsv_to_rgb(color[0], color[1], brigtness)
 			self.data.insert(0, (int(255*rgb[0]), int(255*rgb[1]), int(255*rgb[2])))
 			brigtness -= step_brigtness

--- a/include/effectengine/Effect.h
+++ b/include/effectengine/Effect.h
@@ -43,7 +43,7 @@ public:
 	/// @brief Set manual interruption to true,
 	///        Note: DO NOT USE QThread::interruption!
 	///
-	void requestInterruption() { _interupt = true; }
+	void requestInterruption() { _interupt = true; } // NOSONAR - QThread::requestInterruption is not used to avoid confusion with the effect's own interruption mechanism
 
 	///
 	/// @brief Check an interruption was requested.
@@ -52,7 +52,7 @@ public:
 	///
 	/// @return    The flag state
 	///
-	bool isInterruptionRequested();
+	bool isInterruptionRequested() const; // NOSONAR - QThread::requestInterruption is not used to avoid confusion with the effect's own interruption mechanism
 
 	///
 	/// @brief Get the remaining timeout, or indication it is endless

--- a/include/effectengine/Effect.h
+++ b/include/effectengine/Effect.h
@@ -12,6 +12,7 @@
 #include <utils/Image.h>
 
 #include <atomic>
+#include <QScopedPointer>
 
 class Hyperion;
 class Logger;
@@ -110,7 +111,7 @@ private:
 
 	QSize           _imageSize;
 	QImage          _image;
-	QPainter*       _painter;
+	QScopedPointer<QPainter> _painter;
 	QVector<QImage> _imageStack;
 
 	double	_lowestUpdateIntervalInSeconds;

--- a/include/effectengine/EffectDefinition.h
+++ b/include/effectengine/EffectDefinition.h
@@ -6,7 +6,9 @@
 
 struct EffectDefinition
 {
-	QString name, script, file;
+	QString name;
+	QString script;
+	QString file;
 	QJsonObject args;
 	unsigned smoothCfg;
 };

--- a/include/effectengine/EffectDefinition.h
+++ b/include/effectengine/EffectDefinition.h
@@ -4,6 +4,10 @@
 #include <QString>
 #include <QJsonObject>
 
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(effect);
+
 struct EffectDefinition
 {
 	QString name;

--- a/include/effectengine/EffectFileHandler.h
+++ b/include/effectengine/EffectFileHandler.h
@@ -6,6 +6,11 @@
 #include <effectengine/EffectSchema.h>
 #include <utils/settings.h>
 
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QMap>
+
 class EffectFileHandler : public QObject
 {
 	Q_OBJECT
@@ -81,6 +86,36 @@ private:
 	/// @brief load effect schemas, called by updateEffects()
 	///
 	bool loadEffectSchema(const QString& path, const QString& effectSchemaFile, EffectSchema& effectSchema);
+
+	///
+	/// @brief Load all effect definitions from a directory, called by updateEffects()
+	///
+	void loadEffectsFromDirectory(const QString& path, const QDir& directory, const QStringList& disableList, QMap<QString, EffectDefinition>& availableEffects);
+
+	///
+	/// @brief Load all effect schemas from a directory, called by updateEffects()
+	///
+	void loadSchemasFromDirectory(const QString& path, QDir& directory);
+
+	///
+	/// @brief Resolve the file path for a new/updated effect and write it, called by saveEffect()
+	///
+	QString resolveEffectFilePath(const QJsonObject& message, const QString& effectName, const QJsonArray& effectArray, QJsonObject& effectJson);
+
+	///
+	/// @brief Save an embedded image for a gif effect, called by saveEffect()
+	///
+	QString saveEffectImage(const QJsonObject& message, const QJsonArray& effectArray, QJsonObject& effectJson);
+
+	///
+	/// @brief Remove the unused imageSource key (url/file) from the effect args
+	///
+	void cleanImageSource(const QJsonObject& message, QJsonObject& effectJson) const;
+
+	///
+	/// @brief Remove effect configuration and associated image files
+	///
+	QString removeEffectFiles(const EffectDefinition& effect, const QFileInfo& effectConfigurationFile);
 
 private:
  	QJsonObject _effectConfig;

--- a/include/effectengine/EffectFileHandler.h
+++ b/include/effectengine/EffectFileHandler.h
@@ -1,15 +1,17 @@
 #pragma once
 
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QMap>
+#include <QSharedPointer>
+#include <QWeakPointer>
+
 // util
 #include <utils/Logger.h>
 #include <effectengine/EffectDefinition.h>
 #include <effectengine/EffectSchema.h>
 #include <utils/settings.h>
-
-#include <QDir>
-#include <QFileInfo>
-#include <QJsonArray>
-#include <QMap>
 
 class EffectFileHandler : public QObject
 {

--- a/include/effectengine/EffectModule.h
+++ b/include/effectengine/EffectModule.h
@@ -18,7 +18,7 @@ public:
 	static PyObject* json2python(const QJsonValue& jsonData);
 
 	// Wrapper methods for Python interpreter extra buildin methods
-	static PyMethodDef effectMethods[];
+	static PyMethodDef effectMethods[]; // NOSONAR - C-style array required by PyMethodDef Python C API
 	static PyObject* wrapSetColor              (PyObject *self, PyObject *args);
 	static PyObject* wrapSetImage              (PyObject *self, PyObject *args);
 	static PyObject* wrapGetImage              (PyObject *self, PyObject *args);

--- a/include/effectengine/EffectSchema.h
+++ b/include/effectengine/EffectSchema.h
@@ -6,6 +6,7 @@
 
 struct EffectSchema
 {
-	QString pyFile, schemaFile;
+	QString pyFile;
+	QString schemaFile;
 	QJsonObject pySchema;
 };

--- a/include/utils/Image.h
+++ b/include/utils/Image.h
@@ -184,7 +184,7 @@ public:
 	void clear(const pixel_type background);
 
 	///
-	/// Reset the image to 1x1 with default background color
+	/// Reset the image to 0x0
 	///
 	void reset();
 

--- a/libsrc/effectengine/CMakeLists.txt
+++ b/libsrc/effectengine/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(effectengine
 	${CMAKE_SOURCE_DIR}/include/effectengine/EffectModule.h
 	${CMAKE_SOURCE_DIR}/include/effectengine/EffectSchema.h
 	${CMAKE_SOURCE_DIR}/libsrc/effectengine/Effect.cpp
+	${CMAKE_SOURCE_DIR}/libsrc/effectengine/EffectDefinition.cpp
 	${CMAKE_SOURCE_DIR}/libsrc/effectengine/EffectEngine.cpp
 	${CMAKE_SOURCE_DIR}/libsrc/effectengine/EffectFileHandler.cpp
 	${CMAKE_SOURCE_DIR}/libsrc/effectengine/EffectModule.cpp

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -64,7 +64,7 @@ Effect::~Effect()
 	_imageStack.clear();
 }
 
-bool Effect::isInterruptionRequested()
+bool Effect::isInterruptionRequested() const
 {
 	return _interupt || (!_isEndless && getRemaining() <= 0);
 }

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -106,7 +106,7 @@ bool Effect::setModuleParameters()
 #if (PY_VERSION_HEX >= 0x030A0000)
 		Py_DECREF(capsule);  // 3.10+: reference not stolen on failure
 #endif
-		Py_DECREF(module);
+		Py_XDECREF(module);
 		return false;
 	}
 

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -98,13 +98,18 @@ bool Effect::setModuleParameters()
 		Py_DECREF(hyperionModule);
 		return false;
 	}
-	if (PyModule_AddObject(hyperionModule, "__effectObj", capsule) < 0) {
-		PyErr_Print();  // Print error if adding capsule fails
-		// PyModule_AddObject steals the reference on success.
-		// On failure: Python < 3.10 steals it unconditionally; 3.10+ does not.
 #if (PY_VERSION_HEX >= 0x030A0000)
-		Py_DECREF(capsule);  // 3.10+: reference not stolen on failure
+	// 3.10+: AddObjectRef never steals; module dict acquires its own ref internally.
+	// Caller always owns capsule and must Py_DECREF regardless of success or failure.
+	const int addResult = PyModule_AddObjectRef(hyperionModule, "__effectObj", capsule);
+	Py_DECREF(capsule);
+	if (addResult < 0) {
+#else
+	// Pre-3.10: AddObject steals the reference unconditionally (success AND failure).
+	// Do not Py_DECREF capsule in either branch.
+	if (PyModule_AddObject(hyperionModule, "__effectObj", capsule) < 0) {
 #endif
+		PyErr_Print();  // Print error if adding capsule fails
 		Py_DECREF(hyperionModule);
 		return false;
 	}
@@ -136,8 +141,8 @@ bool Effect::setModuleParameters()
 	}
 	Py_XDECREF(argsObj);
 
-	// Decrement module reference
-	Py_XDECREF(hyperionModule);
+	// Decrement module reference (non-null guaranteed by null-check at top of function)
+	Py_DECREF(hyperionModule);
 
 	return true;
 }

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -94,10 +94,19 @@ bool Effect::setModuleParameters()
 
 	// Add a capsule containing 'this' to the module for callback access
 	PyObject* capsule = PyCapsule_New((void*)this, "hyperion.__effectObj", nullptr);
-	if (capsule == nullptr || PyModule_AddObject(module, "__effectObj", capsule) < 0) {
+	if (capsule == nullptr) {
+		PyErr_Print();  // Print error if capsule creation fails
+		Py_DECREF(module);
+		return false;
+	}
+	if (PyModule_AddObject(module, "__effectObj", capsule) < 0) {
 		PyErr_Print();  // Print error if adding capsule fails
-		Py_XDECREF(module);  // Clean up if capsule addition fails
-		Py_XDECREF(capsule);
+		// PyModule_AddObject steals the reference on success.
+		// On failure: Python < 3.10 steals it unconditionally; 3.10+ does not.
+#if (PY_VERSION_HEX >= 0x030A0000)
+		Py_DECREF(capsule);  // 3.10+: reference not stolen on failure
+#endif
+		Py_DECREF(module);
 		return false;
 	}
 
@@ -123,8 +132,8 @@ bool Effect::setModuleParameters()
 
 	// Add args variable to the interpreter
 	PyObject* argsObj = EffectModule::json2python(_args);
-	if (PyObject_SetAttrString(module, "args", argsObj) < 0) {
-		PyErr_Print();  // Print error if setting attribute fails
+	if (argsObj == nullptr || PyObject_SetAttrString(module, "args", argsObj) < 0) {
+		PyErr_Print();  // Print error if conversion or setting attribute fails
 	}
 	Py_XDECREF(argsObj);
 

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -105,7 +105,7 @@ bool Effect::setModuleParameters()
 #if (PY_VERSION_HEX >= 0x030A0000)
 		Py_DECREF(capsule);  // 3.10+: reference not stolen on failure
 #endif
-		Py_XDECREF(hyperionModule);
+		Py_DECREF(hyperionModule);
 		return false;
 	}
 

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -16,7 +16,7 @@
 
 // Constants
 namespace {
-	int DEFAULT_MAX_UPDATE_RATE_HZ { 200 };
+	constexpr int DEFAULT_MAX_UPDATE_RATE_HZ { 200 };
 } //End of constants
 
 Effect::Effect(const QSharedPointer<Hyperion>& hyperionInstance, int priority, int timeout, const QString &script, const QString &name, const QJsonObject &args, const QString &imageData)
@@ -53,7 +53,7 @@ Effect::Effect(const QSharedPointer<Hyperion>& hyperionInstance, int priority, i
 	// init effect image for image based effects, size is based on led layout
 	_image = QImage(_imageSize, QImage::Format_ARGB32_Premultiplied);
 	_image.fill(Qt::black);
-	_painter = new QPainter(&_image);
+	_painter.reset(new QPainter(&_image));
 
 	Q_INIT_RESOURCE(EffectEngine);
 }
@@ -61,7 +61,6 @@ Effect::Effect(const QSharedPointer<Hyperion>& hyperionInstance, int priority, i
 Effect::~Effect()
 {
 	TRACK_SCOPE_SUBCOMPONENT() << _name;
-	delete _painter;
 	_imageStack.clear();
 }
 
@@ -85,9 +84,9 @@ int Effect::getRemaining() const
 bool Effect::setModuleParameters()
 {
 	// import the buildtin Hyperion module
-	PyObject* module = PyImport_ImportModule("hyperion");
+	PyObject* hyperionModule = PyImport_ImportModule("hyperion");
 
-	if (module == nullptr) {
+	if (hyperionModule == nullptr) {
 		PyErr_Print();  // Print error if module import fails
 		return false;
 	}
@@ -96,17 +95,17 @@ bool Effect::setModuleParameters()
 	PyObject* capsule = PyCapsule_New((void*)this, "hyperion.__effectObj", nullptr);
 	if (capsule == nullptr) {
 		PyErr_Print();  // Print error if capsule creation fails
-		Py_DECREF(module);
+		Py_DECREF(hyperionModule);
 		return false;
 	}
-	if (PyModule_AddObject(module, "__effectObj", capsule) < 0) {
+	if (PyModule_AddObject(hyperionModule, "__effectObj", capsule) < 0) {
 		PyErr_Print();  // Print error if adding capsule fails
 		// PyModule_AddObject steals the reference on success.
 		// On failure: Python < 3.10 steals it unconditionally; 3.10+ does not.
 #if (PY_VERSION_HEX >= 0x030A0000)
 		Py_DECREF(capsule);  // 3.10+: reference not stolen on failure
 #endif
-		Py_XDECREF(module);
+		Py_XDECREF(hyperionModule);
 		return false;
 	}
 
@@ -116,7 +115,7 @@ bool Effect::setModuleParameters()
 	int ledCount = 0;
 	QMetaObject::invokeMethod(hyperion.get(), "getLedCount", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, ledCount));
 	PyObject* ledCountObj = Py_BuildValue("i", ledCount);
-	if (ledCountObj == nullptr || PyObject_SetAttrString(module, "ledCount", ledCountObj) < 0) {
+	if (ledCountObj == nullptr || PyObject_SetAttrString(hyperionModule, "ledCount", ledCountObj) < 0) {
 		PyErr_Print();  // Print error if setting attribute fails
 	}
 	Py_XDECREF(ledCountObj);
@@ -125,20 +124,20 @@ bool Effect::setModuleParameters()
 	int latchTime = 0;
 	QMetaObject::invokeMethod(hyperion.get(), "getLatchTime", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, latchTime));
 	PyObject* latchTimeObj = Py_BuildValue("i", latchTime);
-	if (latchTimeObj == nullptr || PyObject_SetAttrString(module, "latchTime", latchTimeObj) < 0) {
+	if (latchTimeObj == nullptr || PyObject_SetAttrString(hyperionModule, "latchTime", latchTimeObj) < 0) {
 		PyErr_Print();  // Print error if setting attribute fails
 	}
 	Py_XDECREF(latchTimeObj);
 
 	// Add args variable to the interpreter
 	PyObject* argsObj = EffectModule::json2python(_args);
-	if (argsObj == nullptr || PyObject_SetAttrString(module, "args", argsObj) < 0) {
+	if (argsObj == nullptr || PyObject_SetAttrString(hyperionModule, "args", argsObj) < 0) {
 		PyErr_Print();  // Print error if conversion or setting attribute fails
 	}
 	Py_XDECREF(argsObj);
 
 	// Decrement module reference
-	Py_XDECREF(module);
+	Py_XDECREF(hyperionModule);
 
 	return true;
 }

--- a/libsrc/effectengine/Effect.cpp
+++ b/libsrc/effectengine/Effect.cpp
@@ -116,7 +116,7 @@ bool Effect::setModuleParameters()
 	int ledCount = 0;
 	QMetaObject::invokeMethod(hyperion.get(), "getLedCount", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, ledCount));
 	PyObject* ledCountObj = Py_BuildValue("i", ledCount);
-	if (PyObject_SetAttrString(module, "ledCount", ledCountObj) < 0) {
+	if (ledCountObj == nullptr || PyObject_SetAttrString(module, "ledCount", ledCountObj) < 0) {
 		PyErr_Print();  // Print error if setting attribute fails
 	}
 	Py_XDECREF(ledCountObj);
@@ -125,7 +125,7 @@ bool Effect::setModuleParameters()
 	int latchTime = 0;
 	QMetaObject::invokeMethod(hyperion.get(), "getLatchTime", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, latchTime));
 	PyObject* latchTimeObj = Py_BuildValue("i", latchTime);
-	if (PyObject_SetAttrString(module, "latchTime", latchTimeObj) < 0) {
+	if (latchTimeObj == nullptr || PyObject_SetAttrString(module, "latchTime", latchTimeObj) < 0) {
 		PyErr_Print();  // Print error if setting attribute fails
 	}
 	Py_XDECREF(latchTimeObj);

--- a/libsrc/effectengine/EffectDefinition.cpp
+++ b/libsrc/effectengine/EffectDefinition.cpp
@@ -1,0 +1,3 @@
+#include <effectengine/EffectDefinition.h>
+
+Q_LOGGING_CATEGORY(effect, "hyperion.effect")

--- a/libsrc/effectengine/EffectEngine.cpp
+++ b/libsrc/effectengine/EffectEngine.cpp
@@ -219,6 +219,8 @@ int EffectEngine::runEffect(const QString &effectName, const QJsonObject &args, 
 
 int EffectEngine::runEffectScript(const QString &script, const QString &name, const QJsonObject &args, int priority, int timeout, const QString &origin, unsigned smoothCfg, const QString &imageData)
 {
+	qCDebug(effect) << "Run effect script:" << script << "with name:" << name << "args:" << args << "priority:" << priority << "timeout:" << timeout << "origin:" << origin << "smoothCfg:" << smoothCfg << "imageData:" << imageData.size() << "bytes";
+
 	// clear current effect on the channel
 	channelCleared(priority);
 

--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -190,15 +190,18 @@ QString EffectFileHandler::saveEffectImage(const QJsonObject& message, const QJs
 		return "";
 
 	QJsonObject args = message["args"].toObject();
-	const QString effectsDirPath = effectArray[0].toString().replace("$ROOT", _rootPath);
-	const QString effectsDirAbs = QFileInfo(effectsDirPath).absoluteFilePath();
-	const QString imageFilePath = effectsDirPath + '/' + args.value("file").toString();
-	const QFileInfo imageFileName(imageFilePath);
-	if (!imageFileName.absoluteFilePath().startsWith(effectsDirAbs + '/'))
-		return QString("Invalid image file path '%1'.").arg(args.value("file").toString());
+	const QString requestedFile = args.value("file").toString();
+	if (requestedFile.contains('/') || requestedFile.contains('\\') || requestedFile.contains(".."))
+		return QString("Invalid image file path '%1'.").arg(requestedFile);
 
-	if (!FileUtils::writeFile(imageFileName.absoluteFilePath(), QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
-		return QString("Error while saving image file '%1', please check the Hyperion Log").arg(message["args"].toObject().value("file").toString());
+	const QDir effectsDir(effectArray[0].toString().replace("$ROOT", _rootPath));
+	const QString effectsDirAbs = QDir::cleanPath(effectsDir.absolutePath());
+	const QString imageFilePath = QDir::cleanPath(effectsDir.absoluteFilePath(requestedFile));
+	if (!imageFilePath.startsWith(effectsDirAbs + QDir::separator()))
+		return QString("Invalid image file path '%1'.").arg(requestedFile);
+
+	if (!FileUtils::writeFile(imageFilePath, QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
+		return QString("Error while saving image file '%1', please check the Hyperion Log").arg(requestedFile);
 
 	args["file"] = imageFilePath;
 	effectJson["args"] = args;

--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -1,15 +1,16 @@
 #include <effectengine/EffectFileHandler.h>
-#include <utils/MemoryTracker.h>
 
-// util
-#include <utils/JsonUtils.h>
+#include <algorithm>
 
-// qt
 #include <QJsonArray>
 #include <QFileInfo>
 #include <QDir>
 #include <QMap>
 #include <QByteArray>
+#include <QString>
+
+#include <utils/MemoryTracker.h>
+#include <utils/JsonUtils.h>
 
 QSharedPointer<EffectFileHandler> EffectFileHandler::_instance;
 
@@ -76,11 +77,11 @@ QString EffectFileHandler::deleteEffect(const QString& effectName)
 	}
 
 	if (it == effectsDefinition.cend())
-		return "Effect " + effectName + " not found";
+		return QString("Effect %1 not found").arg(effectName);
 
 	QFileInfo effectConfigurationFile(it->file);
 	if (effectConfigurationFile.absoluteFilePath().startsWith(':'))
-		return "Can't delete internal effect: " + effectName;
+		return QString("Can't delete internal effect: %1").arg(effectName);
 
 	return removeEffectFiles(*it, effectConfigurationFile);
 }
@@ -88,7 +89,7 @@ QString EffectFileHandler::deleteEffect(const QString& effectName)
 QString EffectFileHandler::removeEffectFiles(const EffectDefinition& effect, const QFileInfo& effectConfigurationFile)
 {
 	if (!effectConfigurationFile.exists())
-		return "Can't find effect configuration file: " + effectConfigurationFile.absoluteFilePath();
+		return QString("Can't find effect configuration file: %1").arg(effectConfigurationFile.absoluteFilePath());
 
 	if ((effect.script == ":/effects/gif.py") && !effect.args.value("file").toString("").isEmpty())
 	{
@@ -101,7 +102,7 @@ QString EffectFileHandler::removeEffectFiles(const EffectDefinition& effect, con
 
 	if (!QFile::remove(effectConfigurationFile.absoluteFilePath()))
 	{
-		return "Can't delete effect configuration file: " + effectConfigurationFile.absoluteFilePath() + ". Please check permissions";
+		return QString("Can't delete effect configuration file: %1. Please check permissions").arg(effectConfigurationFile.absoluteFilePath());
 	}
 
 	updateEffects();
@@ -123,18 +124,18 @@ QString EffectFileHandler::saveEffect(const QJsonObject& message)
 	}
 
 	if (it == effectsSchemas.cend())
-		return "Missing schema file for Python script " + message["script"].toString();
+		return QString("Missing schema file for Python script %1").arg(message["script"].toString());
 
 	if (!JsonUtils::validate("EffectFileHandler", message["args"], it->schemaFile, _log).first)
 		return "Error during arg validation against schema, please consult the Hyperion Log";
 
 	const QJsonArray effectArray = _effectConfig["paths"].toArray();
 	if (effectArray.empty())
-		return "Can't save new effect. Effect path empty";
+		return "Cannot save new effect. Effect path is empty";
 
 	const QString effectName = message["name"].toString();
 	if (effectName.trimmed().isEmpty() || effectName.trimmed().startsWith(":"))
-		return "Can't save new effect. Effect name is empty or begins with a dot.";
+		return "Cannot save new effect. Effect name is empty or begins with a colon (internal-effect prefix).";
 
 	QJsonObject effectJson;
 	effectJson["name"]   = effectName;
@@ -162,7 +163,7 @@ QString EffectFileHandler::resolveEffectFilePath(const QJsonObject& message, con
 	{
 		newFileName.setFile(iter->file);
 		if (newFileName.absoluteFilePath().startsWith(':'))
-			return "The effect name '" + effectName + "' is assigned to an internal effect. Please rename your effect.";
+			return QString("The effect name '%1' is assigned to an internal effect. Please rename your effect.").arg(effectName);
 	}
 	else
 	{
@@ -192,7 +193,7 @@ QString EffectFileHandler::saveEffectImage(const QJsonObject& message, const QJs
 	const QFileInfo imageFileName(imageFilePath);
 
 	if (!FileUtils::writeFile(imageFileName.absoluteFilePath(), QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
-		return "Error while saving image file '" + message["args"].toObject().value("file").toString() + ", please check the Hyperion Log";
+		return QString("Error while saving image file '%1', please check the Hyperion Log").arg(message["args"].toObject().value("file").toString());
 
 	args["file"] = imageFilePath;
 	effectJson["args"] = args;
@@ -202,6 +203,7 @@ QString EffectFileHandler::saveEffectImage(const QJsonObject& message, const QJs
 void EffectFileHandler::cleanImageSource(const QJsonObject& message, QJsonObject& effectJson) const
 {
 	const QString imageSource = message["args"].toObject().value("imageSource").toString("");
+	qCDebug(effect) << "Image source:" << imageSource;
 	if (imageSource != "url" && imageSource != "file")
 		return;
 

--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -67,7 +67,6 @@ void EffectFileHandler::handleSettingsUpdate(settings::type type, const QJsonDoc
 
 QString EffectFileHandler::deleteEffect(const QString& effectName)
 {
-	QString resultMsg;
 	const auto& effectsDefinition = getEffects();
 	auto it = effectsDefinition.cbegin();
 	for (; it != effectsDefinition.cend(); ++it)
@@ -75,159 +74,140 @@ QString EffectFileHandler::deleteEffect(const QString& effectName)
 		if (it->name == effectName)
 			break;
 	}
-	
-	if (it != effectsDefinition.cend())
+
+	if (it == effectsDefinition.cend())
+		return "Effect " + effectName + " not found";
+
+	QFileInfo effectConfigurationFile(it->file);
+	if (effectConfigurationFile.absoluteFilePath().startsWith(':'))
+		return "Can't delete internal effect: " + effectName;
+
+	return removeEffectFiles(*it, effectConfigurationFile);
+}
+
+QString EffectFileHandler::removeEffectFiles(const EffectDefinition& effect, const QFileInfo& effectConfigurationFile)
+{
+	if (!effectConfigurationFile.exists())
+		return "Can't find effect configuration file: " + effectConfigurationFile.absoluteFilePath();
+
+	if ((effect.script == ":/effects/gif.py") && !effect.args.value("file").toString("").isEmpty())
 	{
-		QFileInfo effectConfigurationFile(it->file);
-		if (!effectConfigurationFile.absoluteFilePath().startsWith(':'))
+		QFileInfo effectImageFile(effect.args.value("file").toString());
+		if (effectImageFile.exists())
 		{
-			if (effectConfigurationFile.exists())
-			{
-				if ((it->script == ":/effects/gif.py") && !it->args.value("file").toString("").isEmpty())
-				{
-					QFileInfo effectImageFile(it->args.value("file").toString());
-					if (effectImageFile.exists())
-					{
-						QFile::remove(effectImageFile.absoluteFilePath());
-					}
-				}
-
-				bool result = QFile::remove(effectConfigurationFile.absoluteFilePath());
-
-				if (result)
-				{
-					updateEffects();
-					resultMsg = "";
-				}
-				else
-				{
-					resultMsg = "Can't delete effect configuration file: " + effectConfigurationFile.absoluteFilePath() + ". Please check permissions";
-				}
-			}
-			else
-			{
-				resultMsg = "Can't find effect configuration file: " + effectConfigurationFile.absoluteFilePath();
-			}
-		}
-		else
-		{
-			resultMsg = "Can't delete internal effect: " + effectName;
+			QFile::remove(effectImageFile.absoluteFilePath());
 		}
 	}
-	else
+
+	if (!QFile::remove(effectConfigurationFile.absoluteFilePath()))
 	{
-		resultMsg = "Effect " + effectName + " not found";
+		return "Can't delete effect configuration file: " + effectConfigurationFile.absoluteFilePath() + ". Please check permissions";
 	}
 
-	return resultMsg;
+	updateEffects();
+	return "";
 }
 
 QString EffectFileHandler::saveEffect(const QJsonObject& message)
 {
-	QString resultMsg;
-	if (!message["args"].toObject().isEmpty())
+	if (message["args"].toObject().isEmpty())
+		return "Missing or empty Object 'args'";
+
+	const QString scriptName = message["script"].toString();
+	const auto& effectsSchemas = getEffectSchemas();
+	auto it = effectsSchemas.cbegin();
+	for (; it != effectsSchemas.cend(); ++it)
 	{
-		QString scriptName = message["script"].toString();
+		if (it->pyFile == scriptName)
+			break;
+	}
 
-		const auto& effectsSchemas = getEffectSchemas();
-		auto it = effectsSchemas.cbegin();
-		for (; it != effectsSchemas.cend(); ++it)
-		{
-			if (it->pyFile == scriptName)
-				break;
-		}
+	if (it == effectsSchemas.cend())
+		return "Missing schema file for Python script " + message["script"].toString();
 
-		if (it != effectsSchemas.cend())
-		{
-			if (!JsonUtils::validate("EffectFileHandler", message["args"], it->schemaFile, _log).first)
-			{
-				return "Error during arg validation against schema, please consult the Hyperion Log";
-			}
+	if (!JsonUtils::validate("EffectFileHandler", message["args"], it->schemaFile, _log).first)
+		return "Error during arg validation against schema, please consult the Hyperion Log";
 
-			QJsonObject effectJson;
-			QJsonArray effectArray;
-			effectArray = _effectConfig["paths"].toArray();
+	const QJsonArray effectArray = _effectConfig["paths"].toArray();
+	if (effectArray.empty())
+		return "Can't save new effect. Effect path empty";
 
-			if (!effectArray.empty())
-			{
-				QString effectName = message["name"].toString();
-				if (effectName.trimmed().isEmpty() || effectName.trimmed().startsWith(":"))
-				{
-					return "Can't save new effect. Effect name is empty or begins with a dot.";
-				}
+	const QString effectName = message["name"].toString();
+	if (effectName.trimmed().isEmpty() || effectName.trimmed().startsWith(":"))
+		return "Can't save new effect. Effect name is empty or begins with a dot.";
 
-				effectJson["name"] = effectName;
-				effectJson["script"] = message["script"].toString();
-				effectJson["args"] = message["args"].toObject();
+	QJsonObject effectJson;
+	effectJson["name"]   = effectName;
+	effectJson["script"] = scriptName;
+	effectJson["args"]   = message["args"].toObject();
 
-				QList<EffectDefinition> availableEffects = getEffects();
-				auto iter = std::find_if(availableEffects.cbegin(), availableEffects.cend(),
-					[&effectName](const EffectDefinition& effectDefinition) { return effectDefinition.name == effectName; }
-				);
+	const QString resultMsg = resolveEffectFilePath(message, effectName, effectArray, effectJson);
+	if (!resultMsg.isEmpty())
+		return resultMsg;
 
-				QFileInfo newFileName;
-				if (iter != availableEffects.cend())
-				{
-					newFileName.setFile(iter->file);
-					if (newFileName.absoluteFilePath().startsWith(':'))
-					{
-						return "The effect name '" + effectName + "' is assigned to an internal effect. Please rename your effect.";
-					}
-				}
-				else
-				{
-					QString f = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + effectName.replace(QString(" "), QString("")) + QString(".json");
-					newFileName.setFile(f);
-				}
+	Info(_log, "Reload effect list");
+	updateEffects();
+	return "";
+}
 
-				if (!message["imageData"].toString("").isEmpty() && !message["args"].toObject().value("file").toString("").isEmpty())
-				{
-					QJsonObject args = message["args"].toObject();
-					QString imageFilePath = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + args.value("file").toString();
+QString EffectFileHandler::resolveEffectFilePath(const QJsonObject& message, const QString& effectName, const QJsonArray& effectArray, QJsonObject& effectJson)
+{
+	QList<EffectDefinition> availableEffects = getEffects();
+	auto iter = std::find_if(availableEffects.cbegin(), availableEffects.cend(),
+		[&effectName](const EffectDefinition& effectDefinition) { return effectDefinition.name == effectName; }
+	);
 
-					QFileInfo imageFileName(imageFilePath);
-					if (!FileUtils::writeFile(imageFileName.absoluteFilePath(), QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
-					{
-						return "Error while saving image file '" + message["args"].toObject().value("file").toString() + ", please check the Hyperion Log";
-					}
-
-					//Update json with image file location
-					args["file"] = imageFilePath;
-					effectJson["args"] = args;
-				}
-
-				if (message["args"].toObject().value("imageSource").toString("") == "url" || message["args"].toObject().value("imageSource").toString("") == "file")
-				{
-					QJsonObject args = message["args"].toObject();
-					args.remove(args.value("imageSource").toString("") == "url" ? "file" : "url");
-					effectJson["args"] = args;
-				}
-
-				if (!JsonUtils::write(newFileName.absoluteFilePath(), effectJson, _log))
-				{
-					return "Error while saving effect, please check the Hyperion Log";
-				}
-
-				Info(_log, "Reload effect list");
-				updateEffects();
-				resultMsg = "";
-			}
-			else
-			{
-				resultMsg = "Can't save new effect. Effect path empty";
-			}
-		}
-		else
-		{
-			resultMsg = "Missing schema file for Python script " + message["script"].toString();
-		}
+	QFileInfo newFileName;
+	if (iter != availableEffects.cend())
+	{
+		newFileName.setFile(iter->file);
+		if (newFileName.absoluteFilePath().startsWith(':'))
+			return "The effect name '" + effectName + "' is assigned to an internal effect. Please rename your effect.";
 	}
 	else
 	{
-		resultMsg = "Missing or empty Object 'args'";
+		QString f = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + QString(effectName).replace(QString(" "), QString("")) + QString(".json");
+		newFileName.setFile(f);
 	}
 
-	return resultMsg;
+	const QString imgResult = saveEffectImage(message, effectArray, effectJson);
+	if (!imgResult.isEmpty())
+		return imgResult;
+
+	cleanImageSource(message, effectJson);
+
+	if (!JsonUtils::write(newFileName.absoluteFilePath(), effectJson, _log))
+		return "Error while saving effect, please check the Hyperion Log";
+
+	return "";
+}
+
+QString EffectFileHandler::saveEffectImage(const QJsonObject& message, const QJsonArray& effectArray, QJsonObject& effectJson)
+{
+	if (message["imageData"].toString("").isEmpty() || message["args"].toObject().value("file").toString("").isEmpty())
+		return "";
+
+	QJsonObject args = message["args"].toObject();
+	const QString imageFilePath = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + args.value("file").toString();
+	const QFileInfo imageFileName(imageFilePath);
+
+	if (!FileUtils::writeFile(imageFileName.absoluteFilePath(), QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
+		return "Error while saving image file '" + message["args"].toObject().value("file").toString() + ", please check the Hyperion Log";
+
+	args["file"] = imageFilePath;
+	effectJson["args"] = args;
+	return "";
+}
+
+void EffectFileHandler::cleanImageSource(const QJsonObject& message, QJsonObject& effectJson) const
+{
+	const QString imageSource = message["args"].toObject().value("imageSource").toString("");
+	if (imageSource != "url" && imageSource != "file")
+		return;
+
+	QJsonObject args = message["args"].toObject();
+	args.remove(imageSource == "url" ? "file" : "url");
+	effectJson["args"] = args;
 }
 
 void EffectFileHandler::updateEffects()
@@ -266,55 +246,14 @@ void EffectFileHandler::updateEffects()
 		if (!directory.exists())
 		{
 			if (directory.mkpath(path))
-			{
 				Info(_log, "New Effect path \"%s\" created successfully", QSTRING_CSTR(path));
-			}
 			else
-			{
 				Warning(_log, "Failed to create Effect path \"%s\", please check permissions", QSTRING_CSTR(path));
-			}
 		}
 		else
 		{
-			int efxCount = 0;
-			const QStringList filenames = directory.entryList(QStringList() << "*.json", QDir::Files, QDir::Name | QDir::IgnoreCase);
-			for (const QString& filename : filenames)
-			{
-				EffectDefinition def;
-				if (loadEffectDefinition(path, filename, def))
-				{
-					InfoIf(availableEffects.find(def.name) != availableEffects.end(), _log,
-						"effect overload effect '%s' is now taken from '%s'", QSTRING_CSTR(def.name), QSTRING_CSTR(path));
-
-					if (disableList.contains(def.name))
-					{
-						Info(_log, "effect '%s' not loaded, because it is disabled in hyperion config", QSTRING_CSTR(def.name));
-					}
-					else
-					{
-						availableEffects[def.name] = def;
-						efxCount++;
-					}
-				}
-			}
-			Info(_log, "%d effects loaded from directory %s", efxCount, QSTRING_CSTR(path));
-
-			// collect effect schemas
-			efxCount = 0;
-
-			QString schemaPath = path + "schema" + '/';
-			directory.setPath(schemaPath);
-			const QStringList schemaFileNames = directory.entryList(QStringList() << "*.json", QDir::Files, QDir::Name | QDir::IgnoreCase);
-			for (const QString& schemaFileName : schemaFileNames)
-			{
-				EffectSchema pyEffect;
-				if (loadEffectSchema(path, directory.filePath(schemaFileName), pyEffect))
-				{
-					_effectSchemas.push_back(pyEffect);
-					efxCount++;
-				}
-			}
-			InfoIf(efxCount > 0, _log, "%d effect schemas loaded from directory %s", efxCount, QSTRING_CSTR(schemaPath));
+			loadEffectsFromDirectory(path, directory, disableList, availableEffects);
+			loadSchemasFromDirectory(path, directory);
 		}
 	}
 
@@ -326,6 +265,50 @@ void EffectFileHandler::updateEffects()
 	ErrorIf(_availableEffects.empty(), _log, "no effects found, check your effect directories");
 
 	emit effectListChanged();
+}
+
+void EffectFileHandler::loadEffectsFromDirectory(const QString& path, const QDir& directory, const QStringList& disableList, QMap<QString, EffectDefinition>& availableEffects)
+{
+	int efxCount = 0;
+	const QStringList filenames = directory.entryList(QStringList() << "*.json", QDir::Files, QDir::Name | QDir::IgnoreCase);
+	for (const QString& filename : filenames)
+	{
+		EffectDefinition def;
+		if (!loadEffectDefinition(path, filename, def))
+			continue;
+
+		InfoIf(availableEffects.find(def.name) != availableEffects.end(), _log,
+			"effect overload effect '%s' is now taken from '%s'", QSTRING_CSTR(def.name), QSTRING_CSTR(path));
+
+		if (disableList.contains(def.name))
+		{
+			Info(_log, "effect '%s' not loaded, because it is disabled in hyperion config", QSTRING_CSTR(def.name));
+		}
+		else
+		{
+			availableEffects[def.name] = def;
+			efxCount++;
+		}
+	}
+	Info(_log, "%d effects loaded from directory %s", efxCount, QSTRING_CSTR(path));
+}
+
+void EffectFileHandler::loadSchemasFromDirectory(const QString& path, QDir& directory)
+{
+	int efxCount = 0;
+	const QString schemaPath = path + "schema" + '/';
+	directory.setPath(schemaPath);
+	const QStringList schemaFileNames = directory.entryList(QStringList() << "*.json", QDir::Files, QDir::Name | QDir::IgnoreCase);
+	for (const QString& schemaFileName : schemaFileNames)
+	{
+		EffectSchema pyEffect;
+		if (loadEffectSchema(path, directory.filePath(schemaFileName), pyEffect))
+		{
+			_effectSchemas.push_back(pyEffect);
+			efxCount++;
+		}
+	}
+	InfoIf(efxCount > 0, _log, "%d effect schemas loaded from directory %s", efxCount, QSTRING_CSTR(schemaPath));
 }
 
 bool EffectFileHandler::loadEffectDefinition(const QString& path, const QString& effectConfigFile, EffectDefinition& effectDefinition)

--- a/libsrc/effectengine/EffectFileHandler.cpp
+++ b/libsrc/effectengine/EffectFileHandler.cpp
@@ -53,8 +53,6 @@ void EffectFileHandler::handleSettingsUpdate(settings::type type, const QJsonDoc
 		_effectConfig = config.object();
 
 		QJsonArray effectPathArray = _effectConfig["paths"].toArray();
-
-		// TODO: Remove workaround and move effect config to global settings
 		if (effectPathArray.empty())
 		{
 			effectPathArray.append("$ROOT/custom-effects");
@@ -167,7 +165,10 @@ QString EffectFileHandler::resolveEffectFilePath(const QJsonObject& message, con
 	}
 	else
 	{
-		QString f = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + QString(effectName).replace(QString(" "), QString("")) + QString(".json");
+		const QString sanitizedName = QString(effectName).replace(QString(" "), QString(""));
+		if (sanitizedName.contains('/') || sanitizedName.contains('\\') || sanitizedName.contains(".."))
+			return QString("The effect name '%1' contains invalid characters.").arg(effectName);
+		const QString f = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + sanitizedName + QString(".json");
 		newFileName.setFile(f);
 	}
 
@@ -189,8 +190,12 @@ QString EffectFileHandler::saveEffectImage(const QJsonObject& message, const QJs
 		return "";
 
 	QJsonObject args = message["args"].toObject();
-	const QString imageFilePath = effectArray[0].toString().replace("$ROOT", _rootPath) + '/' + args.value("file").toString();
+	const QString effectsDirPath = effectArray[0].toString().replace("$ROOT", _rootPath);
+	const QString effectsDirAbs = QFileInfo(effectsDirPath).absoluteFilePath();
+	const QString imageFilePath = effectsDirPath + '/' + args.value("file").toString();
 	const QFileInfo imageFileName(imageFilePath);
+	if (!imageFileName.absoluteFilePath().startsWith(effectsDirAbs + '/'))
+		return QString("Invalid image file path '%1'.").arg(args.value("file").toString());
 
 	if (!FileUtils::writeFile(imageFileName.absoluteFilePath(), QByteArray::fromBase64(message["imageData"].toString("").toUtf8()), _log))
 		return QString("Error while saving image file '%1', please check the Hyperion Log").arg(message["args"].toObject().value("file").toString());

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -111,16 +111,20 @@ PyObject* EffectModule::json2python(const QJsonValue& jsonData)
 		{
 			QJsonArray arrayData = jsonData.toArray();
 			PyObject* list = PyList_New(arrayData.size());
+			if (!list)
+			{
+				return nullptr; // Allocation failed
+			}
 			int index = 0;
 			for (QJsonArray::iterator i = arrayData.begin(); i != arrayData.end(); ++i, ++index)
 			{
 				PyObject* obj = json2python(*i);
 				if (!obj)
 				{
-					Py_XDECREF(list);
+					Py_DECREF(list);
 					return nullptr; // Error occurred, return null
 				}
-				// PyList_SetItem steals reference to obj and returns 0 on success
+				// PyList_SetItem unconditionally steals the reference to obj, even on failure
 				if (PyList_SetItem(list, index, obj) != 0)
 				{
 					Py_DECREF(list);
@@ -135,6 +139,10 @@ PyObject* EffectModule::json2python(const QJsonValue& jsonData)
 			// Python's dict
 			QJsonObject jsonObject = jsonData.toObject();
 			PyObject* pyDict = PyDict_New();
+			if (!pyDict)
+			{
+				return nullptr; // Allocation failed
+			}
 			for (auto it = jsonObject.begin(); it != jsonObject.end(); ++it)
 			{
 				// Convert key

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -328,29 +328,33 @@ static QByteArray imageToRGB(const QImage& qimage, int width, int height, bool g
 
 struct ImageCropParams
 {
-	int cropLeft  = 0;
-	int cropTop   = 0;
-	int cropRight = 0;
+	int cropLeft   = 0;
+	int cropTop    = 0;
+	int cropRight  = 0;
 	int cropBottom = 0;
-	int grayscale = 0;
 };
 
-static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& buffer, QImageReader& reader, ImageCropParams& crop)
+static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& buffer, QImageReader& reader, ImageCropParams& crop, bool& grayscale)
 {
 	char* source = nullptr;
+
 	if (imageData.isEmpty())
 	{
+		qCDebug(effect) << "setupImageSource: no embedded imageData, parsing source from args";
 		Q_INIT_RESOURCE(EffectEngine);
 
-		if (!PyArg_ParseTuple(args, "s|iiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale))
+		int grayscaleInt = 0;
+		if (!PyArg_ParseTuple(args, "s|iiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &grayscaleInt))
 		{
 			PyErr_SetString(PyExc_TypeError, "String required");
 			return false;
 		}
+		grayscale = (grayscaleInt != 0);
 
 		const auto url = QUrl(source);
-		if (url.isValid())
+		if (url.isValid() && !url.scheme().isEmpty() && url.scheme() != "file")
 		{
+			qCDebug(effect) << "setupImageSource: fetching via network -" << url.toString();
 			QNetworkAccessManager networkManager;
 			QScopedPointer<QNetworkReply> networkReply(networkManager.get(QNetworkRequest(url)));
 
@@ -364,6 +368,11 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 				buffer.open(QBuffer::ReadOnly);
 				reader.setDecideFormatFromContent(true);
 				reader.setDevice(&buffer);
+				qCDebug(effect) << "setupImageSource: network fetch OK, buffer size =" << buffer.size();
+			}
+			else
+			{
+				qCDebug(effect) << "setupImageSource: network error -" << networkReply->errorString();
 			}
 			// QScopedPointer automatically deletes networkReply here
 		}
@@ -374,17 +383,22 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 			if (file.mid(0, 1) == ":")
 				file = ":/effects/" + file.mid(1);
 
+			qCDebug(effect) << "setupImageSource: loading from file -" << file;
 			reader.setDecideFormatFromContent(true);
 			reader.setFileName(file);
 		}
 	}
 	else
 	{
-		if (!PyArg_ParseTuple(args, "|siiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale))
+		qCDebug(effect) << "setupImageSource: embedded imageData present, size =" << imageData.size();
+		int grayscaleInt = 0;
+		if (!PyArg_ParseTuple(args, "|siiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &grayscaleInt))
 		{
 			return false;
 		}
-		buffer.setData(QByteArray::fromBase64(imageData.toUtf8()));
+		grayscale = (grayscaleInt != 0);
+		const QByteArray decoded = QByteArray::fromBase64(imageData.toUtf8());
+		buffer.setData(decoded);
 		buffer.open(QBuffer::ReadOnly);
 		reader.setDecideFormatFromContent(true);
 		reader.setDevice(&buffer);
@@ -397,34 +411,52 @@ PyObject* EffectModule::wrapGetImage(PyObject* /*self*/, PyObject* args)
 	QBuffer buffer;
 	QImageReader reader;
 	ImageCropParams crop;
+	bool grayscale = false;
 
-	if (!setupImageSource(args, getEffect()->_imageData, buffer, reader, crop))
+	if (!setupImageSource(args, getEffect()->_imageData, buffer, reader, crop, grayscale))
 	{
 		return nullptr;
 	}
 
 	if (!reader.canRead())
 	{
+		qCDebug(effect) << "wrapGetImage: reader cannot read -" << reader.errorString();
 		PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
 		return nullptr;
 	}
-	
-	PyObject* result = PyList_New(reader.imageCount());
-	if(!result) return nullptr;
 
-	for (int imageNumber = 0; imageNumber < reader.imageCount(); ++imageNumber)
+	// imageCount() returns 0 for non-animated formats (JPEG, PNG, …); treat as 1 frame
+	const int rawImageCount = reader.imageCount();
+	const int imageCount = qMax(rawImageCount, 1);
+	const bool isAnimated = (rawImageCount > 0);
+	qCDebug(effect) << "wrapGetImage: format =" << reader.format()
+	                         << "| imageCount() =" << rawImageCount
+	                         << "| treating as" << imageCount << "frame(s)"
+	                         << "| animated =" << isAnimated;
+
+	PyObject* result = PyList_New(imageCount);
+	if (!result) return nullptr;
+
+	for (int imageNumber = 0; imageNumber < imageCount; ++imageNumber)
 	{
-		reader.jumpToImage(imageNumber);
-		if (!reader.canRead())
+		if (isAnimated)
 		{
-			Py_DECREF(result);
-			PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
-			return nullptr;
+			reader.jumpToImage(imageNumber);
+			if (!reader.canRead())
+			{
+				qCDebug(effect) << "wrapGetImage: frame" << imageNumber << "not readable -" << reader.errorString();
+				Py_DECREF(result);
+				PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
+				return nullptr;
+			}
 		}
 
 		QImage qimage = reader.read();
 		int width = qimage.width();
 		int height = qimage.height();
+		qCDebug(effect) << "wrapGetImage: frame" << imageNumber << "decoded:" << width << "x" << height
+		                         << "| image isNull =" << qimage.isNull()
+		                         << "| grayscale =" << grayscale;
 
 		if (crop.cropLeft > 0 || crop.cropTop > 0 || crop.cropRight > 0 || crop.cropBottom > 0)
 		{
@@ -441,7 +473,7 @@ PyObject* EffectModule::wrapGetImage(PyObject* /*self*/, PyObject* args)
 			height = qimage.height();
 		}
 
-		QByteArray binaryImage = imageToRGB(qimage, width, height, crop.grayscale);
+		QByteArray binaryImage = imageToRGB(qimage, width, height, grayscale);
 
 		PyObject* pyBytes = PyByteArray_FromStringAndSize(binaryImage.constData(), binaryImage.size());
 		if (!pyBytes)
@@ -1104,6 +1136,8 @@ PyObject* EffectModule::wrapImageMinSize(PyObject* /*self*/, PyObject* args)
 	{
 		if (width < w || height < h)
 		{
+			// End the active paint session before scaling (new QPainter must not start while old one is active)
+			getEffect()->_painter.reset();
 			getEffect()->_image = getEffect()->_image.scaled(qMax(width, w), qMax(height, h), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
 			getEffect()->_imageSize = getEffect()->_image.size();
 			getEffect()->_painter.reset(new QPainter(&(getEffect()->_image)));

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -123,7 +123,6 @@ PyObject* EffectModule::json2python(const QJsonValue& jsonData)
 				// PyList_SetItem steals reference to obj and returns 0 on success
 				if (PyList_SetItem(list, index, obj) != 0)
 				{
-					Py_DECREF(obj);
 					Py_DECREF(list);
 					return nullptr; // Failed to insert item
 				}
@@ -425,7 +424,6 @@ PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
 				// Replace macro with function to allow error check
 				if (PyList_SetItem(result, i, dict) != 0)
 				{
-					Py_DECREF(dict);
 					Py_DECREF(result);
 					return nullptr; // failed to insert
 				}

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <limits>
 
 #include <effectengine/Effect.h>
 #include <effectengine/EffectModule.h>
@@ -277,12 +278,26 @@ PyObject* EffectModule::wrapSetImage(PyObject* /*self*/, PyObject* args)
 	{
 		if (PyByteArray_Check(bytearray))
 		{
+			if (width <= 0 || height <= 0)
+			{
+				PyErr_SetString(PyExc_ValueError, "Image width and height must be positive");
+				return nullptr;
+			}
+
 			Py_ssize_t length = PyByteArray_Size(bytearray);
-			if (length == 3 * width * height)
+			const uint64_t pixelCount = static_cast<uint64_t>(width) * static_cast<uint64_t>(height);
+			if (pixelCount > static_cast<uint64_t>(std::numeric_limits<Py_ssize_t>::max()) / 3U)
+			{
+				PyErr_SetString(PyExc_OverflowError, "Image dimensions are too large");
+				return nullptr;
+			}
+
+			const Py_ssize_t expectedLength = static_cast<Py_ssize_t>(pixelCount * 3U);
+			if (length == expectedLength)
 			{
 				Image<ColorRgb> image(width, height);
 				const char* data = PyByteArray_AS_STRING(bytearray);
-				memcpy(image.memptr(), data, length);
+				memcpy(image.memptr(), data, static_cast<size_t>(length));
 				emit getEffect()->setInputImage(getEffect()->_priority, image, getEffect()->getRemaining(), false);
 				Py_RETURN_NONE;
 			}
@@ -906,7 +921,12 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* /*self*/, PyObject* args)
 					(uint8_t)(data[idx + 4])
 				));
 		}
+
 		painter->setBrush(gradient);
+		QPen oldPen = painter->pen();
+		painter->setPen(Qt::NoPen);
+		painter->drawPie(centerX - radius, centerY - radius, radius * 2, radius * 2, startAngle * 16, spanAngle * 16);
+		painter->setPen(oldPen);
 		Py_RETURN_NONE;
 	}
 
@@ -1185,11 +1205,10 @@ PyObject* EffectModule::wrapImageCOffset(PyObject* /*self*/, PyObject* args)
 {
 	int offsetX = 0;
 	int offsetY = 0;
-	Py_ssize_t argCount = PyTuple_Size(args);
-
-	if (argCount == 2)
+	if (!PyArg_ParseTuple(args, "ii", &offsetX, &offsetY))
 	{
-		PyArg_ParseTuple(args, "ii", &offsetX, &offsetY);
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
 	}
 
 	getEffect()->_painter->translate(QPoint(offsetX, offsetY));

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -39,12 +39,12 @@ static int hyperion_exec(PyObject* hyperionModule) {
 }
 
 // Module deallocation function to clean up per-interpreter state
-static void hyperion_free(PyObject* /* hyperionModule */)
+static void hyperion_free(void* /* hyperionModule */) // NOSONAR - signature mandated by Python C API freefunc typedef
 {
 	// No specific cleanup required in this example
 }
 
-static PyModuleDef_Slot hyperion_slots[] = {
+static PyModuleDef_Slot hyperion_slots[] = { // NOSONAR - C-style array required by PyModuleDef_Slot Python C API
 	{Py_mod_exec, static_cast<void*>(hyperion_exec)},
 #if (PY_VERSION_HEX >= 0x030C0000)
 	{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
@@ -123,15 +123,15 @@ static PyObject* json2pythonObject(const QJsonValue& jsonData)
 		PyObject* pyKey = PyUnicode_FromString(it.key().toUtf8().constData());
 		if (!pyKey)
 		{
-			Py_XDECREF(pyDict);
+			Py_DECREF(pyDict);
 			return nullptr; // Error occurred, return null
 		}
 		// Convert value
 		PyObject* pyValue = EffectModule::json2python(it.value());
 		if (!pyValue)
 		{
-			Py_XDECREF(pyKey);
-			Py_XDECREF(pyDict);
+			Py_DECREF(pyKey);
+			Py_DECREF(pyDict);
 			return nullptr; // Error occurred, return null
 		}
 		// Add to dictionary with error check
@@ -187,7 +187,7 @@ PyObject* EffectModule::json2python(const QJsonValue& jsonData)
 }
 
 // Python method table
-PyMethodDef EffectModule::effectMethods[] = {
+PyMethodDef EffectModule::effectMethods[] = { // NOSONAR - C-style array required by PyMethodDef Python C API
 	{"setColor"              , EffectModule::wrapSetColor              , METH_VARARGS, "Set a new color for the leds."},
 	{"setImage"              , EffectModule::wrapSetImage              , METH_VARARGS, "Set a new image to process and determine new led colors."},
 	{"getImage"              , EffectModule::wrapGetImage              , METH_VARARGS, "get image data from file."},
@@ -352,10 +352,10 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 		if (url.isValid())
 		{
 			QNetworkAccessManager networkManager;
-			QNetworkReply* networkReply = networkManager.get(QNetworkRequest(url));
+			QScopedPointer<QNetworkReply> networkReply(networkManager.get(QNetworkRequest(url)));
 
 			QEventLoop eventLoop;
-			connect(networkReply, &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
+			connect(networkReply.data(), &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
 			eventLoop.exec();
 
 			if (networkReply->error() == QNetworkReply::NoError)
@@ -365,8 +365,7 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 				reader.setDecideFormatFromContent(true);
 				reader.setDevice(&buffer);
 			}
-
-			networkReply->deleteLater();
+			// QScopedPointer automatically deletes networkReply here
 		}
 		else
 		{

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -18,20 +18,20 @@
 #include <QEventLoop>
 
 // Define a struct for per-interpreter state
-typedef struct {
-} hyperion_module_state;
+using hyperion_module_state = struct {
+};
 
 // Macro to access the module state
-#define GET_HYPERION_STATE(module) ((hyperion_module_state*)PyModule_GetState(module))
+#define GET_HYPERION_STATE(hyperionModule) ((hyperion_module_state*)PyModule_GetState(hyperionModule))
 
 // Get the effect from the capsule
 #define getEffect() static_cast<Effect*>((Effect*)PyCapsule_Import("hyperion.__effectObj", 0))
 
 // Module execution function for multi-phase init
-static int hyperion_exec(PyObject* module) {
+static int hyperion_exec(PyObject* hyperionModule) {
 	// Initialize per-interpreter state
-	hyperion_module_state* state = GET_HYPERION_STATE(module);
-	if (state == NULL)
+	hyperion_module_state const* state = GET_HYPERION_STATE(hyperionModule);
+	if (state == nullptr)
 	{
 		return -1;
 	}
@@ -39,17 +39,17 @@ static int hyperion_exec(PyObject* module) {
 }
 
 // Module deallocation function to clean up per-interpreter state
-static void hyperion_free(void* /* module */)
+static void hyperion_free(PyObject* /* hyperionModule */)
 {
 	// No specific cleanup required in this example
 }
 
 static PyModuleDef_Slot hyperion_slots[] = {
-	{Py_mod_exec, reinterpret_cast<void*>(hyperion_exec)},
+	{Py_mod_exec, static_cast<void*>(hyperion_exec)},
 #if (PY_VERSION_HEX >= 0x030C0000)
 	{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-	{0, NULL}
+	{0, nullptr}
 };
 
 // Module definition with multi-phase and per-interpreter state
@@ -59,9 +59,9 @@ static struct PyModuleDef hyperion_module = {
 	"Hyperion module",             // Module docstring
 	sizeof(hyperion_module_state), // Size of per-interpreter state
 	EffectModule::effectMethods,   // Methods array
-	NULL,                          // Slots array (will be added in PyInit_hyperion)
-	NULL,                          // Traverse function (optional)
-	NULL,                          // Clear function (optional)
+	nullptr,                       // Slots array (will be added in PyInit_hyperion)
+	nullptr,                       // Traverse function (optional)
+	nullptr,                       // Clear function (optional)
 	hyperion_free                  // Free function
 };
 
@@ -79,6 +79,73 @@ PyMODINIT_FUNC PyInit_hyperion(void)
 void EffectModule::registerHyperionExtensionModule()
 {
 	PyImport_AppendInittab("hyperion", &PyInit_hyperion);
+}
+
+static PyObject* json2pythonArray(const QJsonValue& jsonData)
+{
+	QJsonArray arrayData = jsonData.toArray();
+	PyObject* list = PyList_New(arrayData.size());
+	if (!list)
+	{
+		return nullptr; // Allocation failed
+	}
+	int index = 0;
+	for (QJsonArray::iterator i = arrayData.begin(); i != arrayData.end(); ++i, ++index)
+	{
+		PyObject* obj = EffectModule::json2python(*i);
+		if (!obj)
+		{
+			Py_DECREF(list);
+			return nullptr; // Error occurred, return null
+		}
+		// PyList_SetItem unconditionally steals the reference to obj, even on failure
+		if (PyList_SetItem(list, index, obj) != 0)
+		{
+			Py_DECREF(list);
+			return nullptr; // Failed to insert item
+		}
+	}
+	return list;
+}
+
+static PyObject* json2pythonObject(const QJsonValue& jsonData)
+{
+	// Python's dict
+	QJsonObject jsonObject = jsonData.toObject();
+	PyObject* pyDict = PyDict_New();
+	if (!pyDict)
+	{
+		return nullptr; // Allocation failed
+	}
+	for (auto it = jsonObject.begin(); it != jsonObject.end(); ++it)
+	{
+		// Convert key
+		PyObject* pyKey = PyUnicode_FromString(it.key().toUtf8().constData());
+		if (!pyKey)
+		{
+			Py_XDECREF(pyDict);
+			return nullptr; // Error occurred, return null
+		}
+		// Convert value
+		PyObject* pyValue = EffectModule::json2python(it.value());
+		if (!pyValue)
+		{
+			Py_XDECREF(pyKey);
+			Py_XDECREF(pyDict);
+			return nullptr; // Error occurred, return null
+		}
+		// Add to dictionary with error check
+		if (PyDict_SetItem(pyDict, pyKey, pyValue) < 0)
+		{
+			Py_DECREF(pyKey);
+			Py_DECREF(pyValue);
+			Py_DECREF(pyDict);
+			return nullptr; // insertion failed
+		}
+		Py_DECREF(pyKey);
+		Py_DECREF(pyValue);
+	}
+	return pyDict;
 }
 
 PyObject* EffectModule::json2python(const QJsonValue& jsonData)
@@ -108,71 +175,10 @@ PyObject* EffectModule::json2python(const QJsonValue& jsonData)
 			return PyUnicode_FromString(jsonData.toString().toUtf8().constData());
 
 		case QJsonValue::Array:
-		{
-			QJsonArray arrayData = jsonData.toArray();
-			PyObject* list = PyList_New(arrayData.size());
-			if (!list)
-			{
-				return nullptr; // Allocation failed
-			}
-			int index = 0;
-			for (QJsonArray::iterator i = arrayData.begin(); i != arrayData.end(); ++i, ++index)
-			{
-				PyObject* obj = json2python(*i);
-				if (!obj)
-				{
-					Py_DECREF(list);
-					return nullptr; // Error occurred, return null
-				}
-				// PyList_SetItem unconditionally steals the reference to obj, even on failure
-				if (PyList_SetItem(list, index, obj) != 0)
-				{
-					Py_DECREF(list);
-					return nullptr; // Failed to insert item
-				}
-			}
-			return list;
-		}
+			return json2pythonArray(jsonData);
 
 		case QJsonValue::Object:
-		{
-			// Python's dict
-			QJsonObject jsonObject = jsonData.toObject();
-			PyObject* pyDict = PyDict_New();
-			if (!pyDict)
-			{
-				return nullptr; // Allocation failed
-			}
-			for (auto it = jsonObject.begin(); it != jsonObject.end(); ++it)
-			{
-				// Convert key
-				PyObject* pyKey = PyUnicode_FromString(it.key().toUtf8().constData());
-				if (!pyKey)
-				{
-					Py_XDECREF(pyDict);
-					return nullptr; // Error occurred, return null
-				}
-				// Convert value
-				PyObject* pyValue = json2python(it.value());
-				if (!pyValue)
-				{
-					Py_XDECREF(pyKey);
-					Py_XDECREF(pyDict);
-					return nullptr;  // Error occurred, return null
-				}
-				// Add to dictionary with error check
-				if (PyDict_SetItem(pyDict, pyKey, pyValue) < 0)
-				{
-					Py_DECREF(pyKey);
-					Py_DECREF(pyValue);
-					Py_DECREF(pyDict);
-					return nullptr; // insertion failed
-				}
-				Py_DECREF(pyKey);
-				Py_DECREF(pyValue);
-				}
-			return pyDict;
-		}
+			return json2pythonObject(jsonData);
 
 	default:
 		PyErr_SetString(PyExc_TypeError, "Unsupported QJsonValue type.");
@@ -208,13 +214,13 @@ PyMethodDef EffectModule::effectMethods[] = {
 	{"imageResetT"           , EffectModule::wrapImageResetT           , METH_NOARGS,  "Resets all coords modifications (rotate,offset,shear)"},
 	{"lowestUpdateInterval"  , EffectModule::wrapLowestUpdateInterval  , METH_NOARGS,  "Gets the lowest permissible interval time in seconds"},
 	{"imageStackClear"       , EffectModule::wrapImageStackClear       , METH_NOARGS,  "Clears the internal saved image stack"},
-	{NULL, NULL, 0, NULL}
+	{nullptr, nullptr, 0, nullptr}
 };
 
 PyObject* EffectModule::wrapSetColor(PyObject* self, PyObject* args)
 {
 	// check the number of arguments
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	if (argCount == 3)
 	{
 		// three separate arguments for red, green, and blue
@@ -232,35 +238,26 @@ PyObject* EffectModule::wrapSetColor(PyObject* self, PyObject* args)
 	{
 		// bytearray of values
 		PyObject* bytearray = nullptr;
-		if (PyArg_ParseTuple(args, "O", &bytearray))
-		{
-			if (PyByteArray_Check(bytearray))
-			{
-				size_t length = PyByteArray_Size(bytearray);
-				if (length == 3 * static_cast<size_t>(getEffect()->_hyperionWeak.toStrongRef()->getLedCount()))
-				{
-					char* data = PyByteArray_AS_STRING(bytearray);
-					memcpy(getEffect()->_colors.data(), data, length);
-					QVector<ColorRgb> _cQV = getEffect()->_colors;
-					emit getEffect()->setInput(getEffect()->_priority, QVector<ColorRgb>(_cQV.begin(), _cQV.end()), getEffect()->getRemaining(), false);
-					Py_RETURN_NONE;
-				}
-				else
-				{
-					PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should be 3*ledCount");
-					return nullptr;
-				}
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Argument is not a bytearray");
-				return nullptr;
-			}
-		}
-		else
+		if (!PyArg_ParseTuple(args, "O", &bytearray))
 		{
 			return nullptr;
 		}
+		if (!PyByteArray_Check(bytearray))
+		{
+			PyErr_SetString(PyExc_RuntimeError, "Argument is not a bytearray");
+			return nullptr;
+		}
+		size_t length = PyByteArray_Size(bytearray);
+		if (length != 3 * static_cast<size_t>(getEffect()->_hyperionWeak.toStrongRef()->getLedCount()))
+		{
+			PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should be 3*ledCount");
+			return nullptr;
+		}
+		char* data = PyByteArray_AS_STRING(bytearray);
+		memcpy(getEffect()->_colors.data(), data, length);
+		QVector<ColorRgb> _cQV = getEffect()->_colors;
+		emit getEffect()->setInput(getEffect()->_priority, QVector<ColorRgb>(_cQV.begin(), _cQV.end()), getEffect()->getRemaining(), false);
+		Py_RETURN_NONE;
 	}
 	else
 	{
@@ -279,7 +276,7 @@ PyObject* EffectModule::wrapSetImage(PyObject* self, PyObject* args)
 	{
 		if (PyByteArray_Check(bytearray))
 		{
-			int length = PyByteArray_Size(bytearray);
+			Py_ssize_t length = PyByteArray_Size(bytearray);
 			if (length == 3 * width * height)
 			{
 				Image<ColorRgb> image(width, height);
@@ -310,29 +307,52 @@ PyObject* EffectModule::wrapSetImage(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
+static QByteArray imageToRGB(const QImage& qimage, int width, int height, bool grayscale)
 {
-	QBuffer buffer;
-	QImageReader reader;
-	char* source;
-	int cropLeft = 0, cropTop = 0, cropRight = 0, cropBottom = 0;
-	int grayscale = false;
+	qsizetype size = qsizetype(width) * qsizetype(height) * 3;
+	QByteArray binaryImage(size, Qt::Uninitialized);
+	char* dest = binaryImage.data();
+	for (int i = 0; i < height; ++i)
+	{
+		const QRgb* scanline = reinterpret_cast<const QRgb*>(qimage.scanLine(i));
+		for (int j = 0; j < width; ++j)
+		{
+			QRgb pixel = scanline[j];
+			*dest++ = static_cast<char>(!grayscale ? qRed(pixel) : qGray(pixel));
+			*dest++ = static_cast<char>(!grayscale ? qGreen(pixel) : qGray(pixel));
+			*dest++ = static_cast<char>(!grayscale ? qBlue(pixel) : qGray(pixel));
+		}
+	}
+	return binaryImage;
+}
 
-	if (getEffect()->_imageData.isEmpty())
+struct ImageCropParams
+{
+	int cropLeft  = 0;
+	int cropTop   = 0;
+	int cropRight = 0;
+	int cropBottom = 0;
+	int grayscale = 0;
+};
+
+static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& buffer, QImageReader& reader, ImageCropParams& crop)
+{
+	char* source = nullptr;
+	if (imageData.isEmpty())
 	{
 		Q_INIT_RESOURCE(EffectEngine);
 
-		if (!PyArg_ParseTuple(args, "s|iiiip", &source, &cropLeft, &cropTop, &cropRight, &cropBottom, &grayscale))
+		if (!PyArg_ParseTuple(args, "s|iiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale))
 		{
 			PyErr_SetString(PyExc_TypeError, "String required");
-			return nullptr;
+			return false;
 		}
 
 		const QUrl url = QUrl(source);
 		if (url.isValid())
 		{
-			QNetworkAccessManager* networkManager = new QNetworkAccessManager();
-			QNetworkReply* networkReply = networkManager->get(QNetworkRequest(url));
+			QNetworkAccessManager networkManager;
+			QNetworkReply* networkReply = networkManager.get(QNetworkRequest(url));
 
 			QEventLoop eventLoop;
 			connect(networkReply, &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
@@ -346,8 +366,7 @@ PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
 				reader.setDevice(&buffer);
 			}
 
-			delete networkReply;
-			delete networkManager;
+			networkReply->deleteLater();
 		}
 		else
 		{
@@ -362,95 +381,91 @@ PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
 	}
 	else
 	{
-		PyArg_ParseTuple(args, "|siiiip", &source, &cropLeft, &cropTop, &cropRight, &cropBottom, &grayscale);
-		buffer.setData(QByteArray::fromBase64(getEffect()->_imageData.toUtf8()));
+		PyArg_ParseTuple(args, "|siiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale);
+		buffer.setData(QByteArray::fromBase64(imageData.toUtf8()));
 		buffer.open(QBuffer::ReadOnly);
 		reader.setDecideFormatFromContent(true);
 		reader.setDevice(&buffer);
 	}
+	return true;
+}
 
-	if (reader.canRead())
+PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
+{
+	QBuffer buffer;
+	QImageReader reader;
+	ImageCropParams crop;
+
+	if (!setupImageSource(args, getEffect()->_imageData, buffer, reader, crop))
 	{
-		PyObject* result = PyList_New(reader.imageCount());
-		if(!result) return nullptr;
-
-		for (int i = 0; i < reader.imageCount(); ++i)
-		{
-			reader.jumpToImage(i);
-			if (reader.canRead())
-			{
-				QImage qimage = reader.read();
-				int width = qimage.width();
-				int height = qimage.height();
-
-				if (cropLeft > 0 || cropTop > 0 || cropRight > 0 || cropBottom > 0)
-				{
-					if (cropLeft + cropRight >= width || cropTop + cropBottom >= height)
-					{
-						Py_DECREF(result);
-						QString errorStr = QString("Rejecting invalid crop values: left: %1, right: %2, top: %3, bottom: %4, higher than height/width %5/%6").arg(cropLeft).arg(cropRight).arg(cropTop).arg(cropBottom).arg(height).arg(width);
-						PyErr_SetString(PyExc_RuntimeError, qPrintable(errorStr));
-						return nullptr;
-					}
-
-					qimage = qimage.copy(cropLeft, cropTop, width - cropLeft - cropRight, height - cropTop - cropBottom);
-					width = qimage.width();
-					height = qimage.height();
-				}
-
-				qsizetype size = qsizetype(width) * qsizetype(height) * 3;
-				QByteArray binaryImage(size, Qt::Uninitialized);
-				char* dest = binaryImage.data();
-				for (int i = 0; i < height; ++i)
-				{
-					const QRgb* scanline = reinterpret_cast<const QRgb*>(qimage.scanLine(i));
-					for (int j = 0; j < width; ++j)
-					{
-						QRgb pixel = scanline[j];
-						*dest++ = static_cast<char>(!grayscale ? qRed(pixel) : qGray(pixel));
-						*dest++ = static_cast<char>(!grayscale ? qGreen(pixel) : qGray(pixel));
-						*dest++ = static_cast<char>(!grayscale ? qBlue(pixel) : qGray(pixel));
-					}
-				}
-
-				PyObject* pyBytes = PyByteArray_FromStringAndSize(binaryImage.constData(), binaryImage.size());
-				if (!pyBytes)
-				{
-					Py_DECREF(result);
-					return nullptr;
-				}
-
-				// Use format unit 'N' to pass ownership of pyBytes to the dict without needing DECREF here
-				PyObject* dict = Py_BuildValue("{s:i,s:i,s:N}", "imageWidth", width, "imageHeight", height, "imageData", pyBytes);
-
-				if (!dict)
-				{
-					Py_DECREF(result);
-					return nullptr;
-				}
-
-				// Replace macro with function to allow error check
-				if (PyList_SetItem(result, i, dict) != 0)
-				{
-					Py_DECREF(result);
-					return nullptr; // failed to insert
-				}
-			}
-			else
-			{
-				Py_DECREF(result);
-				PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
-				return nullptr;
-			}
-		}
-
-		return result;
+		return nullptr;
 	}
-	else
+
+	if (!reader.canRead())
 	{
 		PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
 		return nullptr;
 	}
+	
+	PyObject* result = PyList_New(reader.imageCount());
+	if(!result) return nullptr;
+
+	for (int imageNumber = 0; imageNumber < reader.imageCount(); ++imageNumber)
+	{
+		reader.jumpToImage(imageNumber);
+		if (!reader.canRead())
+		{
+			Py_DECREF(result);
+			PyErr_SetString(PyExc_TypeError, reader.errorString().toUtf8().constData());
+			return nullptr;
+		}
+
+		QImage qimage = reader.read();
+		int width = qimage.width();
+		int height = qimage.height();
+
+		if (crop.cropLeft > 0 || crop.cropTop > 0 || crop.cropRight > 0 || crop.cropBottom > 0)
+		{
+			if (crop.cropLeft + crop.cropRight >= width || crop.cropTop + crop.cropBottom >= height)
+			{
+				Py_DECREF(result);
+				QString errorStr = QString("Rejecting invalid crop values: left: %1, right: %2, top: %3, bottom: %4, higher than height/width %5/%6").arg(crop.cropLeft).arg(crop.cropRight).arg(crop.cropTop).arg(crop.cropBottom).arg(height).arg(width);
+				PyErr_SetString(PyExc_RuntimeError, qPrintable(errorStr));
+				return nullptr;
+			}
+
+			qimage = qimage.copy(crop.cropLeft, crop.cropTop, width - crop.cropLeft - crop.cropRight, height - crop.cropTop - crop.cropBottom);
+			width = qimage.width();
+			height = qimage.height();
+		}
+
+		QByteArray binaryImage = imageToRGB(qimage, width, height, crop.grayscale);
+
+		PyObject* pyBytes = PyByteArray_FromStringAndSize(binaryImage.constData(), binaryImage.size());
+		if (!pyBytes)
+		{
+			Py_DECREF(result);
+			return nullptr;
+		}
+
+		// Use format unit 'N' to pass ownership of pyBytes to the dict without needing DECREF here
+		PyObject* dict = Py_BuildValue("{s:i,s:i,s:N}", "imageWidth", width, "imageHeight", height, "imageData", pyBytes);
+
+		if (!dict)
+		{
+			Py_DECREF(result);
+			return nullptr;
+		}
+
+		// Replace macro with function to allow error check
+		if (PyList_SetItem(result, imageNumber, dict) != 0)
+		{
+			Py_DECREF(result);
+			return nullptr; // failed to insert
+		}
+	}
+
+	return result;
 }
 
 PyObject* EffectModule::wrapAbort(PyObject* self, PyObject*)
@@ -461,7 +476,7 @@ PyObject* EffectModule::wrapAbort(PyObject* self, PyObject*)
 
 PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int imgId = -1;
 	bool argsOk = (argCount == 0);
 	if (argCount == 1 && PyArg_ParseTuple(args, "i", &imgId))
@@ -469,9 +484,15 @@ PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 		argsOk = true;
 	}
 
-	if (!argsOk || (imgId > -1 && imgId >= getEffect()->_imageStack.size()))
+	if (!argsOk)
 	{
 		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
+	}
+
+	if (imgId > -1 && imgId >= getEffect()->_imageStack.size())
+	{
+		PyErr_SetString(PyExc_IndexError, "Image id out of range.");
 		return nullptr;
 	}
 
@@ -502,7 +523,7 @@ PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
 	int startRX = 0;
 	int startRY = 0;
@@ -525,55 +546,51 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
 		argsOK = true;
 	}
 
-	if (argsOK)
+	if (!argsOK)
 	{
-		if (PyByteArray_Check(bytearray))
-		{
-			const int length = PyByteArray_Size(bytearray);
-			const unsigned arrayItemLength = 5;
-			if (length % arrayItemLength == 0)
-			{
-				QRect myQRect(startRX, startRY, width, height);
-				QLinearGradient gradient(QPoint(startX, startY), QPoint(endX, endY));
-				char* data = PyByteArray_AS_STRING(bytearray);
-
-				for (int idx = 0; idx < length; idx += arrayItemLength)
-				{
-					gradient.setColorAt(
-						((uint8_t)data[idx]) / 255.0,
-						QColor(
-							(uint8_t)(data[idx + 1]),
-							(uint8_t)(data[idx + 2]),
-							(uint8_t)(data[idx + 3]),
-							(uint8_t)(data[idx + 4])
-						));
-				}
-
-				gradient.setSpread(static_cast<QGradient::Spread>(spread));
-				getEffect()->_painter->fillRect(myQRect, gradient);
-
-				Py_RETURN_NONE;
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
-				return nullptr;
-			}
-		}
-		else
-		{
-			PyErr_SetString(PyExc_RuntimeError, "No bytearray properly defined");
-			return nullptr;
-		}
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
 	}
 
-	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
-	return nullptr;
+	if (!PyByteArray_Check(bytearray))
+	{
+		PyErr_SetString(PyExc_RuntimeError, "No bytearray properly defined");
+		return nullptr;
+	}
+
+	const Py_ssize_t length = PyByteArray_Size(bytearray);
+	const unsigned arrayItemLength = 5;
+	if (length % arrayItemLength != 0)
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
+		return nullptr;
+	}
+
+	QRect myQRect(startRX, startRY, width, height);
+	QLinearGradient gradient(QPoint(startX, startY), QPoint(endX, endY));
+	char* data = PyByteArray_AS_STRING(bytearray);
+
+	for (int idx = 0; idx < length; idx += arrayItemLength)
+	{
+		gradient.setColorAt(
+			((uint8_t)data[idx]) / 255.0,
+			QColor(
+				(uint8_t)(data[idx + 1]),
+				(uint8_t)(data[idx + 2]),
+				(uint8_t)(data[idx + 3]),
+				(uint8_t)(data[idx + 4])
+			));
+	}
+
+	gradient.setSpread(static_cast<QGradient::Spread>(spread));
+	getEffect()->_painter->fillRect(myQRect, gradient);
+
+	Py_RETURN_NONE;
 }
 
 PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
 	int centerX = 0;
 	int centerY = 0;
@@ -595,55 +612,51 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
 	}
 	angle = qMax(qMin(angle, 360), 0);
 
-	if (argsOK)
+	if (!argsOK)
 	{
-		if (PyByteArray_Check(bytearray))
-		{
-			const int length = PyByteArray_Size(bytearray);
-			const unsigned arrayItemLength = 5;
-			if (length % arrayItemLength == 0)
-			{
-				QRect myQRect(startX, startY, width, height);
-				QConicalGradient gradient(QPoint(centerX, centerY), angle);
-				char* data = PyByteArray_AS_STRING(bytearray);
-
-				for (int idx = 0; idx < length; idx += arrayItemLength)
-				{
-					gradient.setColorAt(
-						((uint8_t)data[idx]) / 255.0,
-						QColor(
-							(uint8_t)(data[idx + 1]),
-							(uint8_t)(data[idx + 2]),
-							(uint8_t)(data[idx + 3]),
-							(uint8_t)(data[idx + 4])
-						));
-				}
-
-				getEffect()->_painter->fillRect(myQRect, gradient);
-
-				Py_RETURN_NONE;
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
-				return nullptr;
-			}
-		}
-		else
-		{
-			PyErr_SetString(PyExc_RuntimeError, "Argument 8 is not a bytearray");
-			return nullptr;
-		}
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
 	}
 
-	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
-	return nullptr;
+	if (!PyByteArray_Check(bytearray))
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Argument 8 is not a bytearray");
+		return nullptr;
+	}
+
+	const Py_ssize_t length = PyByteArray_Size(bytearray);
+	const unsigned arrayItemLength = 5;
+	if (length % arrayItemLength != 0)
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
+		return nullptr;
+	}
+
+	QRect myQRect(startX, startY, width, height);
+	QConicalGradient gradient(QPoint(centerX, centerY), angle);
+	char* data = PyByteArray_AS_STRING(bytearray);
+
+	for (int idx = 0; idx < length; idx += arrayItemLength)
+	{
+		gradient.setColorAt(
+			((uint8_t)data[idx]) / 255.0,
+			QColor(
+				(uint8_t)(data[idx + 1]),
+				(uint8_t)(data[idx + 2]),
+				(uint8_t)(data[idx + 3]),
+				(uint8_t)(data[idx + 4])
+			));
+	}
+
+	getEffect()->_painter->fillRect(myQRect, gradient);
+
+	Py_RETURN_NONE;
 }
 
 
 PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
 	int centerX = 0;
 	int centerY = 0;
@@ -682,56 +695,51 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
 		focalRadius = radius;
 	}
 
-	if (argsOK)
+	if (!argsOK)
 	{
-		if (PyByteArray_Check(bytearray))
-		{
-			int length = PyByteArray_Size(bytearray);
-			if (length % 4 == 0)
-			{
-
-				QRect myQRect(startX, startY, width, height);
-				QRadialGradient gradient(QPoint(centerX, centerY), qMax(radius, 0));
-				char* data = PyByteArray_AS_STRING(bytearray);
-
-				for (int idx = 0; idx < length; idx += 4)
-				{
-					gradient.setColorAt(
-						((uint8_t)data[idx]) / 255.0,
-						QColor(
-							(uint8_t)(data[idx + 1]),
-							(uint8_t)(data[idx + 2]),
-							(uint8_t)(data[idx + 3])
-						));
-				}
-
-				gradient.setSpread(static_cast<QGradient::Spread>(spread));
-				getEffect()->_painter->fillRect(myQRect, gradient);
-
-				Py_RETURN_NONE;
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 4");
-				return nullptr;
-			}
-		}
-		else
-		{
-			PyErr_SetString(PyExc_RuntimeError, "Last argument is not a bytearray");
-			return nullptr;
-		}
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
 	}
 
-	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
-	return nullptr;
+	if (!PyByteArray_Check(bytearray))
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Last argument is not a bytearray");
+		return nullptr;
+	}
+
+	Py_ssize_t length = PyByteArray_Size(bytearray);
+	if (length % 4 != 0)
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 4");
+		return nullptr;
+	}
+
+	QRect myQRect(startX, startY, width, height);
+	QRadialGradient gradient(QPoint(centerX, centerY), qMax(radius, 0));
+	char* data = PyByteArray_AS_STRING(bytearray);
+
+	for (int idx = 0; idx < length; idx += 4)
+	{
+		gradient.setColorAt(
+			((uint8_t)data[idx]) / 255.0,
+			QColor(
+				(uint8_t)(data[idx + 1]),
+				(uint8_t)(data[idx + 2]),
+				(uint8_t)(data[idx + 3])
+			));
+	}
+
+	gradient.setSpread(static_cast<QGradient::Spread>(spread));
+	getEffect()->_painter->fillRect(myQRect, gradient);
+
+	Py_RETURN_NONE;
 }
 
 PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
 {
 	PyObject* bytearray = nullptr;
 
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -748,45 +756,41 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
 		argsOK = true;
 	}
 
-	if (argsOK)
+	if (!argsOK)
 	{
-		if (PyByteArray_Check(bytearray))
-		{
-			int length = PyByteArray_Size(bytearray);
-			if (length % 2 == 0)
-			{
-				QVector <QPoint> points;
-				char* data = PyByteArray_AS_STRING(bytearray);
-
-				for (int idx = 0; idx < length; idx += 2)
-				{
-					points.append(QPoint((int)(data[idx]), (int)(data[idx + 1])));
-				}
-
-				QPainter* painter = getEffect()->_painter;
-				QPen oldPen = painter->pen();
-				QPen newPen(QColor(r, g, b, a));
-				painter->setPen(newPen);
-				painter->setBrush(QBrush(QColor(r, g, b, a), Qt::SolidPattern));
-				painter->drawPolygon(points);
-				painter->setPen(oldPen);
-				Py_RETURN_NONE;
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 2");
-				return nullptr;
-			}
-		}
-		else
-		{
-			PyErr_SetString(PyExc_RuntimeError, "Argument 1 is not a bytearray");
-			return nullptr;
-		}
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
 	}
 
-	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
-	return nullptr;
+	if (!PyByteArray_Check(bytearray))
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Argument 1 is not a bytearray");
+		return nullptr;
+	}
+
+	Py_ssize_t length = PyByteArray_Size(bytearray);
+	if (length % 2 != 0)
+	{
+		PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 2");
+		return nullptr;
+	}
+
+	QVector<QPoint> points;
+	char* data = PyByteArray_AS_STRING(bytearray);
+
+	for (int idx = 0; idx < length; idx += 2)
+	{
+		points.append(QPoint((int)(data[idx]), (int)(data[idx + 1])));
+	}
+
+	QPainter* painter = getEffect()->_painter.get();
+	QPen oldPen = painter->pen();
+	QPen newPen(QColor(r, g, b, a));
+	painter->setPen(newPen);
+	painter->setBrush(QBrush(QColor(r, g, b, a), Qt::SolidPattern));
+	painter->drawPolygon(points);
+	painter->setPen(oldPen);
+	Py_RETURN_NONE;
 }
 
 PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
@@ -824,72 +828,60 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
 		argsOK = true;
 	}
 
-	if (argsOK)
+	if (!argsOK)
 	{
-		QPainter* painter = getEffect()->_painter;
-		startAngle = qMax(qMin(startAngle, 360), 0);
-		spanAngle = qMax(qMin(spanAngle, 360), -360);
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
+		return nullptr;
+	}
 
-		if (argCount == 7 || argCount == 5)
+	QPainter* painter = getEffect()->_painter.get();
+	startAngle = qMax(qMin(startAngle, 360), 0);
+	spanAngle = qMax(qMin(spanAngle, 360), -360);
+
+	if (argCount == 7 || argCount == 5)
+	{
+		if (!PyByteArray_Check(bytearray))
 		{
-			a = 0;
-			if (PyByteArray_Check(bytearray))
-			{
-				int length = PyByteArray_Size(bytearray);
-				if (length % 5 == 0)
-				{
-
-					QConicalGradient gradient(QPoint(centerX, centerY), startAngle);
-
-
-					char* data = PyByteArray_AS_STRING(bytearray);
-
-					for (int idx = 0; idx < length; idx += 5)
-					{
-						gradient.setColorAt(
-							((uint8_t)data[idx]) / 255.0,
-							QColor(
-								(uint8_t)(data[idx + 1]),
-								(uint8_t)(data[idx + 2]),
-								(uint8_t)(data[idx + 3]),
-								(uint8_t)(data[idx + 4])
-							));
-					}
-					painter->setBrush(gradient);
-
-					Py_RETURN_NONE;
-				}
-				else
-				{
-					PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
-					return nullptr;
-				}
-			}
-			else
-			{
-				PyErr_SetString(PyExc_RuntimeError, "Last argument is not a bytearray");
-				return nullptr;
-			}
+			PyErr_SetString(PyExc_RuntimeError, "Last argument is not a bytearray");
+			return nullptr;
 		}
-		else
+		Py_ssize_t length = PyByteArray_Size(bytearray);
+		if (length % 5 != 0)
 		{
-			painter->setBrush(QBrush(QColor(r, g, b, a), Qt::SolidPattern));
+			PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should multiple of 5");
+			return nullptr;
 		}
-		QPen oldPen = painter->pen();
-		QPen newPen(QColor(r, g, b, a));
-		painter->setPen(newPen);
-		painter->drawPie(centerX - radius, centerY - radius, centerX + radius, centerY + radius, startAngle * 16, spanAngle * 16);
-		painter->setPen(oldPen);
+
+		QConicalGradient gradient(QPoint(centerX, centerY), startAngle);
+		char* data = PyByteArray_AS_STRING(bytearray);
+
+		for (int idx = 0; idx < length; idx += 5)
+		{
+			gradient.setColorAt(
+				((uint8_t)data[idx]) / 255.0,
+				QColor(
+					(uint8_t)(data[idx + 1]),
+					(uint8_t)(data[idx + 2]),
+					(uint8_t)(data[idx + 3]),
+					(uint8_t)(data[idx + 4])
+				));
+		}
+		painter->setBrush(gradient);
 		Py_RETURN_NONE;
 	}
 
-	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
-	return nullptr;
+	painter->setBrush(QBrush(QColor(r, g, b, a), Qt::SolidPattern));
+	QPen oldPen = painter->pen();
+	QPen newPen(QColor(r, g, b, a));
+	painter->setPen(newPen);
+	painter->drawPie(centerX - radius, centerY - radius, centerX + radius, centerY + radius, startAngle * 16, spanAngle * 16);
+	painter->setPen(oldPen);
+	Py_RETURN_NONE;
 }
 
 PyObject* EffectModule::wrapImageSolidFill(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -932,7 +924,7 @@ PyObject* EffectModule::wrapImageSolidFill(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -956,7 +948,7 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
 
 	if (argsOK)
 	{
-		QPainter* painter = getEffect()->_painter;
+		QPainter* painter = getEffect()->_painter.get();
 		QRect myQRect(startX, startY, endX, endY);
 		QPen oldPen = painter->pen();
 		QPen newPen(QColor(r, g, b, a));
@@ -974,7 +966,7 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -996,7 +988,7 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
 
 	if (argsOK)
 	{
-		QPainter* painter = getEffect()->_painter;
+		QPainter* painter = getEffect()->_painter.get();
 		QPen oldPen = painter->pen();
 		QPen newPen(QColor(r, g, b, a));
 		newPen.setWidth(thick);
@@ -1013,7 +1005,7 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -1037,7 +1029,7 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
 
 	if (argsOK)
 	{
-		QPainter* painter = getEffect()->_painter;
+		QPainter* painter = getEffect()->_painter.get();
 		QRect myQRect(startX, startY, width, height);
 		QPen oldPen = painter->pen();
 		QPen newPen(QColor(r, g, b, a));
@@ -1056,7 +1048,7 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageSetPixel(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
 	int g = 0;
 	int b = 0;
@@ -1076,7 +1068,7 @@ PyObject* EffectModule::wrapImageSetPixel(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageGetPixel(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int x = 0;
 	int y = 0;
 
@@ -1100,7 +1092,7 @@ PyObject* EffectModule::wrapImageSave(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageMinSize(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int w = 0;
 	int h = 0;
 	int width = getEffect()->_imageSize.width();
@@ -1110,11 +1102,9 @@ PyObject* EffectModule::wrapImageMinSize(PyObject* self, PyObject* args)
 	{
 		if (width < w || height < h)
 		{
-			delete getEffect()->_painter;
-
 			getEffect()->_image = getEffect()->_image.scaled(qMax(width, w), qMax(height, h), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
 			getEffect()->_imageSize = getEffect()->_image.size();
-			getEffect()->_painter = new QPainter(&(getEffect()->_image));
+			getEffect()->_painter.reset(new QPainter(&(getEffect()->_image)));
 		}
 		return Py_BuildValue("ii", getEffect()->_image.width(), getEffect()->_image.height());
 	}
@@ -1135,7 +1125,7 @@ PyObject* EffectModule::wrapImageHeight(PyObject* self, PyObject* args)
 
 PyObject* EffectModule::wrapImageCRotate(PyObject* self, PyObject* args)
 {
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int angle;
 
 	if (argCount == 1 && PyArg_ParseTuple(args, "i", &angle))
@@ -1153,7 +1143,7 @@ PyObject* EffectModule::wrapImageCOffset(PyObject* self, PyObject* args)
 {
 	int offsetX = 0;
 	int offsetY = 0;
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 
 	if (argCount == 2)
 	{
@@ -1168,7 +1158,7 @@ PyObject* EffectModule::wrapImageCShear(PyObject* self, PyObject* args)
 {
 	int sh = 0;
 	int sv = 0;
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 
 	if (argCount == 2 && PyArg_ParseTuple(args, "ii", &sh, &sv))
 	{

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -45,7 +45,7 @@ static void hyperion_free(void* /* hyperionModule */) // NOSONAR - signature man
 }
 
 static PyModuleDef_Slot hyperion_slots[] = { // NOSONAR - C-style array required by PyModuleDef_Slot Python C API
-	{Py_mod_exec, static_cast<void*>(hyperion_exec)},
+	{Py_mod_exec, reinterpret_cast<void*>(hyperion_exec)},
 #if (PY_VERSION_HEX >= 0x030C0000)
 	{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
@@ -355,7 +355,7 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 			QScopedPointer<QNetworkReply> networkReply(networkManager.get(QNetworkRequest(url)));
 
 			QEventLoop eventLoop;
-			connect(networkReply.data(), &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
+			QObject::connect(networkReply.get(), &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
 			eventLoop.exec();
 
 			if (networkReply->error() == QNetworkReply::NoError)

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -2,6 +2,7 @@
 
 #include <effectengine/Effect.h>
 #include <effectengine/EffectModule.h>
+#include <effectengine/EffectDefinition.h>
 
 // hyperion
 #include <hyperion/Hyperion.h>
@@ -378,7 +379,12 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 		}
 		else
 		{
-			QString file = QString::fromUtf8(source);
+			QString file;
+
+			if (url.isLocalFile())
+				file = url.toLocalFile();
+			else
+				file = QString::fromUtf8(source);
 
 			if (file.mid(0, 1) == ":")
 				file = ":/effects/" + file.mid(1);

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -471,6 +471,7 @@ PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 
 	if (!argsOk || (imgId > -1 && imgId >= getEffect()->_imageStack.size()))
 	{
+		if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 		return nullptr;
 	}
 
@@ -565,6 +566,8 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
 			return nullptr;
 		}
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -632,6 +635,8 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
 			return nullptr;
 		}
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -717,6 +722,8 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
 			return nullptr;
 		}
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -777,6 +784,8 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
 			return nullptr;
 		}
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -873,6 +882,8 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
 		painter->setPen(oldPen);
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -913,6 +924,8 @@ PyObject* EffectModule::wrapImageSolidFill(PyObject* self, PyObject* args)
 		getEffect()->_painter->fillRect(myQRect, QColor(r, g, b, a));
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -954,6 +967,8 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
 
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -991,6 +1006,8 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
 
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1031,6 +1048,8 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
 
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1050,6 +1069,7 @@ PyObject* EffectModule::wrapImageSetPixel(PyObject* self, PyObject* args)
 		Py_RETURN_NONE;
 	}
 
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1065,6 +1085,8 @@ PyObject* EffectModule::wrapImageGetPixel(PyObject* self, PyObject* args)
 		QRgb rgb = getEffect()->_image.pixel(x, y);
 		return Py_BuildValue("iii", qRed(rgb), qGreen(rgb), qBlue(rgb));
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1096,6 +1118,8 @@ PyObject* EffectModule::wrapImageMinSize(PyObject* self, PyObject* args)
 		}
 		return Py_BuildValue("ii", getEffect()->_image.width(), getEffect()->_image.height());
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1120,6 +1144,8 @@ PyObject* EffectModule::wrapImageCRotate(PyObject* self, PyObject* args)
 		getEffect()->_painter->rotate(angle);
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 
@@ -1149,6 +1175,8 @@ PyObject* EffectModule::wrapImageCShear(PyObject* self, PyObject* args)
 		getEffect()->_painter->shear(sh, sv);
 		Py_RETURN_NONE;
 	}
+
+	if (!PyErr_Occurred()) { PyErr_SetString(PyExc_TypeError, "Invalid argument count or type."); }
 	return nullptr;
 }
 

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -45,7 +45,7 @@ static void hyperion_free(void* /* hyperionModule */) // NOSONAR - signature man
 }
 
 static PyModuleDef_Slot hyperion_slots[] = { // NOSONAR - C-style array required by PyModuleDef_Slot Python C API
-	{Py_mod_exec, reinterpret_cast<void*>(hyperion_exec)},
+	{Py_mod_exec, reinterpret_cast<void*>(hyperion_exec)}, // NOSONAR
 #if (PY_VERSION_HEX >= 0x030C0000)
 	{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
@@ -53,7 +53,7 @@ static PyModuleDef_Slot hyperion_slots[] = { // NOSONAR - C-style array required
 };
 
 // Module definition with multi-phase and per-interpreter state
-static struct PyModuleDef hyperion_module = {
+static struct PyModuleDef hyperion_module = { // NOSONAR - m_slots is assigned in PyInit_hyperion; struct must be mutable
 	PyModuleDef_HEAD_INIT,
 	"hyperion",                    // Module name
 	"Hyperion module",             // Module docstring
@@ -90,7 +90,7 @@ static PyObject* json2pythonArray(const QJsonValue& jsonData)
 		return nullptr; // Allocation failed
 	}
 	int index = 0;
-	for (QJsonArray::iterator i = arrayData.begin(); i != arrayData.end(); ++i, ++index)
+	for (auto i = arrayData.begin(); i != arrayData.end(); ++i, ++index)
 	{
 		PyObject* obj = EffectModule::json2python(*i);
 		if (!obj)
@@ -217,7 +217,7 @@ PyMethodDef EffectModule::effectMethods[] = { // NOSONAR - C-style array require
 	{nullptr, nullptr, 0, nullptr}
 };
 
-PyObject* EffectModule::wrapSetColor(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapSetColor(PyObject* /*self*/, PyObject* args)
 {
 	// check the number of arguments
 	Py_ssize_t argCount = PyTuple_Size(args);
@@ -253,7 +253,7 @@ PyObject* EffectModule::wrapSetColor(PyObject* self, PyObject* args)
 			PyErr_SetString(PyExc_RuntimeError, "Length of bytearray argument should be 3*ledCount");
 			return nullptr;
 		}
-		char* data = PyByteArray_AS_STRING(bytearray);
+		const char* data = PyByteArray_AS_STRING(bytearray);
 		memcpy(getEffect()->_colors.data(), data, length);
 		QVector<ColorRgb> _cQV = getEffect()->_colors;
 		emit getEffect()->setInput(getEffect()->_priority, QVector<ColorRgb>(_cQV.begin(), _cQV.end()), getEffect()->getRemaining(), false);
@@ -266,7 +266,7 @@ PyObject* EffectModule::wrapSetColor(PyObject* self, PyObject* args)
 	}
 }
 
-PyObject* EffectModule::wrapSetImage(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapSetImage(PyObject* /*self*/, PyObject* args)
 {
 	// bytearray of values
 	int width = 0;
@@ -280,7 +280,7 @@ PyObject* EffectModule::wrapSetImage(PyObject* self, PyObject* args)
 			if (length == 3 * width * height)
 			{
 				Image<ColorRgb> image(width, height);
-				char* data = PyByteArray_AS_STRING(bytearray);
+				const char* data = PyByteArray_AS_STRING(bytearray);
 				memcpy(image.memptr(), data, length);
 				emit getEffect()->setInputImage(getEffect()->_priority, image, getEffect()->getRemaining(), false);
 				Py_RETURN_NONE;
@@ -314,7 +314,7 @@ static QByteArray imageToRGB(const QImage& qimage, int width, int height, bool g
 	char* dest = binaryImage.data();
 	for (int i = 0; i < height; ++i)
 	{
-		const QRgb* scanline = reinterpret_cast<const QRgb*>(qimage.scanLine(i));
+		const auto* scanline = reinterpret_cast<const QRgb*>(qimage.scanLine(i)); // NOSONAR - idiomatic Qt pattern for typed scanline access
 		for (int j = 0; j < width; ++j)
 		{
 			QRgb pixel = scanline[j];
@@ -348,7 +348,7 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 			return false;
 		}
 
-		const QUrl url = QUrl(source);
+		const auto url = QUrl(source);
 		if (url.isValid())
 		{
 			QNetworkAccessManager networkManager;
@@ -380,7 +380,10 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 	}
 	else
 	{
-		PyArg_ParseTuple(args, "|siiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale);
+		if (!PyArg_ParseTuple(args, "|siiiip", &source, &crop.cropLeft, &crop.cropTop, &crop.cropRight, &crop.cropBottom, &crop.grayscale))
+		{
+			return false;
+		}
 		buffer.setData(QByteArray::fromBase64(imageData.toUtf8()));
 		buffer.open(QBuffer::ReadOnly);
 		reader.setDecideFormatFromContent(true);
@@ -389,7 +392,7 @@ static bool setupImageSource(PyObject* args, const QString& imageData, QBuffer& 
 	return true;
 }
 
-PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapGetImage(PyObject* /*self*/, PyObject* args)
 {
 	QBuffer buffer;
 	QImageReader reader;
@@ -467,13 +470,13 @@ PyObject* EffectModule::wrapGetImage(PyObject* self, PyObject* args)
 	return result;
 }
 
-PyObject* EffectModule::wrapAbort(PyObject* self, PyObject*)
+PyObject* EffectModule::wrapAbort(PyObject* /*self*/, PyObject*)
 {
 	return Py_BuildValue("i", getEffect()->isInterruptionRequested() ? 1 : 0);
 }
 
 
-PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageShow(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int imgId = -1;
@@ -505,7 +508,7 @@ PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 
 	for (int i = 0; i < height; ++i)
 	{
-		const QRgb* scanline = reinterpret_cast<const QRgb*>(qimage->scanLine(i));
+		const auto* scanline = reinterpret_cast<const QRgb*>(qimage->scanLine(i)); // NOSONAR - idiomatic Qt pattern for typed scanline access
 		for (int j = 0; j < width; ++j)
 		{
 			binaryImage.append((char)qRed(scanline[j]));
@@ -520,7 +523,7 @@ PyObject* EffectModule::wrapImageShow(PyObject* self, PyObject* args)
 	return Py_BuildValue("");
 }
 
-PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageLinearGradient(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
@@ -567,7 +570,7 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
 
 	QRect myQRect(startRX, startRY, width, height);
 	QLinearGradient gradient(QPoint(startX, startY), QPoint(endX, endY));
-	char* data = PyByteArray_AS_STRING(bytearray);
+	const char* data = PyByteArray_AS_STRING(bytearray);
 
 	for (int idx = 0; idx < length; idx += arrayItemLength)
 	{
@@ -587,7 +590,7 @@ PyObject* EffectModule::wrapImageLinearGradient(PyObject* self, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageConicalGradient(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
@@ -633,7 +636,7 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
 
 	QRect myQRect(startX, startY, width, height);
 	QConicalGradient gradient(QPoint(centerX, centerY), angle);
-	char* data = PyByteArray_AS_STRING(bytearray);
+	const char* data = PyByteArray_AS_STRING(bytearray);
 
 	for (int idx = 0; idx < length; idx += arrayItemLength)
 	{
@@ -653,7 +656,7 @@ PyObject* EffectModule::wrapImageConicalGradient(PyObject* self, PyObject* args)
 }
 
 
-PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageRadialGradient(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	PyObject* bytearray = nullptr;
@@ -715,7 +718,7 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
 
 	QRect myQRect(startX, startY, width, height);
 	QRadialGradient gradient(QPoint(centerX, centerY), qMax(radius, 0));
-	char* data = PyByteArray_AS_STRING(bytearray);
+	const char* data = PyByteArray_AS_STRING(bytearray);
 
 	for (int idx = 0; idx < length; idx += 4)
 	{
@@ -734,7 +737,7 @@ PyObject* EffectModule::wrapImageRadialGradient(PyObject* self, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageDrawPolygon(PyObject* /*self*/, PyObject* args)
 {
 	PyObject* bytearray = nullptr;
 
@@ -775,7 +778,7 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
 	}
 
 	QVector<QPoint> points;
-	char* data = PyByteArray_AS_STRING(bytearray);
+	const char* data = PyByteArray_AS_STRING(bytearray);
 
 	for (int idx = 0; idx < length; idx += 2)
 	{
@@ -792,12 +795,12 @@ PyObject* EffectModule::wrapImageDrawPolygon(PyObject* self, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageDrawPie(PyObject* /*self*/, PyObject* args)
 {
 	PyObject* bytearray = nullptr;
 
 	QString brush;
-	int argCount = PyTuple_Size(args);
+	Py_ssize_t argCount = PyTuple_Size(args);
 	int radius = 0;
 	int centerX = 0;
 	int centerY = 0;
@@ -851,8 +854,8 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
 			return nullptr;
 		}
 
-		QConicalGradient gradient(QPoint(centerX, centerY), startAngle);
-		char* data = PyByteArray_AS_STRING(bytearray);
+			QConicalGradient gradient(QPoint(centerX, centerY), startAngle);
+		const char* data = PyByteArray_AS_STRING(bytearray);
 
 		for (int idx = 0; idx < length; idx += 5)
 		{
@@ -878,7 +881,7 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* self, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapImageSolidFill(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageSolidFill(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
@@ -921,7 +924,7 @@ PyObject* EffectModule::wrapImageSolidFill(PyObject* self, PyObject* args)
 }
 
 
-PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageDrawLine(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
@@ -963,7 +966,7 @@ PyObject* EffectModule::wrapImageDrawLine(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageDrawPoint(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
@@ -1002,7 +1005,7 @@ PyObject* EffectModule::wrapImageDrawPoint(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageDrawRect(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
@@ -1045,7 +1048,7 @@ PyObject* EffectModule::wrapImageDrawRect(PyObject* self, PyObject* args)
 }
 
 
-PyObject* EffectModule::wrapImageSetPixel(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageSetPixel(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int r = 0;
@@ -1065,7 +1068,7 @@ PyObject* EffectModule::wrapImageSetPixel(PyObject* self, PyObject* args)
 }
 
 
-PyObject* EffectModule::wrapImageGetPixel(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageGetPixel(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int x = 0;
@@ -1081,7 +1084,7 @@ PyObject* EffectModule::wrapImageGetPixel(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageSave(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageSave(PyObject* /*self*/, PyObject* /*args*/)
 {
 	QImage img(getEffect()->_image.copy());
 	getEffect()->_imageStack.append(img);
@@ -1089,7 +1092,7 @@ PyObject* EffectModule::wrapImageSave(PyObject* self, PyObject* args)
 	return Py_BuildValue("i", getEffect()->_imageStack.size() - 1);
 }
 
-PyObject* EffectModule::wrapImageMinSize(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageMinSize(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int w = 0;
@@ -1112,17 +1115,17 @@ PyObject* EffectModule::wrapImageMinSize(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageWidth(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageWidth(PyObject* /*self*/, PyObject* /*args*/)
 {
 	return Py_BuildValue("i", getEffect()->_imageSize.width());
 }
 
-PyObject* EffectModule::wrapImageHeight(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageHeight(PyObject* /*self*/, PyObject* /*args*/)
 {
 	return Py_BuildValue("i", getEffect()->_imageSize.height());
 }
 
-PyObject* EffectModule::wrapImageCRotate(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageCRotate(PyObject* /*self*/, PyObject* args)
 {
 	Py_ssize_t argCount = PyTuple_Size(args);
 	int angle;
@@ -1138,7 +1141,7 @@ PyObject* EffectModule::wrapImageCRotate(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageCOffset(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageCOffset(PyObject* /*self*/, PyObject* args)
 {
 	int offsetX = 0;
 	int offsetY = 0;
@@ -1153,7 +1156,7 @@ PyObject* EffectModule::wrapImageCOffset(PyObject* self, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapImageCShear(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageCShear(PyObject* /*self*/, PyObject* args)
 {
 	int sh = 0;
 	int sv = 0;
@@ -1169,18 +1172,18 @@ PyObject* EffectModule::wrapImageCShear(PyObject* self, PyObject* args)
 	return nullptr;
 }
 
-PyObject* EffectModule::wrapImageResetT(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageResetT(PyObject* /*self*/, PyObject* /*args*/)
 {
 	getEffect()->_painter->resetTransform();
 	Py_RETURN_NONE;
 }
 
-PyObject* EffectModule::wrapLowestUpdateInterval(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapLowestUpdateInterval(PyObject* /*self*/, PyObject* /*args*/)
 {
 	return Py_BuildValue("d", getEffect()->_lowestUpdateIntervalInSeconds);
 }
 
-PyObject* EffectModule::wrapImageStackClear(PyObject* self, PyObject* args)
+PyObject* EffectModule::wrapImageStackClear(PyObject* /*self*/, PyObject* /*args*/)
 {
 	getEffect()->_imageStack.clear();
 	Py_RETURN_NONE;

--- a/libsrc/effectengine/EffectModule.cpp
+++ b/libsrc/effectengine/EffectModule.cpp
@@ -934,7 +934,7 @@ PyObject* EffectModule::wrapImageDrawPie(PyObject* /*self*/, PyObject* args)
 	QPen oldPen = painter->pen();
 	QPen newPen(QColor(r, g, b, a));
 	painter->setPen(newPen);
-	painter->drawPie(centerX - radius, centerY - radius, centerX + radius, centerY + radius, startAngle * 16, spanAngle * 16);
+	painter->drawPie(centerX - radius, centerY - radius, radius * 2, radius * 2, startAngle * 16, spanAngle * 16);
 	painter->setPen(oldPen);
 	Py_RETURN_NONE;
 }

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -820,21 +820,22 @@ void Hyperion::processUpdate()
 	// copy image & process OR copy ledColors from muxer
 	const Image<ColorRgb>& image = priorityInfo.image;
 
-	if (image.isNull())
-	{
-		TRACK_SCOPE_SUBCOMPONENT_CATEGORY(image_track) << "Empty image - skip update";
-		return;
-	}
-
 	QVector<ColorRgb> ledColors;
-	if (image.width() > 1 || image.height() > 1)
+
+	if (!image.isNull())
 	{
+		TRACK_SCOPE_SUBCOMPONENT_CATEGORY(instance_update) << "Process update using image with id" << image.id() << "and resolution" << image.width() << "x" << image.height();
 		emit currentImage(image);  // Emit the image signal at the controlled rate
 		ledColors = _imageProcessor->process(image);
 	}
 	else
 	{
 		ledColors = priorityInfo.ledColors;
+		if (ledColors.empty())
+		{		
+			TRACK_SCOPE_SUBCOMPONENT_CATEGORY(instance_update) << "Empty image and no LED colors provided - skip update";
+			return;
+		}
 	}
 
 	emit rawLedColors(ledColors);

--- a/libsrc/utils/ImageData.cpp
+++ b/libsrc/utils/ImageData.cpp
@@ -180,12 +180,7 @@ void ImageData<Pixel_T>::clear(const pixel_type background)
 template <typename Pixel_T>
 void ImageData<Pixel_T>::reset()
 {
-	if (_width != 1 || _height != 1)
-	{
-		resize(1, 1);
-	}
-	// Set the single pixel to the default background
-	_pixels[0] = pixel_type();
+	resize(0, 0);
 }
 
 template <typename Pixel_T>

--- a/libsrc/utils/ImageResampler.cpp
+++ b/libsrc/utils/ImageResampler.cpp
@@ -254,7 +254,7 @@ void ImageResampler::processImage(const uint8_t * data, int width, int height, s
 			{
 				int uOffset = width * height + ySource * (width/2);
 				int vOffset = (width * height) + (width * height / 2) + ySource * (width/2);
-				for (int xDest = xDestStart, xSource = _cropLeft + (_horizontalDecimation >> 1); xDest <= xDestEnd; xSource += _horizontalDecimation, ++xDest)
+				for (int xDest = xDestStart, xSource = cropLeft + (_horizontalDecimation >> 1); xDest <= xDestEnd; xSource += _horizontalDecimation, ++xDest)
 				{
 					ColorRgb & rgb = outputImage(abs(xDest), abs(yDest));
 					uint8_t y = data[lineLength * ySource + xSource];

--- a/qtlogging.ini
+++ b/qtlogging.ini
@@ -134,3 +134,6 @@ hyperion.*.debug=false
 #hyperion.leddevice.flow.debug=true
 #hyperion.leddevice.properties.debug=true
 #hyperion.leddevice.write.debug=true
+
+# Effect debug logging
+#hyperion.effect.debug=true


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

**Summary**

Follow-up to #2010, which fixed a double-DECREF after a failed `PyList_SetItem` call. 
A broader audit of the effectengine related code was refactored, stabilized and fixed.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [X] Code style update
- [X] Refactor

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**
- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [x] Yes, CHANGELOG.md is also updated

---

### Related issue

Follows up on #2009 / #2010.

### Description

A broader audit of the effectengine Python C-API usage after #2010 found additional reference-counting and null-pointer bugs of the same class.

### Changes

#### Bug fixes (`EffectModule.cpp`, `Effect.cpp`)

- **`json2python`**: Missing null checks after `PyList_New` / `PyDict_New` — null-pointer dereference on allocation failure. Added null guards and corrected cleanup paths.
- **`setModuleParameters`**: `PyModule_AddObject` version-dependent double-DECREF on Python < 3.10. Split capsule-creation and add-failure paths; guard `Py_DECREF(capsule)` with `#if PY_VERSION_HEX >= 0x030A0000`.
- **`setModuleParameters`**: `json2python` null return passed directly to `PyObject_SetAttrString` without a null check → undefined behaviour. Added null guard.
- **Wrapper functions (`wrap*`)**: All wrappers returned `nullptr` silently on argument-parse failure without setting a Python exception, causing `SystemError` in the interpreter. Added `PyErr_SetString` before each `return nullptr`.
- **`wrapImageShow`**: Out-of-range image ID raised `TypeError` instead of `IndexError`. Corrected exception type.
- **`wrapGetImage`**: `QImageReader::imageCount()` returns 0 for non-animated formats (JPEG, PNG). The result was allocated as a zero-element list, silently dropping the image. Now treated as 1 frame with a `qMax(count, 1)` fallback.
- **`setupImageSource`**: `file://` URLs passed to `QImageReader::setFileName` as raw URL strings instead of local paths. Fixed using `QUrl::isLocalFile()` / `url.toLocalFile()`.

#### Security fixes (`EffectFileHandler.cpp`)

- **`resolveEffectFilePath`**: Effect name used to construct the JSON file path without sanitising path separators or `..` segments — path traversal allowing writes outside the effects directory.
- **`saveEffectImage`**: `args["file"]` appended to the effects directory path without validation — path traversal allowing arbitrary file writes. Fixed by verifying the resolved absolute path stays within the effects directory.

#### New effect

- **Juggler**: New built-in effect — coloured balls juggled across the LED image canvas.

#### Refactoring & improvements

- **`EffectDefinition`**: Moved `Q_DECLARE_LOGGING_CATEGORY(effect)` to `EffectDefinition.h`; added `EffectDefinition.cpp` with `Q_LOGGING_CATEGORY(effect, "hyperion.effect")`. Added `qCDebug(effect)` traces throughout `EffectEngine`, `EffectModule`, and `EffectFileHandler`. Debug logging is opt-in via `qtlogging.ini` (`#hyperion.effect.debug=true`).
- **`EffectModule.cpp`**: Extracted `setupImageSource` and `imageToRGB` helpers to reduce cognitive complexity and nesting depth in `wrapGetImage`.
- **`EffectFileHandler.cpp`**: Split `saveEffect` into `resolveEffectFilePath`, `saveEffectImage`, and `cleanImageSource` for clarity. Converted string concatenation in error messages to `QString::arg()` for safety and readability.
- **Effect scripts**: Minor stability and style fixes in `pacman.py`, `traces.py`, and `trails.py`.
- **Empty image**: `0×0` is now the canonical empty image; `1×1` is no longer treated as empty.

- **`ImageResampler`**: I422 Format - Consistently use  adjusted local cropLeft computed earlier 