### PR TITLE
Fix color smoothing output interval calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Effect scripts: Minor stability and style fixes in `pacman.py`, `traces.py`, `trails.py`(#2011)
   - WebUI - Return a valid Content-Type for static assets to prevent module loading failures
   - MdnsBrowser compile errors when ENABLE_MDNS is false (#2024)
-  - LinearColorSmoothing - fix incorrect output interval calculation
+  - LinearColorSmoothing - fix incorrect output interval calculation, fix handling for update frequency >= 1000Hz
 
 ---
 ### Technical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Effect scripts: Minor stability and style fixes in `pacman.py`, `traces.py`, `trails.py`(#2011)
   - WebUI - Return a valid Content-Type for static assets to prevent module loading failures
   - MdnsBrowser compile errors when ENABLE_MDNS is false (#2024)
+  - LinearColorSmoothing - fix incorrect output interval calculation
 
 ---
 ### Technical

--- a/include/hyperion/LinearColorSmoothing.h
+++ b/include/hyperion/LinearColorSmoothing.h
@@ -285,6 +285,9 @@ private:
 		/// The interval time in milliseconds of the timer used for scheduling LED update operations. A value of 0 indicates sub-millisecond timing.
 		int _updateInterval;
 
+		/// The exact interval time in microseconds for scheduling LED update operations.
+		int64_t _outputIntervalMicros;
+
 		/// The type of smoothing to perform
 		SmoothingType _type;
 

--- a/include/hyperion/LinearColorSmoothing.h
+++ b/include/hyperion/LinearColorSmoothing.h
@@ -22,7 +22,7 @@
 Q_DECLARE_LOGGING_CATEGORY(smoothing);
 
 // The type of float
-#define floatT float // Select double, float or __fp16
+using floatT = double; // Select double, float or __fp16
 
 class QTimer;
 class Logger;
@@ -266,7 +266,7 @@ private:
 	bool _dithering;
 
 	/// The decay power > 0. A value of exactly 1 is linear decay, higher numbers indicate a faster decay rate.
-	double _decay;
+	floatT _decay;
 
 	/// Value of 1.0 / settlingTime; inverse of the window size used for weighting of frames.
 	floatT _invWindow;

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -680,7 +680,7 @@ bool LinearColorSmoothing::selectConfig(int cfgID, bool force)
 		_settlingTime = _cfgList[cfgID]._settlingTime;
 		_outputDelay = _cfgList[cfgID]._outputDelay;
 		_pause = _cfgList[cfgID]._pause;
-		_outputIntervalMicros = int64_t(1000000.0 / _updateInterval); // 1s = 1e6 µs
+		_outputIntervalMicros = int64_t(MS_PER_MICRO) * _cfgList[cfgID]._updateInterval; // ms -> µs
 		_interpolationRate = _cfgList[cfgID]._interpolationRate;
 		_interpolationIntervalMicros = int64_t(1000000.0 / _interpolationRate);
 		_dithering = _cfgList[cfgID]._dithering;

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -30,6 +30,9 @@ namespace {
 /// The number of microseconds per millisecond = 1000.
 const int64_t MS_PER_MICRO = 1000;
 
+/// The number of microseconds per second = 1000000.
+const int64_t MICROS_PER_SECOND = MS_PER_MICRO * MS_PER_MICRO;
+
 /// The number of bits that are used for shifting the fixed point values
 const int FPShift = (sizeof(uint64_t)*8 - (12 + 9));
 
@@ -54,6 +57,29 @@ const int DEFAULT_UPDATEFREQUENCY = 25;		// in Hz
 
 constexpr std::chrono::milliseconds DEFAULT_UPDATEINTERVALL{MS_PER_MICRO/ DEFAULT_UPDATEFREQUENCY};
 const unsigned DEFAULT_OUTPUTDEPLAY = 0;	// in frames
+
+int updateIntervalMsFromFrequency(const double frequencyHz)
+{
+	return static_cast<int>(MS_PER_MICRO / frequencyHz);
+}
+
+int64_t outputIntervalMicrosFromFrequency(const double frequencyHz)
+{
+	return static_cast<int64_t>(std::llround(MICROS_PER_SECOND / frequencyHz));
+}
+
+void sleepUntilNextAction(const int64_t now, const int64_t nextActionExpected)
+{
+	const int64_t microsTillNextAction = nextActionExpected - now;
+	const int64_t SLEEP_MAX_MICROS = 1000L; // We want to use usleep for up to 1ms
+	const int64_t SLEEP_RES_MICROS = 100L; // Expected resolution is >= 100µs on stock linux
+
+	if (microsTillNextAction > SLEEP_RES_MICROS)
+	{
+		const int64_t wait = std::min(microsTillNextAction - SLEEP_RES_MICROS, SLEEP_MAX_MICROS);
+		std::this_thread::sleep_for(std::chrono::microseconds(wait));
+	}
+}
 }
 
 using namespace hyperion;
@@ -69,6 +95,7 @@ LinearColorSmoothing::LinearColorSmoothing(const QJsonObject &config, const QSha
 	, _timer(nullptr)
 	, _outputDelay(DEFAULT_OUTPUTDEPLAY)
 	, _pause(false)
+	, _outputIntervalMicros(DEFAULT_UPDATEINTERVALL.count() * MS_PER_MICRO)
 	, _currentConfigId(SmoothingConfigID::SYSTEM)
 	, _enabled(false)
 	, _enabledSystemCfg(false)
@@ -133,9 +160,11 @@ void LinearColorSmoothing::updateSettings(const QJsonObject &config)
 		_enabledSystemCfg = _enabled;
 
 		int64_t settlingTime_ms = static_cast<int64_t>(config[SETTINGS_KEY_SETTLING_TIME].toInt(DEFAULT_SETTLINGTIME));
-		int _updateInterval_ms =static_cast<int>(MS_PER_MICRO / config[SETTINGS_KEY_UPDATE_FREQUENCY].toDouble(DEFAULT_UPDATEFREQUENCY));
+		const double updateFrequencyHz = config[SETTINGS_KEY_UPDATE_FREQUENCY].toDouble(DEFAULT_UPDATEFREQUENCY);
+		int _updateInterval_ms = updateIntervalMsFromFrequency(updateFrequencyHz);
 
 		SmoothingCfg cfg(false, settlingTime_ms, _updateInterval_ms);
+		cfg._outputIntervalMicros = outputIntervalMicrosFromFrequency(updateFrequencyHz);
 
 		const QString typeString = config[SETTINGS_KEY_SMOOTHING_TYPE].toString();
 
@@ -437,14 +466,7 @@ void LinearColorSmoothing::performDecay(const int64_t now) {
 	// we have to do µsec-sleep to free CPU time; otherwise the thread would consume 100% CPU time.
 	if(_updateInterval <= 0 && !(interpolatePending || writePending)) {
 		const int64_t nextActionExpected = std::min(interpolationTarget, writeTarget);
-		const int64_t microsTillNextAction = nextActionExpected - now;
-		const int64_t SLEEP_MAX_MICROS = 1000L; // We want to use usleep for up to 1ms
-		const int64_t SLEEP_RES_MICROS = 100L; // Expected resolution is >= 100µs on stock linux
-
-		if(microsTillNextAction > SLEEP_RES_MICROS) {
-			const int64_t wait = std::min(microsTillNextAction - SLEEP_RES_MICROS, SLEEP_MAX_MICROS);
-			std::this_thread::sleep_for(std::chrono::microseconds(wait));
-		}
+		sleepUntilNextAction(now, nextActionExpected);
 	}
 
 	// Write stats every 30 sec
@@ -464,6 +486,18 @@ void LinearColorSmoothing::performDecay(const int64_t now) {
 }
 
 void LinearColorSmoothing::performLinear(const int64_t now) {
+	const int64_t writeTarget = _previousWriteTime + _outputIntervalMicros;
+	const bool writePending = now > writeTarget;
+
+	if (!writePending)
+	{
+		if (_updateInterval <= 0)
+		{
+			sleepUntilNextAction(now, writeTarget);
+		}
+		return;
+	}
+
 	const int64_t deltaTime = _targetTime - now;
 	const float k = 1.0F - 1.0F * deltaTime / (_targetTime - _previousWriteTime);
 	const size_t N = _previousValues.size();
@@ -631,11 +665,12 @@ unsigned LinearColorSmoothing::addConfig(int settlingTime_ms, double ledUpdateFr
 	SmoothingCfg cfg {
 		false,
 		settlingTime_ms,
-		static_cast<int>(MS_PER_MICRO / ledUpdateFrequency_hz),
+		updateIntervalMsFromFrequency(ledUpdateFrequency_hz),
 		SmoothingType::Linear,
 		ledUpdateFrequency_hz,
 		updateDelay
 	};
+	cfg._outputIntervalMicros = outputIntervalMicrosFromFrequency(ledUpdateFrequency_hz);
 	_cfgList.append(std::move(cfg));
 	auto cfgID = static_cast<unsigned>(_cfgList.count() - 1);
 
@@ -652,11 +687,12 @@ unsigned LinearColorSmoothing::updateConfig(int cfgID, int settlingTime_ms, doub
 		SmoothingCfg cfg {
 			false,
 			settlingTime_ms,
-			static_cast<int>(MS_PER_MICRO / ledUpdateFrequency_hz),
+			updateIntervalMsFromFrequency(ledUpdateFrequency_hz),
 			SmoothingType::Linear,
 			ledUpdateFrequency_hz,
 			updateDelay
 		};
+		cfg._outputIntervalMicros = outputIntervalMicrosFromFrequency(ledUpdateFrequency_hz);
 		_cfgList[updatedCfgID] = cfg;
 		Debug(_log,"%s", QSTRING_CSTR(getConfig(updatedCfgID)));
 	}
@@ -680,9 +716,9 @@ bool LinearColorSmoothing::selectConfig(int cfgID, bool force)
 		_settlingTime = _cfgList[cfgID]._settlingTime;
 		_outputDelay = _cfgList[cfgID]._outputDelay;
 		_pause = _cfgList[cfgID]._pause;
-		_outputIntervalMicros = int64_t(MS_PER_MICRO) * _cfgList[cfgID]._updateInterval; // ms -> µs
+		_outputIntervalMicros = _cfgList[cfgID]._outputIntervalMicros;
 		_interpolationRate = _cfgList[cfgID]._interpolationRate;
-		_interpolationIntervalMicros = int64_t(1000000.0 / _interpolationRate);
+		_interpolationIntervalMicros = int64_t(MICROS_PER_SECOND / _interpolationRate);
 		_dithering = _cfgList[cfgID]._dithering;
 		_decay = _cfgList[cfgID]._decay;
 		_invWindow = 1.0F / (MS_PER_MICRO * _settlingTime);
@@ -778,10 +814,12 @@ QString LinearColorSmoothing::getConfig(int cfgID)
 
 		case SmoothingType::Linear:
 		{
+			const double updateIntervalMs = static_cast<double>(cfg._outputIntervalMicros) / MS_PER_MICRO;
+			const double updateFrequencyHz = static_cast<double>(MICROS_PER_SECOND) / cfg._outputIntervalMicros;
 			configText += QString (", Settling time: %1ms, Interval: %2ms (%3Hz)")
 						  .arg(cfg._settlingTime)
-						  .arg(cfg._updateInterval)
-						  .arg(int(MS_PER_MICRO/cfg._updateInterval));
+					  .arg(updateIntervalMs, 0, 'f', 2)
+					  .arg(updateFrequencyHz, 0, 'f', 2);
 			break;
 		}
 		}
@@ -796,7 +834,8 @@ QString LinearColorSmoothing::getConfig(int cfgID)
 LinearColorSmoothing::SmoothingCfg::SmoothingCfg() :
 	_pause(false),
 	_settlingTime(DEFAULT_SETTLINGTIME),
-	_updateInterval(DEFAULT_UPDATEFREQUENCY),
+	_updateInterval(DEFAULT_UPDATEINTERVALL.count()),
+	_outputIntervalMicros(DEFAULT_UPDATEINTERVALL.count() * MS_PER_MICRO),
 	_type(SmoothingType::Linear)
 {
 }
@@ -805,6 +844,7 @@ LinearColorSmoothing::SmoothingCfg::SmoothingCfg(bool pause, int64_t settlingTim
 	_pause(pause),
 	_settlingTime(settlingTime),
 	_updateInterval(updateInterval),
+	_outputIntervalMicros(updateInterval * MS_PER_MICRO),
 	_type(type),
 	_interpolationRate(interpolationRate),
 	_outputDelay(outputDelay),

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -21,7 +21,7 @@ Q_LOGGING_CATEGORY(smoothing, "hyperion.smoothing")
 
 /// Clamps the rounded values to the byte-interval of [0, 255].
 ALWAYS_INLINE long clampRounded(const floatT x) {
-	return std::min(255L, std::max(0L, std::lroundf(x)));
+	return static_cast<long>(qBound(0, qRound(x), 255));
 }
 
 // Constants
@@ -42,15 +42,15 @@ const int SmallShiftBis = sizeof(uint8_t)*8;
 /// The number of bits that are used for shifting the fixed point values plus SmallShiftBis
 const int FPShiftSmall = (sizeof(uint64_t)*8 - (12 + 9 + SmallShiftBis));
 
-const char* SETTINGS_KEY_SMOOTHING_TYPE = "type";
+const char SETTINGS_KEY_SMOOTHING_TYPE[] = "type";
 
-const char* SETTINGS_KEY_SETTLING_TIME = "time_ms";
-const char* SETTINGS_KEY_UPDATE_FREQUENCY = "updateFrequency";
-const char* SETTINGS_KEY_OUTPUT_DELAY = "updateDelay";
+const char SETTINGS_KEY_SETTLING_TIME[] = "time_ms";
+const char SETTINGS_KEY_UPDATE_FREQUENCY[] = "updateFrequency";
+const char SETTINGS_KEY_OUTPUT_DELAY[] = "updateDelay";
 
-const char* SETTINGS_KEY_DECAY = "decay";
-const char* SETTINGS_KEY_INTERPOLATION_RATE = "interpolationRate";
-const char* SETTINGS_KEY_DITHERING = "dithering";
+const char SETTINGS_KEY_DECAY[] = "decay";
+const char SETTINGS_KEY_INTERPOLATION_RATE[] = "interpolationRate";
+const char SETTINGS_KEY_DITHERING[] = "dithering";
 
 const int64_t DEFAULT_SETTLINGTIME = 200;	// in ms
 const int DEFAULT_UPDATEFREQUENCY = 25;		// in Hz
@@ -159,7 +159,7 @@ void LinearColorSmoothing::updateSettings(const QJsonObject &config)
 		setEnable(config["enable"].toBool(_enabled));
 		_enabledSystemCfg = _enabled;
 
-		int64_t settlingTime_ms = static_cast<int64_t>(config[SETTINGS_KEY_SETTLING_TIME].toInt(DEFAULT_SETTLINGTIME));
+		auto settlingTime_ms = static_cast<int64_t>(config[SETTINGS_KEY_SETTLING_TIME].toInt(DEFAULT_SETTLINGTIME));
 		const double updateFrequencyHz = config[SETTINGS_KEY_UPDATE_FREQUENCY].toDouble(DEFAULT_UPDATEFREQUENCY);
 		int _updateInterval_ms = updateIntervalMsFromFrequency(updateFrequencyHz);
 
@@ -319,9 +319,9 @@ void LinearColorSmoothing::assembleAndDitherFrame()
 		prev.blue = static_cast<uint8_t>(ib);
 
 		// Determine the component errors
-		residualErrors[3 * i + 0] = fr - ir;
-		residualErrors[3 * i + 1] = fg - ig;
-		residualErrors[3 * i + 2] = fb - ib;
+		residualErrors[3 * i + 0] = fr - static_cast<floatT>(ir);
+		residualErrors[3 * i + 1] = fg - static_cast<floatT>(ig);
+		residualErrors[3 * i + 2] = fb - static_cast<floatT>(ib);
 	}
 }
 
@@ -352,7 +352,7 @@ void LinearColorSmoothing::assembleFrame()
 
 ALWAYS_INLINE void LinearColorSmoothing::aggregateComponents(const QVector<ColorRgb>& colors, std::vector<uint64_t>& weighted, const floatT weight) {
 	// Determine the integer-scale by converting the weight to fixed point
-	const uint64_t scale = (static_cast<uint64_t>(1L)<<FPShift) * static_cast<double>(weight);
+	const auto scale = static_cast<uint64_t>((static_cast<uint64_t>(1L)<<FPShift) * static_cast<double>(weight));
 
 	const size_t N = colors.size();
 
@@ -413,12 +413,12 @@ void LinearColorSmoothing::interpolateFrame()
 	}
 
 	/// The inverse scaling factor for the color components, clamped to (0, 1.0]; 1.0 for fs < 1, 1 : fs otherwise
-	const floatT inv_fs = ((fs < 1.0F) ? 1.0F : 1.0F / fs) / (1 << SmallShiftBis);
+	const floatT inv_fs = ((fs < static_cast<floatT>(1.0)) ? static_cast<floatT>(1.0) : static_cast<floatT>(1.0) / fs) / (1 << SmallShiftBis);
 
 	// Normalize the mean component values for the window (fs)
 	for (size_t i = 0; i < 3 * N; ++i)
 	{
-		meanValues[i] = (tempValues[i] >> FPShiftSmall) * inv_fs;
+		meanValues[i] = static_cast<floatT>(tempValues[i] >> FPShiftSmall) * inv_fs;
 	}
 
 	_previousInterpolationTime = now;
@@ -474,10 +474,10 @@ void LinearColorSmoothing::performDecay(const int64_t now) {
 	{
 		Debug(_log, "decay - rendered frames [%d] (%f/s), interpolated frames [%d] (%f/s) in [%f ms]"
 			  , _renderedCounter - _renderedStatCounter
-			  , (1.0F * (_renderedCounter - _renderedStatCounter) / ((now - _renderedStatTime) / 1000000.0F))
+			  , (static_cast<floatT>(1.0) * (_renderedCounter - _renderedStatCounter) / ((now - _renderedStatTime) / 1000000.0F))
 			  , _interpolationCounter - _interpolationStatCounter
-			  , (1.0F * (_interpolationCounter - _interpolationStatCounter) / ((now - _renderedStatTime) / 1000000.0F))
-			  , (now - _renderedStatTime) / 1000.0F
+			  , (static_cast<floatT>(1.0) * (_interpolationCounter - _interpolationStatCounter) / ((now - _renderedStatTime) / 1000000.0F))
+			  , (now - _renderedStatTime) / static_cast<floatT>(1000.0)
 			  );
 		_renderedStatTime = now;
 		_renderedStatCounter = _renderedCounter;
@@ -499,7 +499,7 @@ void LinearColorSmoothing::performLinear(const int64_t now) {
 	}
 
 	const int64_t deltaTime = _targetTime - now;
-	const float k = 1.0F - 1.0F * deltaTime / (_targetTime - _previousWriteTime);
+	const floatT k = static_cast<floatT>(1.0) - static_cast<floatT>(1.0) * static_cast<floatT>(deltaTime) / static_cast<floatT>(_targetTime - _previousWriteTime);
 	const size_t N = _previousValues.size();
 
 	for (size_t i = 0; i < N; ++i)
@@ -511,9 +511,9 @@ void LinearColorSmoothing::performLinear(const int64_t now) {
 		const int greendif = target.green - prev.green;
 		const int bluedif  = target.blue  - prev.blue;
 
-		prev.red   += (reddif   < 0 ? -1:1) * std::ceil(k * std::abs(reddif));
-		prev.green += (greendif < 0 ? -1:1) * std::ceil(k * std::abs(greendif));
-		prev.blue  += (bluedif  < 0 ? -1:1) * std::ceil(k * std::abs(bluedif));
+		prev.red   = static_cast<uint8_t>(prev.red   + (reddif   < 0 ? -1:1) * static_cast<int>(std::ceil(k * static_cast<float>(std::abs(reddif)))));
+		prev.green = static_cast<uint8_t>(prev.green + (greendif < 0 ? -1:1) * static_cast<int>(std::ceil(k * static_cast<float>(std::abs(greendif)))));
+		prev.blue  = static_cast<uint8_t>(prev.blue  + (bluedif  < 0 ? -1:1) * static_cast<int>(std::ceil(k * static_cast<float>(std::abs(bluedif)))));
 	}
 
 	writeFrame();
@@ -530,16 +530,13 @@ void LinearColorSmoothing::updateLeds()
 		return;
 	}
 
-	switch (_smoothingType)
+	if (_smoothingType == SmoothingType::Decay)
 	{
-	case SmoothingType::Decay:
 		performDecay(now);
-	break;
-
-	case SmoothingType::Linear:
-	default:
+	}
+	else
+	{
 		performLinear(now);
-	break;
 	}
 }
 
@@ -564,7 +561,7 @@ void LinearColorSmoothing::rememberFrame(const QVector<ColorRgb> &ledColors)
 	}
 
 	// Append the latest frame at back of the queue
-	const REMEMBERED_FRAME frame = REMEMBERED_FRAME(now, ledColors);
+	const auto frame = REMEMBERED_FRAME(now, ledColors);
 	_frameQueue.push_back(frame);
 }
 
@@ -594,29 +591,27 @@ void LinearColorSmoothing::queueColors(const QVector<ColorRgb> &ledColors)
 				emit hyperion->ledDeviceData(ledColors);
 			}
 		}
+		return;
 	}
-	else
-	{
-		// Push new colors in the delay-buffer
-		_outputQueue.push_back(ledColors);
 
-		// If the delay-buffer is filled pop the front and write to device
-		if (!_outputQueue.empty())
+	// Push new colors in the delay-buffer
+	_outputQueue.push_back(ledColors);
+
+	// If the delay-buffer is filled pop the front and write to device
+	if (_outputQueue.size() <= _outputDelay)
+	{
+		return;
+	}
+
+	if (!_pause)
+	{
+		QSharedPointer<Hyperion> hyperion = _hyperionWeak.toStrongRef();
+		if (hyperion)
 		{
-			if (_outputQueue.size() > _outputDelay)
-			{
-				if (!_pause)
-				{
-					QSharedPointer<Hyperion> hyperion = _hyperionWeak.toStrongRef();
-					if (hyperion)
-					{
-						emit hyperion->ledDeviceData(_outputQueue.front());
-					}
-				}
-				_outputQueue.pop_front();
-			}
+			emit hyperion->ledDeviceData(_outputQueue.front());
 		}
 	}
+	_outputQueue.pop_front();
 }
 
 void LinearColorSmoothing::clearQueuedColors()
@@ -710,82 +705,80 @@ bool LinearColorSmoothing::selectConfig(int cfgID, bool force)
 		return true;
 	}
 
-	if (cfgID < _cfgList.count() )
+	if (cfgID >= _cfgList.count() )
 	{
-		_smoothingType = _cfgList[cfgID]._type;
-		_settlingTime = _cfgList[cfgID]._settlingTime;
-		_outputDelay = _cfgList[cfgID]._outputDelay;
-		_pause = _cfgList[cfgID]._pause;
-		_outputIntervalMicros = _cfgList[cfgID]._outputIntervalMicros;
-		_interpolationRate = _cfgList[cfgID]._interpolationRate;
-		_interpolationIntervalMicros = int64_t(MICROS_PER_SECOND / _interpolationRate);
-		_dithering = _cfgList[cfgID]._dithering;
-		_decay = _cfgList[cfgID]._decay;
-		_invWindow = 1.0F / (MS_PER_MICRO * _settlingTime);
-
-		// Set _weightFrame based on the given decay
-		const float decay = _decay;
-		const floatT inv_window = _invWindow;
-
-		// For decay != 1 use power-based approach for calculating the moving average values
-		if(std::abs(decay - 1.0F) > std::numeric_limits<float>::epsilon()) {
-			// Exponential Decay
-			_weightFrame = [inv_window,decay](const int64_t fs, const int64_t fe, const int64_t ws) {
-				const floatT s = (fs - ws) * inv_window;
-				const floatT t = (fe - ws) * inv_window;
-
-				return (decay + 1) * (std::pow(t, decay) - std::pow(s, decay));
-			};
-		} else {
-			// For decay == 1 use linear interpolation of the moving average values
-			// Linear Decay
-			_weightFrame = [inv_window](const int64_t fs, const int64_t fe, const int64_t /*ws*/) {
-				// Linear weighting = (end - start) * scale
-				return static_cast<floatT>((fe - fs) * inv_window);
-			};
-		}
-
-		_renderedStatTime = micros();
-		_renderedCounter = 0;
-		_renderedStatCounter = 0;
-		_interpolationCounter = 0;
-		_interpolationStatCounter = 0;
-
-		//Enable smoothing for effects with smoothing
-		if (cfgID >= SmoothingConfigID::EFFECT_DYNAMIC)
-		{
-			Debug(_log,"Run Effect with Smoothing enabled");
-			_enabledSystemCfg = _enabled;
-			setEnable(true);
-		}
-		else
-		{
-			// Restore enabled state after running an effect with smoothing
-			setEnable(_enabledSystemCfg);
-		}
-
-		if (_cfgList[cfgID]._updateInterval != _updateInterval)
-		{
-
-			_timer->stop();
-			_updateInterval = _cfgList[cfgID]._updateInterval;
-			if (this->enabled())
-			{
-				if (!_pause && !_targetValues.empty())
-				{
-					_timer->start(_updateInterval);
-				}
-			}
-		}
-		_currentConfigId = cfgID;
-		DebugIf(_enabled, _log,"%s", QSTRING_CSTR(getConfig(_currentConfigId)));
-
-		return true;
+		// reset to default
+		_currentConfigId = SmoothingConfigID::SYSTEM;
+		return false;
 	}
 
-	// reset to default
-	_currentConfigId = SmoothingConfigID::SYSTEM;
-	return false;
+	_smoothingType = _cfgList[cfgID]._type;
+	_settlingTime = _cfgList[cfgID]._settlingTime;
+	_outputDelay = _cfgList[cfgID]._outputDelay;
+	_pause = _cfgList[cfgID]._pause;
+	_outputIntervalMicros = _cfgList[cfgID]._outputIntervalMicros;
+	_interpolationRate = _cfgList[cfgID]._interpolationRate;
+	_interpolationIntervalMicros = int64_t(MICROS_PER_SECOND / _interpolationRate);
+	_dithering = _cfgList[cfgID]._dithering;
+	_decay = static_cast<floatT>(_cfgList[cfgID]._decay);
+	_invWindow = static_cast<floatT>(1.0) / (MS_PER_MICRO * static_cast<floatT>(_settlingTime));
+
+	// Set _weightFrame based on the given decay
+	const floatT decay = _decay;
+	const floatT inv_window = _invWindow;
+
+	// For decay != 1 use power-based approach for calculating the moving average values
+	if(std::abs(decay - static_cast<floatT>(1.0)) > std::numeric_limits<floatT>::epsilon()) {
+		// Exponential Decay
+		_weightFrame = [inv_window,decay](const int64_t fs, const int64_t fe, const int64_t ws) {
+			const floatT s = static_cast<floatT>(fs - ws) * inv_window;
+			const floatT t = static_cast<floatT>(fe - ws) * inv_window;
+
+			return (decay + floatT(1)) * (std::pow(t, decay) - std::pow(s, decay));
+		};
+	} 
+	else 
+	{
+		// For decay == 1 use linear interpolation of the moving average values
+		// Linear Decay
+		_weightFrame = [inv_window](const int64_t fs, const int64_t fe, const int64_t /*ws*/) {
+			// Linear weighting = (end - start) * scale
+			return (static_cast<floatT>(fe) - static_cast<floatT>(fs)) * inv_window;
+		};
+	}
+
+	_renderedStatTime = micros();
+	_renderedCounter = 0;
+	_renderedStatCounter = 0;
+	_interpolationCounter = 0;
+	_interpolationStatCounter = 0;
+
+	//Enable smoothing for effects with smoothing
+	if (cfgID >= SmoothingConfigID::EFFECT_DYNAMIC)
+	{
+		Debug(_log,"Run Effect with Smoothing enabled");
+		_enabledSystemCfg = _enabled;
+		setEnable(true);
+	}
+	else
+	{
+		// Restore enabled state after running an effect with smoothing
+		setEnable(_enabledSystemCfg);
+	}
+
+	if (_cfgList[cfgID]._updateInterval != _updateInterval)
+	{
+		_timer->stop();
+		_updateInterval = _cfgList[cfgID]._updateInterval;
+		if (this->enabled() && !_pause && _targetValues.empty())
+		{
+			_timer->start(_updateInterval);
+		}
+	}
+	_currentConfigId = cfgID;
+	DebugIf(_enabled, _log,"%s", QSTRING_CSTR(getConfig(_currentConfigId)));
+
+	return true;
 }
 
 QString LinearColorSmoothing::getConfig(int cfgID)
@@ -803,7 +796,7 @@ QString LinearColorSmoothing::getConfig(int cfgID)
 		switch (cfg._type) {
 		case SmoothingType::Decay:
 		{
-			const double thalf = (1.0-std::pow(1.0/2, 1.0/_decay))*_settlingTime;
+			const double thalf = (1.0-std::pow(1.0/2, 1.0/_decay))*static_cast<double>(_settlingTime);
 			configText += QString (", Interpolation rate: %1Hz, Dithering: %2, decay: %3 -> Halftime: %4ms")
 						  .arg(cfg._interpolationRate,0,'f',2)
 						  .arg((cfg._dithering) ? "true" : "false")
@@ -815,7 +808,7 @@ QString LinearColorSmoothing::getConfig(int cfgID)
 		case SmoothingType::Linear:
 		{
 			const double updateIntervalMs = static_cast<double>(cfg._outputIntervalMicros) / MS_PER_MICRO;
-			const double updateFrequencyHz = static_cast<double>(MICROS_PER_SECOND) / cfg._outputIntervalMicros;
+			const double updateFrequencyHz = static_cast<double>(MICROS_PER_SECOND) / static_cast<double>(cfg._outputIntervalMicros);
 			configText += QString (", Settling time: %1ms, Interval: %2ms (%3Hz)")
 						  .arg(cfg._settlingTime)
 					  .arg(updateIntervalMs, 0, 'f', 2)

--- a/libsrc/hyperion/LinearColorSmoothing.cpp
+++ b/libsrc/hyperion/LinearColorSmoothing.cpp
@@ -770,7 +770,7 @@ bool LinearColorSmoothing::selectConfig(int cfgID, bool force)
 	{
 		_timer->stop();
 		_updateInterval = _cfgList[cfgID]._updateInterval;
-		if (this->enabled() && !_pause && _targetValues.empty())
+		if (this->enabled() && !_pause && !_targetValues.empty())
 		{
 			_timer->start(_updateInterval);
 		}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix incorrect output interval calculation in `LinearColorSmoothing`.

`_updateInterval` already represents the output interval in milliseconds, but it was incorrectly treated as a frequency when calculating `_outputIntervalMicros`.

As a result, a configured output frequency of 60 Hz could effectively result in an output rate of roughly 16 Hz, causing visible brightness steps during smooth transitions.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [X] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [x] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
