### PR TITLE
Fix LedDeviceSkydimo crash on LED count change

### DIFF
--- a/libsrc/leddevice/dev_serial/LedDeviceSkydimo.cpp
+++ b/libsrc/leddevice/dev_serial/LedDeviceSkydimo.cpp
@@ -51,11 +51,19 @@ void LedDeviceSkydimo::prepareHeader()
 int LedDeviceSkydimo::write(const QVector<ColorRgb> & ledValues)
 {
 	auto ledCount = static_cast<uint>(ledValues.size());
-	if (_ledCount != ledCount)
+	// Compare against _bufferLength (only ever set by prepareHeader(), i.e. Skydimo-owned
+	// state) rather than the shared _ledCount, which Hyperion's core can update out-of-band
+	// via setLedCount() before this write() call ever happens (e.g. during the switchOff()/
+	// writeBlack() teardown that follows an LED-count config change). Comparing against
+	// _ledCount there is a false negative - it already matches the new count - so the buffer
+	// resize gets skipped and the assert() below fires against a stale, too-small buffer.
+	const qint64 requiredBufferLength = static_cast<qint64>(HEADER_SIZE) + static_cast<qint64>(ledCount) * static_cast<qint64>(sizeof(ColorRgb));
+	if (_bufferLength != requiredBufferLength)
 	{
-		Warning(_log, "Skydimo LED count has changed (old: %d, new: %d). Rebuilding header.", _ledCount, ledCount);
+		Warning(_log, "Skydimo LED count has changed (new: %d). Rebuilding header.", ledCount);
 
-		_ledRGBCount = ledCount * 3;
+		_ledCount    = ledCount;
+		_ledRGBCount = ledCount * sizeof(ColorRgb);
 		prepareHeader();
 	}
 


### PR DESCRIPTION
## Problem

Changing the LED count for a Skydimo device (in the web UI, or via config) reliably crashes `hyperiond` with `SIGABRT`. Confirmed via a symbolicated coredump:

```
#5 LedDeviceSkydimo::write(QList<ColorRgb> const&)
#6 LedDevice::writeColor(...)
#7 LedDevice::writeBlack(...)
#8 ProviderRs232::powerOff()
#9 LedDevice::switchOff()
```

## Root cause

`LedDeviceSkydimo::write()` decides whether to rebuild its internal buffer by comparing the incoming frame's size against `_ledCount`:

```cpp
if (_ledCount != ledCount) { ... rebuild buffer ... }
```

`_ledCount` isn't Skydimo-local state, though - it's the shared `LedDevice` base-class field, and Hyperion's core updates it directly via `setLedCount()` as soon as the LED count changes in config, independent of whatever this class's own `_ledBuffer` currently looks like.

So the actual sequence when the LED count changes:
1. `setLedCount(newCount)` is called on the live device -> `_ledCount` is now the new value immediately.
2. The device gets torn down: `switchOff()` -> `writeBlack()` -> `writeColor()` builds a black frame sized to `_ledCount` (already the new value) and calls `write()`.
3. Inside `write()`, `ledValues.size()` already equals `_ledCount` (both reflect the new count), so `_ledCount != ledCount` is false - the rebuild is skipped, and `_ledBuffer` is still sized for the *old* count.
4. The `assert()` a few lines down checks the new (larger) frame against the stale (smaller) buffer, fails, and aborts.

## Fix

Compare against `_bufferLength` instead - a value only this class's own `prepareHeader()` ever sets, so it accurately reflects what the buffer was actually last built for, regardless of what external code has done to the shared `_ledCount` in the meantime.

## Testing

Reproduced the crash locally with a real Skydimo device attached, confirmed the exact assert/backtrace via `coredumpctl`/`systemd-coredump`, applied the fix, rebuilt, and confirmed repeated LED-count changes against the same live device no longer crash `hyperiond` (checked via `systemctl --user status` staying `active` and no new coredumps in `coredumpctl list`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>