### PR TITLE
Improve error reporting SSL & port binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed - Locally installed flatc/protoc compilers were not found
 - ProviderRestAPI - Handle QNetworkAccessManager as direct object
+- ProviderRestAPI - Add error when failing to load QT SSL 
 - Update docker compile to reduce prerequisites and allow ninja build
 
 ## [2.2.0](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.0) - 2026-02-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 
+- Windows - Provide more error details, if the UI fails to start due to system proxy is turned on (#2005).
+
 - **Fixes:**
   - Art-Net device is limited to 108 DMX channels (36 RGB LEDs) instead of 512 channels (170 RGB LEDs)
   - Image Effect trigger kills Hyperion (#1980)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 
-- Windows - Provide more error details if the UI fails to start due to system proxy is turned on (#2005).
+ - Windows - Provide more error details if the UI fails to start because the system proxy is enabled (#2005).
 
 - **Fixes:**
   - Art-Net device is limited to 108 DMX channels (36 RGB LEDs) instead of 512 channels (170 RGB LEDs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 
-- Windows - Provide more error details, if the UI fails to start due to system proxy is turned on (#2005).
+- Windows - Provide more error details if the UI fails to start due to system proxy is turned on (#2005).
 
 - **Fixes:**
   - Art-Net device is limited to 108 DMX channels (36 RGB LEDs) instead of 512 channels (170 RGB LEDs)
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed - Locally installed flatc/protoc compilers were not found
 - ProviderRestAPI - Handle QNetworkAccessManager as direct object
-- ProviderRestAPI - Add error when failing to load QT SSL 
+- ProviderRestAPI - Add error when failing to load Qt SSL
 - Update docker compile to reduce prerequisites and allow ninja build
 
 ## [2.2.0](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.0) - 2026-02-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 
+ - Windows - Provide more error details if the UI fails to start because the system proxy is enabled (#2005).
+
 - **Fixes:**
 - Windows DDA Grabber - Prevent image updates when mouse is moved. Provide a Warning on incomptible setting. (#2002)
 ---
@@ -27,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Technical
 
+- ProviderRestAPI - Add error when failing to load Qt SSL
+
 ## [2.2.1](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.1) - 2026-04-06
 
 ### ✨ Added
@@ -36,8 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ### 🔧 Changed
-
- - Windows - Provide more error details if the UI fails to start because the system proxy is enabled (#2005).
 
 - **Fixes:**
   - Art-Net device is limited to 108 DMX channels (36 RGB LEDs) instead of 512 channels (170 RGB LEDs)
@@ -50,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed - Locally installed flatc/protoc compilers were not found
 - ProviderRestAPI - Handle QNetworkAccessManager as direct object
-- ProviderRestAPI - Add error when failing to load Qt SSL
 - Update docker compile to reduce prerequisites and allow ninja build
 
 ## [2.2.0](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.2.0) - 2026-02-02

--- a/include/utils/NetUtils.h
+++ b/include/utils/NetUtils.h
@@ -32,21 +32,30 @@ inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 {
 	const quint16 prevPort = port;
 	QTcpServer server;
+	int failCount = 0;
 
 	while (!server.listen(QHostAddress::Any, port))
 	{
+		++failCount;
 		QAbstractSocket::SocketError err = server.serverError();
 		QString errString = server.errorString();
 
-		Warning(log, "Port '%d' binding failed. SocketError: %d (%s)",
-				port, err, QSTRING_CSTR(errString));
+		if (failCount == 1)
+		{
+			Warning(log, "Port '%d' binding failed. SocketError: %d (%s)",
+					port, err, QSTRING_CSTR(errString));
+		}
+		else
+		{
+			Debug(log, "Port '%d' binding failed. SocketError: %d (%s)",
+				  port, err, QSTRING_CSTR(errString));
+		}
 
 		// On some platforms (notably Windows), certain ports fail with SocketAccessError
 		// due to OS/proxy reservations or exclusions while higher ports remain available.
-		// Log the detail but continue incrementing rather than aborting.
 		if (err == QAbstractSocket::SocketAccessError)
 		{
-			Warning(log, "Port '%d' is reserved or excluded by the OS/Proxy, trying next port.", port);
+			Debug(log, "Port '%d' is reserved or excluded by the OS/Proxy, trying next port.", port);
 		}
 
 		if (port >= MAX_PORT)

--- a/include/utils/NetUtils.h
+++ b/include/utils/NetUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QTcpServer>
+#include <QNetworkProxy>
 #include <QUrl>
 #include <QHostAddress>
 #include <QHostInfo>
@@ -32,6 +33,9 @@ inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 {
 	const quint16 prevPort = port;
 	QTcpServer server;
+	// Bypass any system-level proxy (e.g. SOCKSv5): proxies reject TCP listen/bind
+	// with UnsupportedSocketOperationError and the port cannot be recovered by incrementing.
+	server.setProxy(QNetworkProxy::NoProxy);
 	int failCount = 0;
 
 	while (!server.listen(QHostAddress::Any, port))
@@ -49,6 +53,15 @@ inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 		{
 			Debug(log, "Port '%d' binding failed. SocketError: %d (%s)",
 				  port, err, QSTRING_CSTR(errString));
+		}
+
+		// UnsupportedSocketOperationError typically means a system proxy rejected the
+		// bind (SOCKSv5 does not support listen). setProxy(NoProxy) above should prevent
+		// this, but abort immediately if it still occurs — no port will succeed.
+		if (err == QAbstractSocket::UnsupportedSocketOperationError)
+		{
+			Error(log, "Port '%d' bind rejected as unsupported operation (proxy?). Aborting port search.", port);
+			return false;
 		}
 
 		// On some platforms (notably Windows), certain ports fail with SocketAccessError

--- a/include/utils/NetUtils.h
+++ b/include/utils/NetUtils.h
@@ -30,45 +30,43 @@ const int MAX_PORT = 65535;
 ///
 inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 {
-    const quint16 prevPort = port;
-    QTcpServer server;
-    
-    while (!server.listen(QHostAddress::Any, port))
-    {
-        QAbstractSocket::SocketError err = server.serverError();
-        QString errString = server.errorString();
+	const quint16 prevPort = port;
+	QTcpServer server;
 
-        Warning(log, "Port '%d' binding failed. OS Error: %d (%s)", 
-                port, err, QSTRING_CSTR(errString));
+	while (!server.listen(QHostAddress::Any, port))
+	{
+		QAbstractSocket::SocketError err = server.serverError();
+		QString errString = server.errorString();
 
-        // If Windows denies access outright, incrementing port++ won't solve it.
-        // We can safely return false here without calling server.close() 
-        // because the server never successfully began listening.
-        if (err == QAbstractSocket::SocketAccessError)
-        {
-            Error(log, "Access denied. Port is likely reserved or excluded by the OS/Proxy.");
-            return false;
-        }
+		Warning(log, "Port '%d' binding failed. SocketError: %d (%s)",
+				port, err, QSTRING_CSTR(errString));
 
-        if (port >= MAX_PORT)
-        {
-            Error(log, "Reached maximum port limit (%d).", MAX_PORT);
-            return false;
-        }
+		// On some platforms (notably Windows), certain ports fail with SocketAccessError
+		// due to OS/proxy reservations or exclusions while higher ports remain available.
+		// Log the detail but continue incrementing rather than aborting.
+		if (err == QAbstractSocket::SocketAccessError)
+		{
+			Warning(log, "Port '%d' is reserved or excluded by the OS/Proxy, trying next port.", port);
+		}
 
-        port++;
-    }
-    
-    // Explicitly release the port now that we proved we could listen on it.
-    server.close();
-    
-    if (port != prevPort)
-    {
-        Warning(log, "Requested Port '%d' was unavailable, will use Port '%d' instead", prevPort, port);
-        return false; 
-    }
-    
-    return true;
+		if (port >= MAX_PORT)
+		{
+			Error(log, "Reached maximum port limit (%d).", MAX_PORT);
+			return false;
+		}
+
+		port++;
+	}
+
+	// Explicitly release the port now that we proved we could listen on it.
+	server.close();
+
+	if (port != prevPort)
+	{
+		Warning(log, "Requested Port '%d' was unavailable, will use Port '%d' instead", prevPort, port);
+	}
+
+	return true;
 }
 
 ///

--- a/include/utils/NetUtils.h
+++ b/include/utils/NetUtils.h
@@ -30,20 +30,45 @@ const int MAX_PORT = 65535;
 ///
 inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 {
-	const quint16 prevPort = port;
-	QTcpServer server;
-	while (!server.listen(QHostAddress::Any, port))
-	{
-		Warning(log,"Port '%d' is already in use, will increment", port);
-		port ++;
-	}
-	server.close();
-	if(port != prevPort)
-	{
-		Warning(log, "The requested Port '%d' is already in use, will use Port '%d' instead", prevPort, port);
-		return false;
-	}
-	return true;
+    const quint16 prevPort = port;
+    QTcpServer server;
+    
+    while (!server.listen(QHostAddress::Any, port))
+    {
+        QAbstractSocket::SocketError err = server.serverError();
+        QString errString = server.errorString();
+
+        Warning(log, "Port '%d' binding failed. OS Error: %d (%s)", 
+                port, err, QSTRING_CSTR(errString));
+
+        // If Windows denies access outright, incrementing port++ won't solve it.
+        // We can safely return false here without calling server.close() 
+        // because the server never successfully began listening.
+        if (err == QAbstractSocket::SocketAccessError)
+        {
+            Error(log, "Access denied. Port is likely reserved or excluded by the OS/Proxy.");
+            return false;
+        }
+
+        if (port >= MAX_PORT)
+        {
+            Error(log, "Reached maximum port limit (%d).", MAX_PORT);
+            return false;
+        }
+
+        port++;
+    }
+    
+    // Explicitly release the port now that we proved we could listen on it.
+    server.close();
+    
+    if (port != prevPort)
+    {
+        Warning(log, "Requested Port '%d' was unavailable, will use Port '%d' instead", prevPort, port);
+        return false; 
+    }
+    
+    return true;
 }
 
 ///

--- a/include/utils/NetUtils.h
+++ b/include/utils/NetUtils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QTcpServer>
-#include <QNetworkProxy>
 #include <QUrl>
 #include <QHostAddress>
 #include <QHostInfo>
@@ -33,9 +32,6 @@ inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 {
 	const quint16 prevPort = port;
 	QTcpServer server;
-	// Bypass any system-level proxy (e.g. SOCKSv5): proxies reject TCP listen/bind
-	// with UnsupportedSocketOperationError and the port cannot be recovered by incrementing.
-	server.setProxy(QNetworkProxy::NoProxy);
 	int failCount = 0;
 
 	while (!server.listen(QHostAddress::Any, port))
@@ -56,8 +52,7 @@ inline bool portAvailable(quint16& port, QSharedPointer<Logger> log)
 		}
 
 		// UnsupportedSocketOperationError typically means a system proxy rejected the
-		// bind (SOCKSv5 does not support listen). setProxy(NoProxy) above should prevent
-		// this, but abort immediately if it still occurs — no port will succeed.
+		// bind (SOCKSv5 does not support listen). Aborting immediately if it occurs — no port will succeed.
 		if (err == QAbstractSocket::UnsupportedSocketOperationError)
 		{
 			Error(log, "Port '%d' bind rejected as unsupported operation (proxy?). Aborting port search.", port);

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -431,15 +431,23 @@ bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 	QFile caFile (caFileName);
 	if (!caFile.open(QIODevice::ReadOnly))
 	{
-		Error(_log,"Unable to open CA-Certificate file: %s", QSTRING_CSTR(caFileName));
+		Error(_log, "Unable to open CA-Certificate file: %s", QSTRING_CSTR(caFileName));
 		return false;
 	}
 
 	QSslCertificate const cert (&caFile);
 	caFile.close();
 
-	QList<QSslCertificate> allowedCAs;
-	allowedCAs << cert;
+	// Check if the certificate parsed correctly before adding it
+	if (cert.isNull())
+	{
+		Error(_log, "The file %s does not contain a valid SSL certificate", QSTRING_CSTR(caFileName));
+		return false;
+	}
+
+	// Append to existing CAs instead of overwriting them
+	QList<QSslCertificate> allowedCAs = configuration.caCertificates();
+	allowedCAs.append(cert);
 	configuration.setCaCertificates(allowedCAs);
 
 	QSslConfiguration::setDefaultConfiguration(configuration);
@@ -451,6 +459,15 @@ bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 		_networkManager->connectToHostEncrypted(_apiUrl.host(), static_cast<quint16>(_apiUrl.port()), configuration);
 		rc = true;
 	}
+	else
+	{
+		Error(_log, "SSL support is compiled into Qt, but the underlying SSL libraries failed to load at runtime. "
+		            "Built against: \"%s\", runtime version: \"%s\".",
+		            QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
+		            QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
+	}
+#else
+	Error(_log, "SSL support is entirely disabled in this build of Qt (QT_NO_SSL is defined).");
 #endif
 
 	return rc;

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -1,7 +1,6 @@
 // Local-Hyperion includes
 #include "ProviderRestApi.h"
 
-#include <algorithm>
 #include <chrono>
 
 #include <QObject>
@@ -33,7 +32,7 @@ ProviderRestApi::ProviderRestApi(const QString& scheme, const QString& host, int
 	: _log(Logger::getInstance("LEDDEVICE"))
 	, _networkManager(new QNetworkAccessManager())
 	, _requestTimeout(DEFAULT_REST_TIMEOUT)
-	, _isSelfSignedCertificateAccpeted(false)
+	, _isSelfSignedCertificateAccepted(false)
 {
 	TRACK_SCOPE();
 
@@ -431,21 +430,38 @@ QByteArray httpResponse::getHeader(const QByteArray& header) const
 
 bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 {
+	// Temporary debug line	
+	Warning(_log, "Built against: \"%s\", runtime version: \"%s\".",
+			QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
+			QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
+
+#ifndef QT_NO_SSL
+	if (!QSslSocket::supportsSsl())
+	{
+		Error(_log, "SSL support is compiled into Qt, but the underlying SSL libraries failed to load at runtime. "
+		            "Built against: \"%s\", runtime version: \"%s\".",
+		            QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
+		            QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
+		return false;
+	}
+#else
+	Error(_log, "SSL support is entirely disabled in this build of Qt (QT_NO_SSL is defined).");
+	return false;
+#endif
+
 	QFile caFile (caFileName);
 	if (!caFile.open(QIODevice::ReadOnly))
 	{
 		Error(_log, "Unable to open CA-Certificate file: %s", QSTRING_CSTR(caFileName));
 		return false;
 	}
+	
+	// Temporary debug line
+	Warning(_log, "DEBUG: Resource file size is %lld bytes", caFile.size());
 
 	// Load all PEM certificates from the bundle (handles concatenated/multi-cert bundles)
 	QList<QSslCertificate> newCerts = QSslCertificate::fromDevice(&caFile, QSsl::Pem);
 	caFile.close();
-
-	// Filter out any null/unparseable entries
-	newCerts.erase(std::remove_if(newCerts.begin(), newCerts.end(),
-	                              [](const QSslCertificate& c) { return c.isNull(); }),
-	               newCerts.end());
 
 	if (newCerts.isEmpty())
 	{
@@ -460,28 +476,14 @@ bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 	allowedCAs.append(_caCertificates);
 	_requestSslConfiguration.setCaCertificates(allowedCAs);
 
-#ifndef QT_NO_SSL
-	if (!QSslSocket::supportsSsl())
-	{
-		Error(_log, "SSL support is compiled into Qt, but the underlying SSL libraries failed to load at runtime. "
-		            "Built against: \"%s\", runtime version: \"%s\".",
-		            QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
-		            QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
-		return false;
-	}
-
 	// Use Qt::UniqueConnection to prevent duplicate signal connections on repeated calls
 	QObject::connect( _networkManager.get(), &QNetworkAccessManager::sslErrors, this, &ProviderRestApi::onSslErrors, Qt::UniqueConnection );
 	return true;
-#else
-	Error(_log, "SSL support is entirely disabled in this build of Qt (QT_NO_SSL is defined).");
-	return false;
-#endif
 }
 
 void ProviderRestApi::acceptSelfSignedCertificates(bool isAccepted)
 {
-	_isSelfSignedCertificateAccpeted = isAccepted;
+	_isSelfSignedCertificateAccepted = isAccepted;
 }
 
 void ProviderRestApi::setAlternateServerIdentity(const QString& serverIdentity)
@@ -586,7 +588,7 @@ bool ProviderRestApi::handleSslError(const QSslError& error, const QSslConfigura
 			}
 			break;
 		case QSslError::SelfSignedCertificate:
-			if (_isSelfSignedCertificateAccpeted)
+			if (_isSelfSignedCertificateAccepted)
 			{
 				const QSslCertificate& certificate = error.certificate();
 				if (matchesPinnedCertificate(certificate))

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -1,6 +1,7 @@
 // Local-Hyperion includes
 #include "ProviderRestApi.h"
 
+#include <algorithm>
 #include <chrono>
 
 #include <QObject>
@@ -221,6 +222,13 @@ httpResponse ProviderRestApi::executeOperation(QNetworkAccessManager::Operation 
 	request.setUrl(url);
 	request.setOriginatingObject(this);
 
+#ifndef QT_NO_SSL
+	if (!_caCertificates.isEmpty() && url.scheme().compare("https", Qt::CaseInsensitive) == 0)
+	{
+		request.setSslConfiguration(_requestSslConfiguration);
+	}
+#endif
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
 	_networkManager->setTransferTimeout(static_cast<int>(_requestTimeout.count()));
 #endif
@@ -282,7 +290,6 @@ httpResponse ProviderRestApi::executeOperation(QNetworkAccessManager::Operation 
 
 	return response;
 }
-
 namespace {
 QString getReplyErrorReason(QNetworkReply* const& reply, const httpResponse& response)
 {
@@ -424,10 +431,6 @@ QByteArray httpResponse::getHeader(const QByteArray& header) const
 
 bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 {
-	bool rc {false};
-	/// Add our own CA to the default SSL configuration
-	QSslConfiguration configuration = QSslConfiguration::defaultConfiguration();
-
 	QFile caFile (caFileName);
 	if (!caFile.open(QIODevice::ReadOnly))
 	{
@@ -435,42 +438,45 @@ bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 		return false;
 	}
 
-	QSslCertificate const cert (&caFile);
+	// Load all PEM certificates from the bundle (handles concatenated/multi-cert bundles)
+	QList<QSslCertificate> newCerts = QSslCertificate::fromDevice(&caFile, QSsl::Pem);
 	caFile.close();
 
-	// Check if the certificate parsed correctly before adding it
-	if (cert.isNull())
+	// Filter out any null/unparseable entries
+	newCerts.erase(std::remove_if(newCerts.begin(), newCerts.end(),
+	                              [](const QSslCertificate& c) { return c.isNull(); }),
+	               newCerts.end());
+
+	if (newCerts.isEmpty())
 	{
-		Error(_log, "The file %s does not contain a valid SSL certificate", QSTRING_CSTR(caFileName));
+		Error(_log, "The file %s does not contain any valid SSL certificates", QSTRING_CSTR(caFileName));
 		return false;
 	}
 
-	// Append to existing CAs instead of overwriting them
-	QList<QSslCertificate> allowedCAs = configuration.caCertificates();
-	allowedCAs.append(cert);
-	configuration.setCaCertificates(allowedCAs);
+	_caCertificates = newCerts;
 
-	QSslConfiguration::setDefaultConfiguration(configuration);
+	_requestSslConfiguration = QSslConfiguration::defaultConfiguration();
+	QList<QSslCertificate> allowedCAs = _requestSslConfiguration.caCertificates();
+	allowedCAs.append(_caCertificates);
+	_requestSslConfiguration.setCaCertificates(allowedCAs);
 
 #ifndef QT_NO_SSL
-	if (QSslSocket::supportsSsl())
-	{
-		QObject::connect( _networkManager.get(), &QNetworkAccessManager::sslErrors, this, &ProviderRestApi::onSslErrors );
-		_networkManager->connectToHostEncrypted(_apiUrl.host(), static_cast<quint16>(_apiUrl.port()), configuration);
-		rc = true;
-	}
-	else
+	if (!QSslSocket::supportsSsl())
 	{
 		Error(_log, "SSL support is compiled into Qt, but the underlying SSL libraries failed to load at runtime. "
 		            "Built against: \"%s\", runtime version: \"%s\".",
 		            QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
 		            QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
+		return false;
 	}
+
+	// Use Qt::UniqueConnection to prevent duplicate signal connections on repeated calls
+	QObject::connect( _networkManager.get(), &QNetworkAccessManager::sslErrors, this, &ProviderRestApi::onSslErrors, Qt::UniqueConnection );
+	return true;
 #else
 	Error(_log, "SSL support is entirely disabled in this build of Qt (QT_NO_SSL is defined).");
+	return false;
 #endif
-
-	return rc;
 }
 
 void ProviderRestApi::acceptSelfSignedCertificates(bool isAccepted)

--- a/libsrc/leddevice/dev_net/ProviderRestApi.cpp
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.cpp
@@ -430,18 +430,26 @@ QByteArray httpResponse::getHeader(const QByteArray& header) const
 
 bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 {
-	// Temporary debug line	
-	Warning(_log, "Built against: \"%s\", runtime version: \"%s\".",
-			QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
-			QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
-
 #ifndef QT_NO_SSL
 	if (!QSslSocket::supportsSsl())
 	{
+		QString buildVersion = QSslSocket::sslLibraryBuildVersionString();
+		QString runtimeVersion = QSslSocket::sslLibraryVersionString();
+
+        if (buildVersion.isEmpty())
+        {
+            buildVersion = QStringLiteral("not available");
+        }
+
+        if (runtimeVersion.isEmpty())
+        {
+            runtimeVersion = QStringLiteral("not available");
+        }
+
 		Error(_log, "SSL support is compiled into Qt, but the underlying SSL libraries failed to load at runtime. "
 		            "Built against: \"%s\", runtime version: \"%s\".",
-		            QSTRING_CSTR(QSslSocket::sslLibraryBuildVersionString()),
-		            QSTRING_CSTR(QSslSocket::sslLibraryVersionString()));
+		            QSTRING_CSTR(buildVersion),
+		            QSTRING_CSTR(runtimeVersion));
 		return false;
 	}
 #else
@@ -455,9 +463,6 @@ bool ProviderRestApi::setCaCertificate(const QString& caFileName)
 		Error(_log, "Unable to open CA-Certificate file: %s", QSTRING_CSTR(caFileName));
 		return false;
 	}
-	
-	// Temporary debug line
-	Warning(_log, "DEBUG: Resource file size is %lld bytes", caFile.size());
 
 	// Load all PEM certificates from the bundle (handles concatenated/multi-cert bundles)
 	QList<QSslCertificate> newCerts = QSslCertificate::fromDevice(&caFile, QSsl::Pem);

--- a/libsrc/leddevice/dev_net/ProviderRestApi.h
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.h
@@ -488,7 +488,7 @@ private:
 	QSslConfiguration _requestSslConfiguration;
 
 	QString _serverIdentity;
-	bool _isSelfSignedCertificateAccpeted;
+	bool _isSelfSignedCertificateAccepted;
 };
 
 #endif // PROVIDERRESTAPI_H

--- a/libsrc/leddevice/dev_net/ProviderRestApi.h
+++ b/libsrc/leddevice/dev_net/ProviderRestApi.h
@@ -9,6 +9,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QJsonDocument>
+#include <QSslCertificate>
 #include <QUrlQuery>
 
 #include <QFile>
@@ -483,6 +484,8 @@ private:
 	QUrlQuery _query;
 
 	QNetworkRequest _networkRequestHeaders;
+	QList<QSslCertificate> _caCertificates;
+	QSslConfiguration _requestSslConfiguration;
 
 	QString _serverIdentity;
 	bool _isSelfSignedCertificateAccpeted;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

### 🔧 Changed

- Windows - Provide more error details, if the UI fails to start due to system proxy is turned on (#2005).

---

### Technical

- ProviderRestAPI - Add error when failing to load QT SSL 

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [X] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

