### PR TITLE
Ensure Content-Type is always provided for js modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 
 - **Fixes:**
-- Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
+  - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
+  - WebUI: Loading module from x was blocked because of a disallowed MIME type ("")
 ---
 
 ### 🗑️ Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 
 - **Fixes:**
-  - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
-  - WebUI: Loading module from x was blocked because of a disallowed MIME type ("")
+  - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incompatible setting. (#2002)
+  - WebUI - Return a valid Content-Type for static assets to prevent module loading failures
 ---
 
 ### 🗑️ Removed

--- a/libsrc/webserver/StaticFileServing.cpp
+++ b/libsrc/webserver/StaticFileServing.cpp
@@ -16,12 +16,12 @@
 
 namespace {
 
-QByteArray resolveMimeType(const QString& fileName, const QMimeDatabase* mimeDb)
+QByteArray resolveMimeType(const QString &fileName, const QMimeDatabase *mimeDb)
 {
 	const QMimeType mime = mimeDb->mimeTypeForFile(fileName);
 
 	#if ((QT_VERSION >= QT_VERSION_CHECK(5, 15, 0) && QT_VERSION < QT_VERSION_CHECK(5, 15, 11)) || \
-	     (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0) && QT_VERSION < QT_VERSION_CHECK(6, 5, 0)))
+		 (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0) && QT_VERSION < QT_VERSION_CHECK(6, 5, 0)))
 	// Workaround https://bugreports.qt.io/browse/QTBUG-97392 for affected Qt versions
 	if (mime.name() == QStringLiteral("application/x-extension-html"))
 	{
@@ -43,7 +43,6 @@ QByteArray resolveMimeType(const QString& fileName, const QMimeDatabase* mimeDb)
 
 	return QByteArrayLiteral("application/octet-stream");
 }
-
 }
 
 StaticFileServing::StaticFileServing (QObject * parent)
@@ -165,15 +164,16 @@ void StaticFileServing::onRequestNeedsReply (QtHttpRequest * request, QtHttpRepl
 		QFile file(_baseUrl % "/" % path);
 		if (file.exists())
 		{
-			if (file.open (QFile::ReadOnly)) {
-				QByteArray data = file.readAll ();
-				reply->addHeader ("Content-Type", resolveMimeType(file.fileName(), _mimeDb));
-				reply->appendRawData (data);
-				file.close ();
+			if (file.open(QFile::ReadOnly))
+			{
+				QByteArray data = file.readAll();
+				reply->addHeader("Content-Type", resolveMimeType(file.fileName(), _mimeDb));
+				reply->appendRawData(data);
+				file.close();
 			}
 			else
 			{
-				printErrorToReply (reply, QtHttpReply::Forbidden ,"Requested file: " % path);
+				printErrorToReply(reply, QtHttpReply::Forbidden, "Requested file: " % path);
 			}
 		}
 		else

--- a/libsrc/webserver/StaticFileServing.cpp
+++ b/libsrc/webserver/StaticFileServing.cpp
@@ -14,6 +14,38 @@
 
 #include <exception>
 
+namespace {
+
+QByteArray resolveMimeType(const QString& fileName, const QMimeDatabase* mimeDb)
+{
+	const QMimeType mime = mimeDb->mimeTypeForFile(fileName);
+
+	#if ((QT_VERSION >= QT_VERSION_CHECK(5, 15, 0) && QT_VERSION < QT_VERSION_CHECK(5, 15, 11)) || \
+	     (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0) && QT_VERSION < QT_VERSION_CHECK(6, 5, 0)))
+	// Workaround https://bugreports.qt.io/browse/QTBUG-97392 for affected Qt versions
+	if (mime.name() == QStringLiteral("application/x-extension-html"))
+	{
+		return QByteArrayLiteral("text/html");
+	}
+	#endif
+
+	const QByteArray mimeName = mime.name().toLocal8Bit();
+	if (mime.isValid() && !mime.isDefault() && !mimeName.isEmpty())
+	{
+		return mimeName;
+	}
+
+	const QString suffix = QFileInfo(fileName).suffix().toLower();
+	if (suffix == QStringLiteral("js") || suffix == QStringLiteral("mjs") || suffix == QStringLiteral("cjs"))
+	{
+		return QByteArrayLiteral("text/javascript");
+	}
+
+	return QByteArrayLiteral("application/octet-stream");
+}
+
+}
+
 StaticFileServing::StaticFileServing (QObject * parent)
 	:  QObject   (parent)
 	, _baseUrl ()
@@ -133,19 +165,9 @@ void StaticFileServing::onRequestNeedsReply (QtHttpRequest * request, QtHttpRepl
 		QFile file(_baseUrl % "/" % path);
 		if (file.exists())
 		{
-			QMimeType mime = _mimeDb->mimeTypeForFile (file.fileName ());
 			if (file.open (QFile::ReadOnly)) {
 				QByteArray data = file.readAll ();
-
-				// Workaround https://bugreports.qt.io/browse/QTBUG-97392
-				if (mime.name() == QStringLiteral("application/x-extension-html"))
-				{
-					reply->addHeader ("Content-Type", "text/html");
-				}
-				else
-				{
-					reply->addHeader ("Content-Type", mime.name().toLocal8Bit());
-				}
+				reply->addHeader ("Content-Type", resolveMimeType(file.fileName(), _mimeDb));
 				reply->appendRawData (data);
 				file.close ();
 			}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

### 🔧 Changed

- **Fixes:**
  - WebUI - Return a valid Content-Type for static assets to prevent module loading failures

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [X] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Fixes: #1999 